### PR TITLE
refactor: refactor environment variable handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1682,6 +1682,7 @@ dependencies = [
  "hex",
  "jsonrpsee",
  "kakarot_rpc_core",
+ "lazy_static",
  "log",
  "reqwest",
  "reth-primitives",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,3 +28,4 @@ reth-rlp = { git = "https://github.com/paradigmxyz/reth.git", rev = "fb710e5" }
 reth-primitives = { git = "https://github.com/paradigmxyz/reth.git", rev = "fb710e5" }
 async-trait = "0.1.58"
 jsonrpsee = { version = "0.18.2", features = ["full"] }
+lazy_static = "1.4.0"

--- a/crates/core/src/client/config.rs
+++ b/crates/core/src/client/config.rs
@@ -1,0 +1,40 @@
+use eyre::Result;
+use starknet::core::types::FieldElement;
+
+use super::errors::ConfigError;
+
+fn get_env_var(name: &str) -> Result<String, ConfigError> {
+    std::env::var(name).map_err(|_| ConfigError::EnvironmentVariableMissing(name.into()))
+}
+
+pub struct StarknetConfig {
+    pub starknet_rpc: String,
+    pub kakarot_address: FieldElement,
+    pub proxy_account_class_hash: FieldElement,
+}
+
+impl StarknetConfig {
+    pub fn new(starknet_rpc: &str, kakarot_address: FieldElement, proxy_account_class_hash: FieldElement) -> Self {
+        StarknetConfig { starknet_rpc: String::from(starknet_rpc), kakarot_address, proxy_account_class_hash }
+    }
+
+    pub fn from_env() -> Result<Self, ConfigError> {
+        let starknet_rpc_url = get_env_var("STARKNET_RPC_URL")?;
+
+        let kakarot_address = get_env_var("KAKAROT_ADDRESS")?;
+        let kakarot_address = FieldElement::from_hex_be(&kakarot_address).map_err(|_| {
+            ConfigError::EnvironmentVariableSetWrong(format!(
+                "KAKAROT_ADDRESS should be provided as a hex string, got {kakarot_address}"
+            ))
+        })?;
+
+        let proxy_account_class_hash = get_env_var("PROXY_ACCOUNT_CLASS_HASH")?;
+        let proxy_account_class_hash = FieldElement::from_hex_be(&proxy_account_class_hash).map_err(|_| {
+            ConfigError::EnvironmentVariableSetWrong(format!(
+                "PROXY_ACCOUNT_CLASS_HASH should be provided as a hex string, got {proxy_account_class_hash}"
+            ))
+        })?;
+
+        Ok(StarknetConfig::new(&starknet_rpc_url, kakarot_address, proxy_account_class_hash))
+    }
+}

--- a/crates/core/src/client/errors.rs
+++ b/crates/core/src/client/errors.rs
@@ -23,6 +23,16 @@ pub enum EthRpcErrorCode {
     TransactionRejected = -32003,
 }
 
+// Error that can accure when preparing configuration.
+#[derive(Debug, Error)]
+pub enum ConfigError {
+    #[error("Missing mandatory environment variable: {0}")]
+    EnvironmentVariableMissing(String),
+    /// {0} is details of what is wrong with the variable setting.
+    #[error("{0}")]
+    EnvironmentVariableSetWrong(String),
+}
+
 /// Error that can accure when interacting with the Kakarot ETH API.
 #[derive(Debug, Error)]
 pub enum EthApiError {

--- a/crates/core/src/client/mod.rs
+++ b/crates/core/src/client/mod.rs
@@ -1,4 +1,5 @@
 pub mod client_api;
+pub mod config;
 pub mod constants;
 pub mod errors;
 pub mod helpers;
@@ -35,6 +36,7 @@ use starknet::providers::Provider;
 use url::Url;
 
 use self::client_api::KakarotProvider;
+use self::config::StarknetConfig;
 use self::constants::gas::{BASE_FEE_PER_GAS, MAX_PRIORITY_FEE_PER_GAS};
 use self::constants::selectors::{BALANCE_OF, COMPUTE_STARKNET_ADDRESS, GET_EVM_ADDRESS};
 use self::constants::{MAX_FEE, STARKNET_NATIVE_TOKEN};
@@ -65,12 +67,9 @@ impl KakarotClient<JsonRpcClient<HttpTransport>> {
     /// # Errors
     ///
     /// `Err(EthApiError)` if the operation failed.
-    pub fn new(
-        starknet_rpc: &str,
-        kakarot_address: FieldElement,
-        proxy_account_class_hash: FieldElement,
-    ) -> Result<Self> {
-        let url = Url::parse(starknet_rpc)?;
+    pub fn new(starknet_cfg: StarknetConfig) -> Result<Self> {
+        let StarknetConfig { starknet_rpc, kakarot_address, proxy_account_class_hash } = starknet_cfg;
+        let url = Url::parse(&starknet_rpc)?;
         Ok(Self {
             starknet_provider: JsonRpcClient::new(HttpTransport::new(url)),
             kakarot_address,

--- a/crates/core/src/client/mod.rs
+++ b/crates/core/src/client/mod.rs
@@ -67,8 +67,8 @@ impl KakarotClient<JsonRpcClient<HttpTransport>> {
     /// # Errors
     ///
     /// `Err(EthApiError)` if the operation failed.
-    pub fn new(starknet_cfg: StarknetConfig) -> Result<Self> {
-        let StarknetConfig { starknet_rpc, kakarot_address, proxy_account_class_hash } = starknet_cfg;
+    pub fn new(starknet_config: StarknetConfig) -> Result<Self> {
+        let StarknetConfig { starknet_rpc, kakarot_address, proxy_account_class_hash } = starknet_config;
         let url = Url::parse(&starknet_rpc)?;
         Ok(Self {
             starknet_provider: JsonRpcClient::new(HttpTransport::new(url)),

--- a/crates/core/src/mock/wiremock_utils.rs
+++ b/crates/core/src/mock/wiremock_utils.rs
@@ -10,6 +10,7 @@ use wiremock::matchers::{body_json, method};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
 use crate::client::client_api::KakarotProvider;
+use crate::client::config::StarknetConfig;
 use crate::client::helpers::ethers_block_id_to_starknet_block_id;
 use crate::client::KakarotClient;
 
@@ -119,14 +120,11 @@ pub async fn setup_wiremock() -> String {
 
 pub async fn setup_mock_client() -> Box<dyn KakarotProvider> {
     let starknet_rpc = setup_wiremock().await;
-    Box::new(
-        KakarotClient::new(
-            &starknet_rpc,
-            FieldElement::from_hex_be("0x566864dbc2ae76c2d12a8a5a334913d0806f85b7a4dccea87467c3ba3616e75").unwrap(),
-            FieldElement::from_hex_be("0x0775033b738dfe34c48f43a839c3d882ebe521befb3447240f2d218f14816ef5").unwrap(),
-        )
-        .unwrap(),
-    )
+    let kakarot_address =
+        FieldElement::from_hex_be("0x566864dbc2ae76c2d12a8a5a334913d0806f85b7a4dccea87467c3ba3616e75").unwrap();
+    let proxy_account_class_hash =
+        FieldElement::from_hex_be("0x0775033b738dfe34c48f43a839c3d882ebe521befb3447240f2d218f14816ef5").unwrap();
+    Box::new(KakarotClient::new(StarknetConfig::new(&starknet_rpc, kakarot_address, proxy_account_class_hash)).unwrap())
 }
 
 pub async fn setup_mock_client_crate() -> KakarotClient<JsonRpcClient<HttpTransport>>
@@ -134,13 +132,12 @@ where
     KakarotClient<JsonRpcClient<HttpTransport>>: KakarotProvider,
 {
     let starknet_rpc = setup_wiremock().await;
+    let kakarot_address =
+        FieldElement::from_hex_be("0x566864dbc2ae76c2d12a8a5a334913d0806f85b7a4dccea87467c3ba3616e75").unwrap();
+    let proxy_account_class_hash =
+        FieldElement::from_hex_be("0x0775033b738dfe34c48f43a839c3d882ebe521befb3447240f2d218f14816ef5").unwrap();
 
-    KakarotClient::new(
-        &starknet_rpc,
-        FieldElement::from_hex_be("0x566864dbc2ae76c2d12a8a5a334913d0806f85b7a4dccea87467c3ba3616e75").unwrap(),
-        FieldElement::from_hex_be("0x0775033b738dfe34c48f43a839c3d882ebe521befb3447240f2d218f14816ef5").unwrap(),
-    )
-    .unwrap()
+    KakarotClient::new(StarknetConfig::new(&starknet_rpc, kakarot_address, proxy_account_class_hash)).unwrap()
 }
 
 fn mock_block_number() -> Mock {

--- a/crates/rpc/Cargo.toml
+++ b/crates/rpc/Cargo.toml
@@ -35,6 +35,7 @@ starknet = { workspace = true }
 thiserror = "1.0.38"
 tracing = "0.1.34"
 tracing-subscriber = { version = "0.3.3", features = ["env-filter"] }
+lazy_static = { workspace = true }
 
 [dev-dependencies.cargo-husky]
 version = "1.5.0"

--- a/crates/rpc/src/config.rs
+++ b/crates/rpc/src/config.rs
@@ -1,0 +1,17 @@
+use eyre::{eyre, Result};
+
+pub struct RPCConfig {
+    pub socket_addr: String,
+}
+
+impl RPCConfig {
+    pub fn new(socket_addr: String) -> RPCConfig {
+        RPCConfig { socket_addr }
+    }
+
+    pub fn from_env() -> Result<Self> {
+        let socket_addr = std::env::var("KAKAROT_HTTP_RPC_ADDRESS")
+            .map_err(|_| eyre!("Missing mandatory environment variable: KAKAROT_HTTP_RPC_ADDRESS"))?;
+        Ok(RPCConfig::new(socket_addr))
+    }
+}

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -2,8 +2,10 @@
 // //! It is an adapter layer to interact with Kakarot ZK-EVM.
 use std::net::{AddrParseError, SocketAddr};
 pub mod eth_rpc;
+use config::RPCConfig;
 use eth_api::EthApiServer;
 use eth_rpc::KakarotEthRpc;
+pub mod config;
 pub mod eth_api;
 use eyre::Result;
 use jsonrpsee::server::{ServerBuilder, ServerHandle};
@@ -21,8 +23,11 @@ pub enum RpcError {
 /// # Errors
 ///
 /// Will return `Err` if an error occurs when running the `ServerBuilder` start fails.
-pub async fn run_server(starknet_client: Box<dyn KakarotProvider>) -> Result<(SocketAddr, ServerHandle), RpcError> {
-    let socket_addr = std::env::var("KAKAROT_HTTP_RPC_ADDRESS").unwrap_or_else(|_| "0.0.0.0:3030".to_owned());
+pub async fn run_server(
+    starknet_client: Box<dyn KakarotProvider>,
+    rpc_cfg: RPCConfig,
+) -> Result<(SocketAddr, ServerHandle), RpcError> {
+    let RPCConfig { socket_addr } = rpc_cfg;
 
     let server = ServerBuilder::default().build(socket_addr.parse::<SocketAddr>()?).await?;
 

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -25,9 +25,9 @@ pub enum RpcError {
 /// Will return `Err` if an error occurs when running the `ServerBuilder` start fails.
 pub async fn run_server(
     starknet_client: Box<dyn KakarotProvider>,
-    rpc_cfg: RPCConfig,
+    rpc_config: RPCConfig,
 ) -> Result<(SocketAddr, ServerHandle), RpcError> {
-    let RPCConfig { socket_addr } = rpc_cfg;
+    let RPCConfig { socket_addr } = rpc_config;
 
     let server = ServerBuilder::default().build(socket_addr.parse::<SocketAddr>()?).await?;
 

--- a/crates/rpc/src/main.rs
+++ b/crates/rpc/src/main.rs
@@ -1,35 +1,25 @@
 use dotenv::dotenv;
-use eyre::{eyre, Result};
+use eyre::Result;
+use kakarot_rpc::config::RPCConfig;
 use kakarot_rpc::run_server;
+use kakarot_rpc_core::client::config::StarknetConfig;
 use kakarot_rpc_core::client::KakarotClient;
-use starknet::core::types::FieldElement;
 use tracing_subscriber::util::SubscriberInitExt;
 
 #[tokio::main]
 async fn main() -> Result<()> {
     dotenv().ok();
+    // Environment variables are safe to use after this
 
     let filter = tracing_subscriber::EnvFilter::try_from_default_env()?
         .add_directive("jsonrpsee[method_call{name = \"eth_chainId\"}]=trace".parse()?);
     tracing_subscriber::FmtSubscriber::builder().with_env_filter(filter).finish().try_init()?;
 
-    let starknet_rpc = std::env::var("STARKNET_RPC_URL")
-        .map_err(|_| eyre!("Missing mandatory environment variable: STARKNET_RPC_URL"))?;
+    let starknet_cfg = StarknetConfig::from_env()?;
+    let rpc_cfg = RPCConfig::from_env()?;
+    let kakarot_client = KakarotClient::new(starknet_cfg)?;
 
-    let kakarot_address = std::env::var("KAKAROT_ADDRESS")
-        .map_err(|_| eyre!("Missing mandatory environment variable: KAKAROT_ADDRESS"))?;
-    let kakarot_address = FieldElement::from_hex_be(&kakarot_address)
-        .map_err(|_| eyre!("KAKAROT_ADDRESS should be provided as a hex string, got {kakarot_address}"))?;
-
-    let proxy_account_class_hash = std::env::var("PROXY_ACCOUNT_CLASS_HASH")
-        .map_err(|_| eyre!("Missing mandatory environment variable: PROXY_ACCOUNT_CLASS_HASH"))?;
-    let proxy_account_class_hash = FieldElement::from_hex_be(&proxy_account_class_hash).map_err(|_| {
-        eyre!("PROXY_ACCOUNT_CLASS_HASH should be provided as a hex string, got {proxy_account_class_hash}")
-    })?;
-
-    let kakarot_client = KakarotClient::new(&starknet_rpc, kakarot_address, proxy_account_class_hash)?;
-
-    let (server_addr, server_handle) = run_server(Box::new(kakarot_client)).await?;
+    let (server_addr, server_handle) = run_server(Box::new(kakarot_client), rpc_cfg).await?;
     let url = format!("http://{server_addr}");
 
     println!("RPC Server running on {url}...");

--- a/crates/rpc/src/main.rs
+++ b/crates/rpc/src/main.rs
@@ -15,11 +15,11 @@ async fn main() -> Result<()> {
         .add_directive("jsonrpsee[method_call{name = \"eth_chainId\"}]=trace".parse()?);
     tracing_subscriber::FmtSubscriber::builder().with_env_filter(filter).finish().try_init()?;
 
-    let starknet_cfg = StarknetConfig::from_env()?;
-    let rpc_cfg = RPCConfig::from_env()?;
-    let kakarot_client = KakarotClient::new(starknet_cfg)?;
+    let starknet_config = StarknetConfig::from_env()?;
+    let rpc_config = RPCConfig::from_env()?;
+    let kakarot_client = KakarotClient::new(starknet_config)?;
 
-    let (server_addr, server_handle) = run_server(Box::new(kakarot_client), rpc_cfg).await?;
+    let (server_addr, server_handle) = run_server(Box::new(kakarot_client), rpc_config).await?;
     let url = format!("http://{server_addr}");
 
     println!("RPC Server running on {url}...");

--- a/crates/rpc/tests/utils.rs
+++ b/crates/rpc/tests/utils.rs
@@ -1,4 +1,5 @@
 use kakarot_rpc::eth_rpc::KakarotEthRpc;
+use kakarot_rpc_core::client::config::StarknetConfig;
 use kakarot_rpc_core::client::KakarotClient;
 use kakarot_rpc_core::mock::wiremock_utils::setup_wiremock;
 use starknet::core::types::FieldElement;
@@ -30,13 +31,13 @@ use starknet::core::types::FieldElement;
 /// ```
 pub async fn setup_kakarot_eth_rpc() -> KakarotEthRpc {
     let starknet_rpc = setup_wiremock().await;
+    let kakarot_address =
+        FieldElement::from_hex_be("0x566864dbc2ae76c2d12a8a5a334913d0806f85b7a4dccea87467c3ba3616e75").unwrap();
+    let proxy_account_class_hash =
+        FieldElement::from_hex_be("0x0775033b738dfe34c48f43a839c3d882ebe521befb3447240f2d218f14816ef5").unwrap();
 
-    let kakarot_client = KakarotClient::new(
-        &starknet_rpc,
-        FieldElement::from_hex_be("0x566864dbc2ae76c2d12a8a5a334913d0806f85b7a4dccea87467c3ba3616e75").unwrap(),
-        FieldElement::from_hex_be("0x0775033b738dfe34c48f43a839c3d882ebe521befb3447240f2d218f14816ef5").unwrap(),
-    )
-    .unwrap();
+    let kakarot_client =
+        KakarotClient::new(StarknetConfig::new(&starknet_rpc, kakarot_address, proxy_account_class_hash)).unwrap();
 
     KakarotEthRpc::new(Box::new(kakarot_client))
 }


### PR DESCRIPTION
Refactor environment variable parsing to a single file, and move validation to a single function.

# Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Testing
- [ ] Other (please describe):

# What is the current behavior?

As of now every time we need an environment variable, we parse it and then do a `map_err`,  in the future we might need more environment variables, and they might be used in various files { they are already being used in 2 } + some of these variables might only be needed when a special branch of the code is executed, and if not present might panic the service later.

This PR move parsing of all these variables and exposes them as lazy statics, it also provides a validation function, which can be run before the start of the service, if some critical variable is not present, it will panic the service before it even starts. Hence we can also use this function as a smoke test. i.e. making sure that we don't we do tests until this function passes.

The PR is more for our future needs, where the RPC might become more and more configurable, and for those configurations, we might need more and more environment variables.

Resolves: #199 

# What is the new behavior?

- All variables are exposed as lazy_statics 
- An environment validation function takes care that the service doesn't start before all environment variables are present
- All environment variables have been pre_fixed with `ENV` making sure that to reader it is clear that they are environment variables

# Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

# Other information

As of now there is only test, which is for the success case of the validation function, we can investigate in future on how to test panic cases in the same test, as panics test pass when they are run individually, but tend to fail when run with other tests. 
