### PR TITLE
refactor: extract out all constants being used as hardcoded values or to mock realdata in a single file 🚀 

### DIFF
--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -29,3 +29,4 @@ serde = { version = "1.0" }
 futures = "0.3.26"
 
 wiremock = "0.5.17"
+lazy_static = "1.4.0"

--- a/crates/core/src/client/constants.rs
+++ b/crates/core/src/client/constants.rs
@@ -1,3 +1,7 @@
+use lazy_static::lazy_static;
+use reth_primitives::{H256, H64, U128, U256, U8};
+use starknet::core::types::FieldElement;
+
 pub const CHAIN_ID: u64 = 1_263_227_476;
 
 pub const STARKNET_NATIVE_TOKEN: &str = "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7";
@@ -37,4 +41,21 @@ pub mod gas {
     /// on a "first come first served" basis by the Sequencer.
     /// As a result, the priority fee is set to 0.
     pub const MAX_PRIORITY_FEE_PER_GAS: U128 = U128::ZERO;
+}
+
+// This module contains constants which are being used in place of real data that should be fetched
+// in production.
+lazy_static! {
+    pub static ref GAS_LIMIT: U256 = U256::from(1_000_000u64);
+    pub static ref GAS_USED: U256 = U256::from(500_000u64);
+    pub static ref CUMULATIVE_GAS_USED: U256 = U256::from(1_000_000u64);
+    pub static ref EFFECTIVE_GAS_PRICE: U128 = U128::from(1_000_000u64);
+    pub static ref SIZE: Option<U256> = Some(U256::from(1_000_000u64));
+    pub static ref MAX_FEE: FieldElement = FieldElement::from(100_000_000_000_000_000u64);
+    pub static ref ESTIMATE_GAS: U256 = U256::from(100_000_000_000_000_000u64);
+    pub static ref TRANSACTION_TYPE: U8 = U8::from(0);
+    pub static ref NONCE: Option<H64> = Some(H64::zero());
+    pub static ref MIX_HASH: H256 = H256::zero();
+    pub static ref DIFFICULTY: U256 = U256::from(0);
+    pub static ref TOTAL_DIFFICULTY: Option<U256> = None;
 }

--- a/crates/core/src/client/helpers.rs
+++ b/crates/core/src/client/helpers.rs
@@ -1,7 +1,6 @@
 use eyre::Result;
 use reth_primitives::{
-    Address, BlockId as EthBlockId, BlockNumberOrTag, Bloom, Bytes, Signature, TransactionSigned, H160, H256, U128,
-    U256, U8,
+    Address, BlockId as EthBlockId, BlockNumberOrTag, Bloom, Bytes, Signature, TransactionSigned, H160, H256, U256,
 };
 use reth_rlp::Decodable;
 use reth_rpc_types::TransactionReceipt;
@@ -11,6 +10,7 @@ use starknet::core::types::{
     ValueOutOfRangeError,
 };
 
+use super::constants::{CUMULATIVE_GAS_USED, EFFECTIVE_GAS_PRICE, GAS_USED, TRANSACTION_TYPE};
 use crate::client::client_api::KakarotClientError;
 use crate::client::constants::selectors::ETH_SEND_TRANSACTION;
 
@@ -306,8 +306,8 @@ pub fn create_default_transaction_receipt() -> TransactionReceipt {
         from: H160::from(0),
         to: None,
         // TODO: Fetch real data
-        cumulative_gas_used: U256::from(1_000_000),
-        gas_used: Some(U256::from(500_000)),
+        cumulative_gas_used: *CUMULATIVE_GAS_USED,
+        gas_used: Some(*GAS_USED),
         contract_address: None,
         // TODO : default log value
         logs: vec![],
@@ -317,9 +317,9 @@ pub fn create_default_transaction_receipt() -> TransactionReceipt {
         state_root: None,
         status_code: None,
         // TODO: Fetch real data
-        effective_gas_price: U128::from(1_000_000),
+        effective_gas_price: *EFFECTIVE_GAS_PRICE,
         // TODO: Fetch real data
-        transaction_type: U8::from(0),
+        transaction_type: *TRANSACTION_TYPE,
     }
 }
 

--- a/crates/core/src/client/mod.rs
+++ b/crates/core/src/client/mod.rs
@@ -45,7 +45,7 @@ use constants::selectors::BYTECODE;
 use self::client_api::{KakarotClient, KakarotClientError};
 use self::constants::gas::{BASE_FEE_PER_GAS, MAX_PRIORITY_FEE_PER_GAS};
 use self::constants::selectors::{BALANCE_OF, COMPUTE_STARKNET_ADDRESS, GET_EVM_ADDRESS};
-use self::constants::STARKNET_NATIVE_TOKEN;
+use self::constants::{MAX_FEE, STARKNET_NATIVE_TOKEN};
 use crate::models::convertible::ConvertibleStarknetBlock;
 use crate::models::{BlockWithTxHashes, BlockWithTxs, TokenBalance, TokenBalances};
 
