### PR TITLE
fix: fix docker buildx publish error for docker image

### DIFF
--- a/.github/workflows/kakarot_rpc.yml
+++ b/.github/workflows/kakarot_rpc.yml
@@ -24,5 +24,5 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           push: true
-          tags: ghcr.io/sayajin-labs/kakarot-rpc/node:latest
+          tags: ghcr.io/kkrt-labs/kakarot-rpc/node:latest
           context: .


### PR DESCRIPTION
current publishing of the rpc image fails in `build_and_publish` job,  it seems to be an authentication error, might be we should try to publish it in our new org name for auth to pass, i.e **kkrt-labs**.

Closes #161 

# Pull Request type

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Testing
- [ ] Other (please describe):

# What is the current behavior?

publish fails on `build_and_publish` probably because of auth failure.

Issue Number: #161 

# What is the new behavior?

it should probably pass as the assumption is that it arrives from the change in org name.

# Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->
