### PR TITLE
add a is_kakarot_tx function

### DIFF
--- a/crates/core/src/models/transaction.rs
+++ b/crates/core/src/models/transaction.rs
@@ -119,6 +119,16 @@ impl ConvertibleStarknetTransaction for StarknetTransaction {
 }
 
 impl StarknetTransaction {
+    /// Checks if the transaction is a Kakarot transaction.
+    ///
+    /// ## Arguments
+    ///
+    /// * `client` - The Kakarot client.
+    ///
+    /// ## Returns
+    ///
+    /// `Ok(bool)` if the operation was successful.
+    /// `Err(EthApiError)` if the operation failed.
     async fn is_kakarot_tx(&self, client: &dyn KakarotClient) -> Result<bool, EthApiError> {
         let starknet_block_latest = StarknetBlockId::Tag(BlockTag::Latest);
         let sender_address: FieldElement = self.sender_address()?.into();


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->
Adds a helper function to check if a Starknet transaction is part of Kakarot.
<!-- Give an estimate of the time you spent on this PR in terms of work days. Did you spend 0.5 days on this PR or rather 2 days?  -->

Time spent on this PR: NA

# Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [x] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Testing
- [ ] Other (please describe):

# What is the current behavior?
The check for a Kakarot transaction is coded inside of `to_eth_transaction`.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Resolves: #152 

# What is the new behavior?
Extract the logic from `to_eth_transaction` into a separate function, which will allow for better unit testing and reusability.

# Does this introduce a breaking change?

- [ ] Yes
- [x] No