@@ -862,7 +862,7 @@ impl KakarotClient for KakarotClientImpl<JsonRpcClient<HttpTransport>> {
         let calldata = raw_starknet_calldata(self.kakarot_address, bytes);
 
         // Get estimated_fee from Starknet
-        let max_fee = FieldElement::from(100_000_000_000_000_000_u64);
+        let max_fee = *MAX_FEE;
 
         let signature = vec![];
 

--- a/crates/core/src/mock/assert_helpers.rs
+++ b/crates/core/src/mock/assert_helpers.rs
@@ -1,12 +1,12 @@
 use std::str::FromStr;
 
-use reth_primitives::{Bloom, Bytes, H160, H256, H64, U128, U256};
+use reth_primitives::{Bloom, Bytes, H160, H256, U128, U256};
 use reth_rpc_types::{Block, BlockTransactions, Rich, Signature, Transaction};
 use serde::{Deserialize, Serialize};
 use starknet::core::types::{FieldElement, InvokeTransaction, Transaction as StarknetTransaction};
 
 use crate::client::constants::gas::BASE_FEE_PER_GAS;
-use crate::client::constants::CHAIN_ID;
+use crate::client::constants::{CHAIN_ID, DIFFICULTY, GAS_LIMIT, GAS_USED, MIX_HASH, NONCE, SIZE, TOTAL_DIFFICULTY};
 use crate::client::helpers::{felt_option_to_u256, felt_to_u256, starknet_address_to_ethereum_address};
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -33,9 +33,9 @@ struct BlockTransactionHashesObj {
 pub fn assert_block(block: &Rich<Block>, starknet_res: String, starknet_txs: String, hydrated: bool) {
     let starknet_data = serde_json::from_str::<StarknetBlockTest>(&starknet_res).unwrap();
 
-    assert_eq!(block.total_difficulty, None);
+    assert_eq!(block.total_difficulty, *TOTAL_DIFFICULTY);
     assert_eq!(block.uncles, vec![]);
-    assert_eq!(block.size, Some(U256::from(1_000_000)));
+    assert_eq!(block.size, *SIZE);
 
     let starknet_block_hash = FieldElement::from_str(starknet_data.block_hash.as_str()).unwrap();
 
@@ -103,12 +103,12 @@ pub fn assert_block_header(block: &Rich<Block>, starknet_res: String, hydrated: 
     assert_eq!(block.header.extra_data, Bytes::from(b"0x00"));
     assert_eq!(block.header.logs_bloom, Bloom::default());
 
-    assert_eq!(block.header.gas_used, U256::from(500_000));
-    assert_eq!(block.header.gas_limit, U256::from(1_000_000));
-    assert_eq!(block.header.difficulty, U256::ZERO);
+    assert_eq!(block.header.gas_used, *GAS_USED);
+    assert_eq!(block.header.gas_limit, *GAS_LIMIT);
+    assert_eq!(block.header.difficulty, *DIFFICULTY);
     assert_eq!(block.header.base_fee_per_gas, Some(U256::from(BASE_FEE_PER_GAS)));
-    assert_eq!(block.header.mix_hash, H256::zero());
-    assert_eq!(block.header.nonce, Some(H64::zero()));
+    assert_eq!(block.header.mix_hash, *MIX_HASH);
+    assert_eq!(block.header.nonce, *NONCE);
 }
 
 pub fn assert_transaction(ether_tx: Transaction, starknet_tx: StarknetTransaction) {

--- a/crates/core/src/models/mod.rs
+++ b/crates/core/src/models/mod.rs
@@ -8,6 +8,7 @@ use serde::{Deserialize, Serialize};
 use starknet::core::types::{FieldElement, MaybePendingBlockWithTxHashes, MaybePendingBlockWithTxs, Transaction};
 
 use crate::client::client_api::{KakarotClient, KakarotClientError};
+use crate::client::constants::{DIFFICULTY, GAS_LIMIT, GAS_USED, MIX_HASH, NONCE, SIZE, TOTAL_DIFFICULTY};
 use crate::client::helpers::starknet_address_to_ethereum_address;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -101,19 +102,19 @@ impl BlockWithTxs {
 impl ConvertibleStarknetBlock for BlockWithTxHashes {
     async fn to_eth_block(&self, client: &dyn KakarotClient) -> Result<RichBlock, KakarotClientError> {
         // TODO: Fetch real data
-        let gas_limit = U256::from(1_000_000);
+        let gas_limit = *GAS_LIMIT;
 
         // TODO: Fetch real data
-        let gas_used = U256::from(500_000);
+        let gas_used = *GAS_USED;
 
         // TODO: Fetch real data
-        let difficulty = U256::ZERO;
+        let difficulty = *DIFFICULTY;
 
         // TODO: Fetch real data
         let nonce: Option<H64> = Some(H64::zero());
 
         // TODO: Fetch real data
-        let size: Option<U256> = Some(U256::from(1_000_000));
+        let size: Option<U256> = *SIZE;
 
         // Bloom is a byte array of length 256
         let logs_bloom = Bloom::default();
@@ -122,7 +123,7 @@ impl ConvertibleStarknetBlock for BlockWithTxHashes {
         // TODO: Fetch real data
         let base_fee_per_gas = client.base_fee_per_gas();
         // TODO: Fetch real data
-        let mix_hash = H256::zero();
+        let mix_hash = *MIX_HASH;
 
         let parent_hash = H256::from_slice(&self.parent_hash().to_bytes_be());
         let sequencer = starknet_address_to_ethereum_address(&self.sequencer_address());
@@ -161,8 +162,14 @@ impl ConvertibleStarknetBlock for BlockWithTxHashes {
             mix_hash,
             withdrawals_root: Some(H256::zero()),
         };
-        let block =
-            Block { header, total_difficulty: None, uncles: vec![], transactions, size, withdrawals: Some(vec![]) };
+        let block = Block {
+            header,
+            total_difficulty: *TOTAL_DIFFICULTY,
+            uncles: vec![],
+            transactions,
+            size,
+            withdrawals: Some(vec![]),
+        };
         Ok(block.into())
     }
 }
@@ -171,19 +178,19 @@ impl ConvertibleStarknetBlock for BlockWithTxHashes {
 impl ConvertibleStarknetBlock for BlockWithTxs {
     async fn to_eth_block(&self, client: &dyn KakarotClient) -> Result<RichBlock, KakarotClientError> {
         // TODO: Fetch real data
-        let gas_limit = U256::from(1_000_000);
+        let gas_limit = *GAS_LIMIT;
 
         // TODO: Fetch real data
-        let gas_used = U256::from(500_000);
+        let gas_used = *GAS_USED;
 
         // TODO: Fetch real data
-        let difficulty = U256::ZERO;
+        let difficulty = *DIFFICULTY;
 
         // TODO: Fetch real data
-        let nonce: Option<H64> = Some(H64::zero());
+        let nonce: Option<H64> = *NONCE;
 
         // TODO: Fetch real data
-        let size: Option<U256> = Some(U256::from(1_000_000));
+        let size: Option<U256> = *SIZE;
 
         // Bloom is a byte array of length 256
         let logs_bloom = Bloom::default();
@@ -192,7 +199,7 @@ impl ConvertibleStarknetBlock for BlockWithTxs {
         // TODO: Fetch real data
         let base_fee_per_gas = client.base_fee_per_gas();
         // TODO: Fetch real data
-        let mix_hash = H256::zero();
+        let mix_hash = *MIX_HASH;
 
         let parent_hash = H256::from_slice(&self.parent_hash().to_bytes_be());
 
@@ -229,8 +236,14 @@ impl ConvertibleStarknetBlock for BlockWithTxs {
             mix_hash,
             withdrawals_root: Some(H256::zero()),
         };
-        let block =
-            Block { header, total_difficulty: None, uncles: vec![], transactions, size, withdrawals: Some(vec![]) };
+        let block = Block {
+            header,
+            total_difficulty: *TOTAL_DIFFICULTY,
+            uncles: vec![],
+            transactions,
+            size,
+            withdrawals: Some(vec![]),
+        };
         Ok(block.into())
     }
 }

--- a/crates/rpc/src/eth_rpc.rs
+++ b/crates/rpc/src/eth_rpc.rs
@@ -2,7 +2,7 @@ use jsonrpsee::core::{async_trait, RpcResult as Result};
 use jsonrpsee::proc_macros::rpc;
 use jsonrpsee::types::error::CallError;
 use kakarot_rpc_core::client::client_api::KakarotClient;
-use kakarot_rpc_core::client::constants::CHAIN_ID;
+use kakarot_rpc_core::client::constants::{CHAIN_ID, ESTIMATE_GAS};
 use kakarot_rpc_core::client::helpers::ethers_block_id_to_starknet_block_id;
 use kakarot_rpc_core::models::TokenBalances;
 use reth_primitives::rpc::transaction::eip2930::AccessListWithGasUsed;
@@ -187,7 +187,7 @@ impl EthApiServer for KakarotEthRpc {
     }
 
     async fn estimate_gas(&self, _request: CallRequest, _block_number: Option<BlockId>) -> Result<U256> {
-        Ok(U256::from(1_000_000_000_u64))
+        Ok(*ESTIMATE_GAS)
     }
 
     async fn gas_price(&self) -> Result<U256> {


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

There are multiple places where we are using hardcoded values to mock real data, the pr assembles all such constants in a single `mock_evm_data` module, inside `constants.rs`.

The name of the module comes from the fact that we are using these constants in place of mock values.

As we keep changing these values with real data, we can keep removing these constants as well from the module + now change in their values will also be atomic.

Closes #154 

# Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Testing
- [ ] Other (please describe):

# What is the current behavior?

Currently, we are using hardcoded values in place of constants, whereas we extract them to a single source so that a change to their values is atomic.

Issue Number: #154 

# What is the new behavior?

- All mocked hardcoded values have been extracted to constants.

# Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

# Other information

The heuristic used to find these values were:
- Search for `0_0` pattern throughout the codebase
- Look for TODO comments stating the value to be replaced with real value in future.