### PR TITLE
dev: fix use of `fold` to get the first element of `starknet_contract_address` 🥷 

### DIFF
--- a/crates/core/src/client/mod.rs
+++ b/crates/core/src/client/mod.rs
@@ -200,17 +200,11 @@ impl KakarotClient for KakarotClientImpl<JsonRpcClient<HttpTransport>> {
         };
         // Make the function call to get the Starknet contract address
         let starknet_contract_address = self.inner.call(request, starknet_block_id).await?;
-        
-        if starknet_contract_address.len() != 1 {
-            return Err(KakarotClientError::OtherError(anyhow::anyhow!(
-                "Kakarot get_code: starknet_contract_address length is not 1"
-            )));
-        };
 
         // shadow the variable to FielElement from a Vec<FieldElement>, for use in subsequent code
         let starknet_contract_address = match starknet_contract_address.get(0) {
-            Some(x) => *x,
-            None => {
+            Some(x) if starknet_contract_address.len() == 1 => *x,
+            _ => {
                 return Err(KakarotClientError::OtherError(anyhow::anyhow!(
                     "Kakarot get_code: starknet_contract_address is empty"
                 )));

--- a/crates/core/src/client/mod.rs
+++ b/crates/core/src/client/mod.rs
@@ -200,12 +200,29 @@ impl KakarotClient for KakarotClientImpl<JsonRpcClient<HttpTransport>> {
         };
         // Make the function call to get the Starknet contract address
         let starknet_contract_address = self.inner.call(request, starknet_block_id).await?;
-        // Concatenate the result of the function call
-        let concatenated_result = starknet_contract_address.into_iter().fold(FieldElement::ZERO, |acc, x| acc + x);
+        
+        if starknet_contract_address.len() != 1 {
+            return Err(KakarotClientError::OtherError(anyhow::anyhow!(
+                "Kakarot get_code: starknet_contract_address length is not 1"
+            )));
+        };
+
+        // shadow the variable to FielElement from a Vec<FieldElement>, for use in subsequent code
+        let starknet_contract_address = match starknet_contract_address.get(0) {
+            Some(x) => *x,
+            None => {
+                return Err(KakarotClientError::OtherError(anyhow::anyhow!(
+                    "Kakarot get_code: starknet_contract_address is empty"
+                )));
+            }
+        };
 
         // Prepare the calldata for the bytecode function call
-        let request =
-            FunctionCall { contract_address: concatenated_result, entry_point_selector: BYTECODE, calldata: vec![] };
+        let request = FunctionCall {
+            contract_address: starknet_contract_address,
+            entry_point_selector: BYTECODE,
+            calldata: vec![],
+        };
         // Make the function call to get the contract bytecode
         let contract_bytecode = self.inner.call(request, starknet_block_id).await?;
         // Convert the result of the function call to a vector of bytes


### PR DESCRIPTION
We were using `fold` on the `starknet_contract_address` vector, it is supposed to contain just one field element and that should be the contract address itself, we were using a concatenation technique to query the first value.

It also meant that if the length of this vector is 2 or something else than 1, then we won't be able to catch it, and will keep on concatenating!

The PR adds a better way to do this:
- to check for the length of this Vec  { and report in case there is some error in inspection }
- to query the first element
- shadow the same old variable so that we have a meaningful name for this value

Closes #166 

# Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Testing
- [ ] Other (please describe):

# What is the current behavior?

We are using `fold` to obtain the first value of the `starknet_contract_address` vector, which is not the ideal way to do it.

Issue Number: #166 

# What is the new behavior?

We check for the first value of the `starknet_contract_address` vector in a better way, and also report an error if any in `starknet_contract_address`.

# Does this introduce a breaking change?

- [ ] Yes
- [x] No