### PR TITLE
refactor: use starknet event wrapper in `transaction_receipt`

### DIFF
--- a/crates/core/src/client/client_api.rs
+++ b/crates/core/src/client/client_api.rs
@@ -16,7 +16,7 @@ use crate::models::balance::TokenBalances;
 use crate::models::transaction::StarknetTransactions;
 
 #[async_trait]
-pub trait KakarotEthApi: KakarotStarknetUtils {
+pub trait KakarotEthApi: KakarotStarknetApi {
     async fn block_number(&self) -> Result<U64, EthApiError>;
 
     async fn transaction_by_hash(&self, hash: H256) -> Result<EtherTransaction, EthApiError>;
@@ -81,7 +81,7 @@ pub trait KakarotEthApi: KakarotStarknetUtils {
 }
 
 #[async_trait]
-pub trait KakarotStarknetUtils: Send + Sync {
+pub trait KakarotStarknetApi: Send + Sync {
     fn kakarot_address(&self) -> FieldElement;
     fn proxy_account_class_hash(&self) -> FieldElement;
     fn starknet_provider(&self) -> &JsonRpcClient<HttpTransport>;

--- a/crates/core/src/client/mod.rs
+++ b/crates/core/src/client/mod.rs
@@ -434,11 +434,11 @@ impl KakarotEthApi for KakarotClient<JsonRpcClient<HttpTransport>> {
                     // Cannot use `map` because of the `await` call.
                     for event in events {
                         let event = StarknetEvent::new(event);
-                        let log = event.to_eth_log(self, block_hash, block_number, transaction_hash, None, None).await;
-
-                        if let Ok(log) = log {
+                        if let Ok(log) =
+                            event.to_eth_log(self, block_hash, block_number, transaction_hash, None, None).await
+                        {
                             logs.push(log);
-                        }
+                        };
                     }
 
                     TransactionReceipt {

--- a/crates/core/src/client/mod.rs
+++ b/crates/core/src/client/mod.rs
@@ -34,7 +34,7 @@ use starknet::providers::jsonrpc::{HttpTransport, JsonRpcClient};
 use starknet::providers::Provider;
 use url::Url;
 
-use self::client_api::{KakarotEthApi, KakarotStarknetUtils};
+use self::client_api::{KakarotEthApi, KakarotStarknetApi};
 use self::config::StarknetConfig;
 use self::constants::gas::{BASE_FEE_PER_GAS, MAX_PRIORITY_FEE_PER_GAS};
 use self::constants::selectors::{BALANCE_OF, COMPUTE_STARKNET_ADDRESS, EVM_CONTRACT_DEPLOYED, GET_EVM_ADDRESS};
@@ -660,7 +660,7 @@ impl KakarotEthApi for KakarotClient<JsonRpcClient<HttpTransport>> {
 }
 
 #[async_trait]
-impl KakarotStarknetUtils for KakarotClient<JsonRpcClient<HttpTransport>> {
+impl KakarotStarknetApi for KakarotClient<JsonRpcClient<HttpTransport>> {
     fn kakarot_address(&self) -> FieldElement {
         self.kakarot_address
     }

--- a/crates/core/src/client/mod.rs
+++ b/crates/core/src/client/mod.rs
@@ -17,12 +17,11 @@ use helpers::{
 // TODO: all reth_primitives::rpc types should be replaced when native reth Log is implemented
 // https://github.com/paradigmxyz/reth/issues/1396#issuecomment-1440890689
 use reth_primitives::{
-    keccak256, Address, BlockId, BlockNumberOrTag, Bloom, Bytes, Bytes as RpcBytes, TransactionSigned, H160, H256,
-    U128, U256, U64, U8,
+    keccak256, Address, BlockId, BlockNumberOrTag, Bloom, Bytes, TransactionSigned, H256, U128, U256, U64, U8,
 };
 use reth_rlp::Decodable;
 use reth_rpc_types::{
-    BlockTransactions, CallRequest, FeeHistory, Index, Log, RichBlock, SyncInfo, SyncStatus,
+    BlockTransactions, CallRequest, FeeHistory, Index, RichBlock, SyncInfo, SyncStatus,
     Transaction as EtherTransaction, TransactionReceipt,
 };
 use starknet::core::types::{
@@ -44,7 +43,8 @@ use self::errors::EthApiError;
 use crate::client::constants::selectors::ETH_CALL;
 use crate::models::balance::{TokenBalance, TokenBalances};
 use crate::models::block::{BlockWithTxHashes, BlockWithTxs};
-use crate::models::convertible::{ConvertibleStarknetBlock, ConvertibleStarknetTransaction};
+use crate::models::convertible::{ConvertibleStarknetBlock, ConvertibleStarknetEvent, ConvertibleStarknetTransaction};
+use crate::models::event::StarknetEvent;
 use crate::models::felt::Felt252Wrapper;
 use crate::models::transaction::{StarknetTransaction, StarknetTransactions};
 
@@ -435,43 +435,9 @@ impl KakarotEthApi for KakarotClient<JsonRpcClient<HttpTransport>> {
 
                     // Cannot use `map` because of the `await` call.
                     for event in events {
-                        let contract_address = self.safe_get_evm_address(&event.from_address, &starknet_block_id).await;
-
-                        // event "keys" in cairo are event "topics" in solidity
-                        // they're returned as list where consecutive values are
-                        // low, high, low, high, etc. of the Uint256 Cairo representation
-                        // of the bytes32 topics. This recomputes the original topic
-                        let topics = (0..event.keys.len())
-                            .step_by(2)
-                            .map(|i| {
-                                let next_key = *event.keys.get(i + 1).unwrap_or(&FieldElement::ZERO);
-
-                                // Can unwrap here as we know 2^128 is a valid FieldElement
-                                let two_pow_16: FieldElement =
-                                    FieldElement::from_hex_be("0x100000000000000000000000000000000").unwrap();
-
-                                // TODO: May wrap around prime field - Investigate edge cases
-                                let felt_shifted_next_key = next_key * two_pow_16;
-                                event.keys[i] + felt_shifted_next_key
-                            })
-                            .map(|topic| H256::from(&topic.to_bytes_be()))
-                            .collect::<Vec<_>>();
-
-                        let data = vec_felt_to_bytes(event.data);
-
-                        let log = Log {
-                            // TODO: fetch correct address from Kakarot.
-                            // Contract Address is the account contract's address (EOA or KakarotAA)
-                            address: H160::from_slice(&contract_address.0),
-                            topics,
-                            data: RpcBytes::from(data.0),
-                            block_hash: None,
-                            block_number: None,
-                            transaction_hash: None,
-                            transaction_index: None,
-                            log_index: None,
-                            removed: false,
-                        };
+                        let event = StarknetEvent::new(event);
+                        let log =
+                            event.to_eth_log(self, block_hash, block_number, transaction_hash, None, None).await?;
 
                         logs.push(log);
                     }

--- a/crates/core/src/mock/fixtures/responses/transactions/starknet_getTransactionReceipt.json
+++ b/crates/core/src/mock/fixtures/responses/transactions/starknet_getTransactionReceipt.json
@@ -23,7 +23,7 @@
           "0x04514f14cba800",
           "0x00"
         ],
-        "from_address": "0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+        "from_address": "0x566864dbc2ae76c2d12a8a5a334913d0806f85b7a4dccea87467c3ba3616e75",
         "keys": [
           "0x099cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9"
         ]

--- a/crates/core/src/mock/fixtures/responses/transactions/starknet_getTransactionReceipt.json
+++ b/crates/core/src/mock/fixtures/responses/transactions/starknet_getTransactionReceipt.json
@@ -23,7 +23,7 @@
           "0x04514f14cba800",
           "0x00"
         ],
-        "from_address": "0x566864dbc2ae76c2d12a8a5a334913d0806f85b7a4dccea87467c3ba3616e75",
+        "from_address": "0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
         "keys": [
           "0x099cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9"
         ]

--- a/crates/core/src/models/convertible.rs
+++ b/crates/core/src/models/convertible.rs
@@ -2,7 +2,7 @@ use async_trait::async_trait;
 use reth_primitives::{H256, U256};
 use reth_rpc_types::{Log, RichBlock, Transaction as EthTransaction};
 
-use crate::client::client_api::{KakarotEthApi, KakarotStarknetUtils};
+use crate::client::client_api::{KakarotEthApi, KakarotStarknetApi};
 use crate::client::errors::EthApiError;
 
 #[async_trait]
@@ -14,7 +14,7 @@ pub trait ConvertibleStarknetBlock {
 pub trait ConvertibleStarknetEvent {
     async fn to_eth_log(
         &self,
-        client: &dyn KakarotStarknetUtils,
+        client: &dyn KakarotStarknetApi,
         block_hash: Option<H256>,
         block_number: Option<U256>,
         transaction_hash: Option<H256>,

--- a/crates/core/src/models/event.rs
+++ b/crates/core/src/models/event.rs
@@ -7,7 +7,7 @@ use reth_rpc_types::Log;
 use starknet::core::types::Event;
 
 use super::felt::Felt252Wrapper;
-use crate::client::client_api::KakarotStarknetUtils;
+use crate::client::client_api::KakarotStarknetApi;
 use crate::client::errors::EthApiError;
 use crate::models::convertible::ConvertibleStarknetEvent;
 
@@ -23,7 +23,7 @@ impl StarknetEvent {
 impl ConvertibleStarknetEvent for StarknetEvent {
     async fn to_eth_log(
         &self,
-        client: &dyn KakarotStarknetUtils,
+        client: &dyn KakarotStarknetApi,
         block_hash: Option<H256>,
         block_number: Option<U256>,
         transaction_hash: Option<H256>,

--- a/crates/core/src/models/event.rs
+++ b/crates/core/src/models/event.rs
@@ -37,7 +37,7 @@ impl ConvertibleStarknetEvent for StarknetEvent {
 
         // Derive the evm address from the last item in the `event.keys` vector and remove it
         let (evm_contract_address, keys) = self.0.keys.split_last().ok_or_else(|| {
-            EthApiError::OtherError(anyhow::anyhow!("Kakarot Filter: Event is not an Kakarot evm event"))
+            EthApiError::OtherError(anyhow::anyhow!("Kakarot Filter: Event is not a Kakarot evm event"))
         })?;
 
         let address: Address = {

--- a/crates/core/tests/client.rs
+++ b/crates/core/tests/client.rs
@@ -3,7 +3,7 @@ mod tests {
 
     use std::str::FromStr;
 
-    use kakarot_rpc_core::client::client_api::{KakarotEthApi, KakarotStarknetUtils};
+    use kakarot_rpc_core::client::client_api::{KakarotEthApi, KakarotStarknetApi};
     use kakarot_rpc_core::mock::wiremock_utils::setup_mock_client_crate;
     use kakarot_rpc_core::models::block::BlockWithTxs;
     use kakarot_rpc_core::models::convertible::{ConvertibleStarknetBlock, ConvertibleStarknetEvent};


### PR DESCRIPTION
Use starknet event wrapper in `transaction_receipt`

# Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Testing
- [ ] Other (please describe):

# What is the current behavior?

We are not leveraging the Starknet Wrapper and the `to_eth_log` method implemented in #174 
 
Resolves: #215 

# What is the new behavior?

- We use the wrapper type for native Starknet event
- We use the `to_eth_log` method
- We filter out non-kakarot events from the log
- ~~Updated mock response file to use correct Kakarot_address, so that the tests don't panic with errors defined [here](https://github.com/kkrt-labs/kakarot-rpc/blob/fd9fbf24da43fdd3dd5fff059dabe0b204758b59/crates/core/src/models/event.rs#L34).~~ { as discovered after review from @jobez , that the file can be left as it is, and will act as a test that we are filtering out Starknet events in the RPC call. }

# Does this introduce a breaking change?

- [ ] Yes
- [x] No