### PR TITLE
maintain `unwrap_or` for `block_number` in `get_code`

### DIFF
--- a/crates/eth-rpc/src/eth_rpc.rs
+++ b/crates/eth-rpc/src/eth_rpc.rs
@@ -157,7 +157,8 @@ impl EthApiServer for KakarotEthRpc {
     }
 
     async fn get_code(&self, address: Address, block_number: Option<BlockId>) -> Result<Bytes> {
-        let starknet_block_id = ethers_block_id_to_starknet_block_id(block_number.unwrap())?;
+        let starknet_block_id =
+            ethers_block_id_to_starknet_block_id(block_number.unwrap_or(BlockId::Number(BlockNumberOrTag::Latest)))?;
 
         let code = self.kakarot_client.get_code(address, starknet_block_id).await?;
         Ok(code)
@@ -237,8 +238,8 @@ impl EthApiServer for KakarotEthRpc {
         todo!()
     }
 
-    async fn send_raw_transaction(&self, _bytes: Bytes) -> Result<H256> {
-        let transaction_hash = self.kakarot_client.send_transaction(_bytes).await?;
+    async fn send_raw_transaction(&self, bytes: Bytes) -> Result<H256> {
+        let transaction_hash = self.kakarot_client.send_transaction(bytes).await?;
         Ok(transaction_hash)
     }
 


### PR DESCRIPTION


# Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- ✅  Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Testing
- [ ] Other (please describe):

# What is the current behavior?

When passing `Option::None` for `block_id` in `get_code`, we get a panic. 

Resolves: #<Issue number>

# What is the new behavior?

In other places, there is an `unwrap_or` usage and we use that in this method as well.

# Does this introduce a breaking change?

- [ ] Yes
- ✔️  No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

# Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->
