### PR TITLE
feat: add support for eth_getTransactionCount 🚀

### DIFF
--- a/crates/core/src/client/client_api.rs
+++ b/crates/core/src/client/client_api.rs
@@ -85,6 +85,12 @@ pub trait KakarotClient: Send + Sync {
         starknet_block_id: &StarknetBlockId,
     ) -> Result<Address, KakarotClientError>;
 
+    async fn nonce(
+        &self,
+        ethereum_address: Address,
+        starknet_block_id: StarknetBlockId,
+    ) -> Result<U256, KakarotClientError>;
+
     async fn balance(
         &self,
         ethereum_address: Address,

--- a/crates/core/src/client/constants.rs
+++ b/crates/core/src/client/constants.rs
@@ -20,6 +20,7 @@ pub mod selectors {
     pub const GET_EVM_ADDRESS: FieldElement = selector!("get_evm_address");
 
     pub const BALANCE_OF: FieldElement = selector!("balanceOf");
+    pub const GET_NONCE: FieldElement = selector!("get_nonce");
 }
 
 /// This module contains constants related to EVM gas fees.

--- a/crates/core/src/client/constants.rs
+++ b/crates/core/src/client/constants.rs
@@ -20,7 +20,6 @@ pub mod selectors {
     pub const GET_EVM_ADDRESS: FieldElement = selector!("get_evm_address");
 
     pub const BALANCE_OF: FieldElement = selector!("balanceOf");
-    pub const GET_NONCE: FieldElement = selector!("get_nonce");
 }
 
 /// This module contains constants related to EVM gas fees.

--- a/crates/core/src/client/mod.rs
+++ b/crates/core/src/client/mod.rs
@@ -642,8 +642,8 @@ impl KakarotClient for KakarotClientImpl<JsonRpcClient<HttpTransport>> {
     async fn nonce(&self, ethereum_address: Address, block_id: StarknetBlockId) -> Result<U256, KakarotClientError> {
         let starknet_address = self.compute_starknet_address(ethereum_address, &block_id).await?;
 
-        let nonce_felt = self.inner.get_nonce(block_id, starknet_address).await?;
-        let nonce = U256::from_be_bytes(nonce_felt.to_bytes_be());
+        let nonce = self.inner.get_nonce(block_id, starknet_address).await?;
+        let nonce = U256::from_be_bytes(nonce.to_bytes_be());
 
         Ok(nonce)
     }

--- a/crates/core/src/client/mod.rs
+++ b/crates/core/src/client/mod.rs
@@ -633,7 +633,7 @@ impl KakarotClient for KakarotClientImpl<JsonRpcClient<HttpTransport>> {
 
     /// Get the nonce for a given ethereum address
     /// Convert Ethereum address to Starknet address
-    /// Return the nonce, by calling `get_nonce` on the account contract
+    /// Return the nonce, by calling `get_nonce` for the addresss via starknet rpc
     /// * `ethereum_address` - The EVM address to get the nonce of
     /// * `block_id` - The block to get the nonce at
     ///

--- a/crates/core/src/client/mod.rs
+++ b/crates/core/src/client/mod.rs
@@ -44,7 +44,7 @@ use constants::selectors::BYTECODE;
 
 use self::client_api::{KakarotClient, KakarotClientError};
 use self::constants::gas::{BASE_FEE_PER_GAS, MAX_PRIORITY_FEE_PER_GAS};
-use self::constants::selectors::{BALANCE_OF, COMPUTE_STARKNET_ADDRESS, GET_EVM_ADDRESS};
+use self::constants::selectors::{BALANCE_OF, COMPUTE_STARKNET_ADDRESS, GET_EVM_ADDRESS, GET_NONCE};
 use self::constants::{MAX_FEE, STARKNET_NATIVE_TOKEN};
 use crate::models::convertible::ConvertibleStarknetBlock;
 use crate::models::{BlockWithTxHashes, BlockWithTxs, TokenBalance, TokenBalances};
@@ -629,6 +629,38 @@ impl KakarotClient for KakarotClientImpl<JsonRpcClient<HttpTransport>> {
         let evm_address_sliced = &tmp_slice;
 
         Ok(Address::from(evm_address_sliced))
+    }
+
+    /// Get the nonce for a given ethereum address
+    /// Convert Ethereum address to Starknet address
+    /// Return the nonce, by calling `get_nonce` on the account contract
+    /// * `ethereum_address` - The EVM address to get the nonce of
+    /// * `block_id` - The block to get the nonce at
+    ///
+    /// ### Returns
+    /// * `Result<U256, KakarotClientError>` - The nonce of the EVM address
+    async fn nonce(&self, ethereum_address: Address, block_id: StarknetBlockId) -> Result<U256, KakarotClientError> {
+        let starknet_address = self.compute_starknet_address(ethereum_address, &block_id).await?;
+
+        let request = FunctionCall {
+            // This FieldElement::from_hex_be cannot fail as the value is a constant
+            contract_address: starknet_address,
+            entry_point_selector: GET_NONCE,
+            calldata: vec![],
+        };
+
+        let nonce_felt = self.inner.call(request, block_id).await?;
+
+        let nonce = nonce_felt
+            .first()
+            .ok_or_else(|| {
+                KakarotClientError::OtherError(anyhow::anyhow!("Kakarot Core: Failed to get account nonce"))
+            })?
+            .to_bytes_be();
+
+        let nonce = U256::from_be_bytes(nonce);
+
+        Ok(nonce)
     }
 
     /// Get the balance in Starknet's native token of a specific EVM address.


### PR DESCRIPTION
Implements the eth_getTransactionCount API, this will allow fetching nonce for an account and will allow easy use of tools like Metamask.


# Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Testing
- [ ] Other (please describe):

# What is the current behavior?

The mentioned endpoint is not implemented, and a fixed value 3 is returned.

Resolves: #146 

# What is the new behavior?

- the real nonce associated with a given EOA is returned

# Does this introduce a breaking change?

- [ ] Yes
- [x] No