### PR TITLE
refactor: refactor KakarotProvider trait for seperation of responsibilites

### DIFF
--- a/crates/core/src/client/client_api.rs
+++ b/crates/core/src/client/client_api.rs
@@ -16,20 +16,10 @@ use crate::models::balance::TokenBalances;
 use crate::models::transaction::StarknetTransactions;
 
 #[async_trait]
-pub trait KakarotProvider: Send + Sync {
-    fn kakarot_address(&self) -> FieldElement;
-    fn proxy_account_class_hash(&self) -> FieldElement;
-    fn starknet_provider(&self) -> &JsonRpcClient<HttpTransport>;
-
+pub trait KakarotEthApi: Send + Sync + KakarotStarknetUtils {
     async fn block_number(&self) -> Result<U64, EthApiError>;
 
     async fn transaction_by_hash(&self, hash: H256) -> Result<EtherTransaction, EthApiError>;
-
-    async fn get_eth_block_from_starknet_block(
-        &self,
-        block_id: StarknetBlockId,
-        hydrated_tx: bool,
-    ) -> Result<RichBlock, EthApiError>;
 
     async fn get_code(
         &self,
@@ -56,21 +46,9 @@ pub trait KakarotProvider: Send + Sync {
 
     async fn block_transaction_count_by_hash(&self, hash: H256) -> Result<U64, EthApiError>;
 
-    async fn compute_starknet_address(
-        &self,
-        ethereum_address: Address,
-        starknet_block_id: &StarknetBlockId,
-    ) -> Result<FieldElement, EthApiError>;
-
     async fn submit_starknet_transaction(&self, request: BroadcastedInvokeTransactionV1) -> Result<H256, EthApiError>;
 
     async fn transaction_receipt(&self, hash: H256) -> Result<Option<TransactionReceipt>, EthApiError>;
-
-    async fn get_evm_address(
-        &self,
-        starknet_address: &FieldElement,
-        starknet_block_id: &StarknetBlockId,
-    ) -> Result<Address, EthApiError>;
 
     async fn nonce(&self, ethereum_address: Address, starknet_block_id: StarknetBlockId) -> Result<U256, EthApiError>;
 
@@ -82,13 +60,6 @@ pub trait KakarotProvider: Send + Sync {
         address: Address,
         contract_addresses: Vec<Address>,
     ) -> Result<TokenBalances, EthApiError>;
-
-    async fn filter_starknet_into_eth_txs(
-        &self,
-        initial_transactions: StarknetTransactions,
-        blockhash_opt: Option<H256>,
-        blocknum_opt: Option<U256>,
-    ) -> Result<BlockTransactions, EthApiError>;
 
     async fn send_transaction(&self, bytes: Bytes) -> Result<H256, EthApiError>;
 
@@ -107,4 +78,34 @@ pub trait KakarotProvider: Send + Sync {
 
     async fn estimate_gas(&self, call_request: CallRequest, block_number: Option<BlockId>)
     -> Result<U256, EthApiError>;
+}
+
+#[async_trait]
+pub trait KakarotStarknetUtils: Send + Sync {
+    fn kakarot_address(&self) -> FieldElement;
+    fn proxy_account_class_hash(&self) -> FieldElement;
+    fn starknet_provider(&self) -> &JsonRpcClient<HttpTransport>;
+    async fn compute_starknet_address(
+        &self,
+        ethereum_address: Address,
+        starknet_block_id: &StarknetBlockId,
+    ) -> Result<FieldElement, EthApiError>;
+    async fn get_evm_address(
+        &self,
+        starknet_address: &FieldElement,
+        starknet_block_id: &StarknetBlockId,
+    ) -> Result<Address, EthApiError>;
+
+    async fn filter_starknet_into_eth_txs(
+        &self,
+        initial_transactions: StarknetTransactions,
+        blockhash_opt: Option<H256>,
+        blocknum_opt: Option<U256>,
+    ) -> Result<BlockTransactions, EthApiError>;
+
+    async fn get_eth_block_from_starknet_block(
+        &self,
+        block_id: StarknetBlockId,
+        hydrated_tx: bool,
+    ) -> Result<RichBlock, EthApiError>;
 }

--- a/crates/core/src/client/client_api.rs
+++ b/crates/core/src/client/client_api.rs
@@ -16,7 +16,7 @@ use crate::models::balance::TokenBalances;
 use crate::models::transaction::StarknetTransactions;
 
 #[async_trait]
-pub trait KakarotEthApi: Send + Sync + KakarotStarknetUtils {
+pub trait KakarotEthApi: KakarotStarknetUtils {
     async fn block_number(&self) -> Result<U64, EthApiError>;
 
     async fn transaction_by_hash(&self, hash: H256) -> Result<EtherTransaction, EthApiError>;

--- a/crates/core/src/mock/wiremock_utils.rs
+++ b/crates/core/src/mock/wiremock_utils.rs
@@ -9,7 +9,7 @@ use starknet::providers::JsonRpcClient;
 use wiremock::matchers::{body_json, method};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
-use crate::client::client_api::KakarotProvider;
+use crate::client::client_api::KakarotEthApi;
 use crate::client::config::StarknetConfig;
 use crate::client::helpers::ethers_block_id_to_starknet_block_id;
 use crate::client::KakarotClient;
@@ -118,7 +118,7 @@ pub async fn setup_wiremock() -> String {
     mock_server.uri()
 }
 
-pub async fn setup_mock_client() -> Box<dyn KakarotProvider> {
+pub async fn setup_mock_client() -> Box<dyn KakarotEthApi> {
     let starknet_rpc = setup_wiremock().await;
     let kakarot_address =
         FieldElement::from_hex_be("0x566864dbc2ae76c2d12a8a5a334913d0806f85b7a4dccea87467c3ba3616e75").unwrap();
@@ -129,7 +129,7 @@ pub async fn setup_mock_client() -> Box<dyn KakarotProvider> {
 
 pub async fn setup_mock_client_crate() -> KakarotClient<JsonRpcClient<HttpTransport>>
 where
-    KakarotClient<JsonRpcClient<HttpTransport>>: KakarotProvider,
+    KakarotClient<JsonRpcClient<HttpTransport>>: KakarotEthApi,
 {
     let starknet_rpc = setup_wiremock().await;
     let kakarot_address =

--- a/crates/core/src/models/block.rs
+++ b/crates/core/src/models/block.rs
@@ -4,7 +4,7 @@ use reth_rpc_types::{Block, BlockTransactions, Header, RichBlock};
 use starknet::core::types::{FieldElement, MaybePendingBlockWithTxHashes, MaybePendingBlockWithTxs, Transaction};
 
 use super::convertible::ConvertibleStarknetBlock;
-use crate::client::client_api::KakarotProvider;
+use crate::client::client_api::KakarotEthApi;
 use crate::client::constants::{DIFFICULTY, GAS_LIMIT, GAS_USED, MIX_HASH, NONCE, SIZE, TOTAL_DIFFICULTY};
 use crate::client::errors::EthApiError;
 use crate::client::helpers::starknet_address_to_ethereum_address;
@@ -85,7 +85,7 @@ impl BlockWithTxs {
 
 #[async_trait]
 impl ConvertibleStarknetBlock for BlockWithTxHashes {
-    async fn to_eth_block(&self, client: &dyn KakarotProvider) -> Result<RichBlock, EthApiError> {
+    async fn to_eth_block(&self, client: &dyn KakarotEthApi) -> Result<RichBlock, EthApiError> {
         // TODO: Fetch real data
         let gas_limit = *GAS_LIMIT;
 
@@ -161,7 +161,7 @@ impl ConvertibleStarknetBlock for BlockWithTxHashes {
 
 #[async_trait]
 impl ConvertibleStarknetBlock for BlockWithTxs {
-    async fn to_eth_block(&self, client: &dyn KakarotProvider) -> Result<RichBlock, EthApiError> {
+    async fn to_eth_block(&self, client: &dyn KakarotEthApi) -> Result<RichBlock, EthApiError> {
         // TODO: Fetch real data
         let gas_limit = *GAS_LIMIT;
 

--- a/crates/core/src/models/convertible.rs
+++ b/crates/core/src/models/convertible.rs
@@ -2,19 +2,19 @@ use async_trait::async_trait;
 use reth_primitives::{H256, U256};
 use reth_rpc_types::{Log, RichBlock, Transaction as EthTransaction};
 
-use crate::client::client_api::KakarotProvider;
+use crate::client::client_api::{KakarotEthApi, KakarotStarknetUtils};
 use crate::client::errors::EthApiError;
 
 #[async_trait]
 pub trait ConvertibleStarknetBlock {
-    async fn to_eth_block(&self, client: &dyn KakarotProvider) -> Result<RichBlock, EthApiError>;
+    async fn to_eth_block(&self, client: &dyn KakarotEthApi) -> Result<RichBlock, EthApiError>;
 }
 
 #[async_trait]
 pub trait ConvertibleStarknetEvent {
     async fn to_eth_log(
         &self,
-        client: &dyn KakarotProvider,
+        client: &dyn KakarotStarknetUtils,
         block_hash: Option<H256>,
         block_number: Option<U256>,
         transaction_hash: Option<H256>,
@@ -27,7 +27,7 @@ pub trait ConvertibleStarknetEvent {
 pub trait ConvertibleStarknetTransaction {
     async fn to_eth_transaction(
         &self,
-        client: &dyn KakarotProvider,
+        client: &dyn KakarotEthApi,
         block_hash: Option<H256>,
         block_number: Option<U256>,
         transaction_index: Option<U256>,

--- a/crates/core/src/models/event.rs
+++ b/crates/core/src/models/event.rs
@@ -7,7 +7,7 @@ use reth_rpc_types::Log;
 use starknet::core::types::Event;
 
 use super::felt::Felt252Wrapper;
-use crate::client::client_api::KakarotProvider;
+use crate::client::client_api::KakarotStarknetUtils;
 use crate::client::errors::EthApiError;
 use crate::models::convertible::ConvertibleStarknetEvent;
 
@@ -23,7 +23,7 @@ impl StarknetEvent {
 impl ConvertibleStarknetEvent for StarknetEvent {
     async fn to_eth_log(
         &self,
-        client: &dyn KakarotProvider,
+        client: &dyn KakarotStarknetUtils,
         block_hash: Option<H256>,
         block_number: Option<U256>,
         transaction_hash: Option<H256>,

--- a/crates/core/src/models/transaction.rs
+++ b/crates/core/src/models/transaction.rs
@@ -6,7 +6,7 @@ use starknet::providers::Provider;
 
 use super::felt::Felt252Wrapper;
 use super::ConversionError;
-use crate::client::client_api::KakarotProvider;
+use crate::client::client_api::KakarotEthApi;
 use crate::client::constants::{self, CHAIN_ID};
 use crate::client::errors::EthApiError;
 use crate::client::helpers::{decode_signature_and_to_address_from_tx_calldata, vec_felt_to_bytes};
@@ -67,7 +67,7 @@ impl From<StarknetTransactions> for Vec<Transaction> {
 impl ConvertibleStarknetTransaction for StarknetTransaction {
     async fn to_eth_transaction(
         &self,
-        client: &dyn KakarotProvider,
+        client: &dyn KakarotEthApi,
         block_hash: Option<H256>,
         block_number: Option<U256>,
         transaction_index: Option<U256>,
@@ -129,7 +129,7 @@ impl StarknetTransaction {
     ///
     /// `Ok(bool)` if the operation was successful.
     /// `Err(EthApiError)` if the operation failed.
-    async fn is_kakarot_tx(&self, client: &dyn KakarotProvider) -> Result<bool, EthApiError> {
+    async fn is_kakarot_tx(&self, client: &dyn KakarotEthApi) -> Result<bool, EthApiError> {
         let starknet_block_latest = StarknetBlockId::Tag(BlockTag::Latest);
         let sender_address: FieldElement = self.sender_address()?.into();
 

--- a/crates/core/tests/client.rs
+++ b/crates/core/tests/client.rs
@@ -3,7 +3,7 @@ mod tests {
 
     use std::str::FromStr;
 
-    use kakarot_rpc_core::client::client_api::KakarotProvider;
+    use kakarot_rpc_core::client::client_api::{KakarotEthApi, KakarotStarknetUtils};
     use kakarot_rpc_core::mock::wiremock_utils::setup_mock_client_crate;
     use kakarot_rpc_core::models::block::BlockWithTxs;
     use kakarot_rpc_core::models::convertible::{ConvertibleStarknetBlock, ConvertibleStarknetEvent};

--- a/crates/eth-rpc/src/eth_rpc.rs
+++ b/crates/eth-rpc/src/eth_rpc.rs
@@ -1,7 +1,7 @@
 use jsonrpsee::core::{async_trait, RpcResult as Result};
 use jsonrpsee::proc_macros::rpc;
 use jsonrpsee::types::error::{INTERNAL_ERROR_CODE, METHOD_NOT_FOUND_CODE};
-use kakarot_rpc_core::client::client_api::KakarotProvider;
+use kakarot_rpc_core::client::client_api::KakarotEthApi;
 use kakarot_rpc_core::client::constants::{CHAIN_ID, ESTIMATE_GAS};
 use kakarot_rpc_core::client::errors::rpc_err;
 use kakarot_rpc_core::client::helpers::ethers_block_id_to_starknet_block_id;
@@ -19,7 +19,7 @@ use crate::eth_api::EthApiServer;
 
 /// The RPC module for the Ethereum protocol required by Kakarot.
 pub struct KakarotEthRpc {
-    pub kakarot_client: Box<dyn KakarotProvider>,
+    pub kakarot_client: Box<dyn KakarotEthApi>,
 }
 
 #[async_trait]
@@ -284,7 +284,7 @@ impl KakarotCustomApiServer for KakarotEthRpc {
 
 impl KakarotEthRpc {
     #[must_use]
-    pub fn new(kakarot_client: Box<dyn KakarotProvider>) -> Self {
+    pub fn new(kakarot_client: Box<dyn KakarotEthApi>) -> Self {
         Self { kakarot_client }
     }
 }

--- a/crates/eth-rpc/src/lib.rs
+++ b/crates/eth-rpc/src/lib.rs
@@ -9,7 +9,7 @@ pub mod config;
 pub mod eth_api;
 use eyre::Result;
 use jsonrpsee::server::{ServerBuilder, ServerHandle};
-use kakarot_rpc_core::client::client_api::KakarotProvider;
+use kakarot_rpc_core::client::client_api::KakarotEthApi;
 use thiserror::Error;
 
 #[derive(Error, Debug)]
@@ -24,7 +24,7 @@ pub enum RpcError {
 ///
 /// Will return `Err` if an error occurs when running the `ServerBuilder` start fails.
 pub async fn run_server(
-    starknet_client: Box<dyn KakarotProvider>,
+    starknet_client: Box<dyn KakarotEthApi>,
     rpc_config: RPCConfig,
 ) -> Result<(SocketAddr, ServerHandle), RpcError> {
     let RPCConfig { socket_addr } = rpc_config;

--- a/crates/eth-rpc/src/lib.rs
+++ b/crates/eth-rpc/src/lib.rs
@@ -24,7 +24,7 @@ pub enum RpcError {
 ///
 /// Will return `Err` if an error occurs when running the `ServerBuilder` start fails.
 pub async fn run_server(
-    starknet_client: Box<dyn KakarotEthApi>,
+    kakarot_client: Box<dyn KakarotEthApi>,
     rpc_config: RPCConfig,
 ) -> Result<(SocketAddr, ServerHandle), RpcError> {
     let RPCConfig { socket_addr } = rpc_config;
@@ -33,7 +33,7 @@ pub async fn run_server(
 
     let addr = server.local_addr()?;
 
-    let rpc_calls = KakarotEthRpc::new(starknet_client);
+    let rpc_calls = KakarotEthRpc::new(kakarot_client);
     let handle = server.start(rpc_calls.into_rpc())?;
 
     Ok((addr, handle))


### PR DESCRIPTION
Refactor `KakarotProvider` trait for seperation of responsibilites

# Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Testing
- [ ] Other (please describe):

# What is the current behavior?

Currently, we have a single `KakarotProvider` trait, which defines methods, that are a combination of Eth methods and Starknet methods, which removes the lines of separation between these individual responsibilities.

Resolves: #198 

# What is the new behavior?

- `KakarotProvider` is now a combination of `KakarotEthApi` and `KakarotStarknetUtils`.
- `KakarotEthApi`: All Ethereum-related concerns live here.
- `KakarotStarknetUtils`: All Starknet concerns live here.

# Does this introduce a breaking change?

- [ ] Yes
- [x] No
