### PR TITLE
refactor: refactor `submit_starknet_transaction` our from `KakarotEthApi` to `KakarotStarknetApi`

### DIFF
--- a/crates/core/src/client/api.rs
+++ b/crates/core/src/client/api.rs
@@ -44,11 +44,6 @@ pub trait KakarotEthApi<T: JsonRpcTransport>: KakarotStarknetApi<T> {
 
     async fn block_transaction_count_by_hash(&self, hash: H256) -> Result<U64, EthApiError<T::Error>>;
 
-    async fn submit_starknet_transaction(
-        &self,
-        request: BroadcastedInvokeTransactionV1,
-    ) -> Result<H256, EthApiError<T::Error>>;
-
     async fn transaction_receipt(&self, hash: H256) -> Result<Option<TransactionReceipt>, EthApiError<T::Error>>;
 
     async fn nonce(
@@ -101,6 +96,11 @@ pub trait KakarotStarknetApi<T: JsonRpcTransport>: Send + Sync {
     fn proxy_account_class_hash(&self) -> FieldElement;
 
     fn starknet_provider(&self) -> &JsonRpcClient<T>;
+
+    async fn submit_starknet_transaction(
+        &self,
+        request: BroadcastedInvokeTransactionV1,
+    ) -> Result<H256, EthApiError<T::Error>>;
 
     async fn compute_starknet_address(
         &self,

--- a/crates/core/src/client/api.rs
+++ b/crates/core/src/client/api.rs
@@ -22,19 +22,19 @@ pub trait KakarotEthApi<T: JsonRpcTransport>: KakarotStarknetApi<T> {
     async fn get_code(
         &self,
         ethereum_address: Address,
-        starknet_block_id: StarknetBlockId,
+        starknet_block_id: BlockId,
     ) -> Result<Bytes, EthApiError<T::Error>>;
 
     async fn call_view(
         &self,
         ethereum_address: Address,
         calldata: Bytes,
-        starknet_block_id: StarknetBlockId,
+        starknet_block_id: BlockId,
     ) -> Result<Bytes, EthApiError<T::Error>>;
 
     async fn transaction_by_block_id_and_index(
         &self,
-        block_id: StarknetBlockId,
+        block_id: BlockId,
         tx_index: Index,
     ) -> Result<EtherTransaction, EthApiError<T::Error>>;
 
@@ -46,17 +46,9 @@ pub trait KakarotEthApi<T: JsonRpcTransport>: KakarotStarknetApi<T> {
 
     async fn transaction_receipt(&self, hash: H256) -> Result<Option<TransactionReceipt>, EthApiError<T::Error>>;
 
-    async fn nonce(
-        &self,
-        ethereum_address: Address,
-        starknet_block_id: StarknetBlockId,
-    ) -> Result<U256, EthApiError<T::Error>>;
+    async fn nonce(&self, ethereum_address: Address, block_id: BlockId) -> Result<U256, EthApiError<T::Error>>;
 
-    async fn balance(
-        &self,
-        ethereum_address: Address,
-        starknet_block_id: StarknetBlockId,
-    ) -> Result<U256, EthApiError<T::Error>>;
+    async fn balance(&self, ethereum_address: Address, block_id: BlockId) -> Result<U256, EthApiError<T::Error>>;
 
     async fn token_balances(
         &self,
@@ -66,10 +58,7 @@ pub trait KakarotEthApi<T: JsonRpcTransport>: KakarotStarknetApi<T> {
 
     async fn send_transaction(&self, bytes: Bytes) -> Result<H256, EthApiError<T::Error>>;
 
-    async fn get_transaction_count_by_block(
-        &self,
-        starknet_block_id: StarknetBlockId,
-    ) -> Result<U64, EthApiError<T::Error>>;
+    async fn get_transaction_count_by_block(&self, starknet_block_id: BlockId) -> Result<U64, EthApiError<T::Error>>;
 
     fn base_fee_per_gas(&self) -> U256;
 

--- a/crates/core/src/client/mod.rs
+++ b/crates/core/src/client/mod.rs
@@ -271,17 +271,6 @@ impl<T: JsonRpcTransport + Send + Sync> KakarotEthApi<T> for KakarotClient<JsonR
         Ok(eth_transaction)
     }
 
-    /// Submits a Kakarot transaction to the Starknet provider.
-    async fn submit_starknet_transaction(
-        &self,
-        request: BroadcastedInvokeTransactionV1,
-    ) -> Result<H256, EthApiError<T::Error>> {
-        let transaction_result =
-            self.starknet_provider.add_invoke_transaction(&BroadcastedInvokeTransaction::V1(request)).await?;
-
-        Ok(H256::from(transaction_result.transaction_hash.to_bytes_be()))
-    }
-
     /// Returns the receipt of a transaction by transaction hash.
     async fn transaction_receipt(&self, hash: H256) -> Result<Option<TransactionReceipt>, EthApiError<T::Error>> {
         // TODO: Error when trying to transform 32 bytes hash to FieldElement
@@ -592,6 +581,17 @@ impl<T: JsonRpcTransport + Send + Sync> KakarotStarknetApi<T> for KakarotClient<
         let evm_address: [u8; 20] = slice.try_into().unwrap(); // safe unwrap as slice is of size 20
 
         Ok(Address::from(evm_address))
+    }
+
+    /// Submits a Kakarot transaction to the Starknet provider.
+    async fn submit_starknet_transaction(
+        &self,
+        request: BroadcastedInvokeTransactionV1,
+    ) -> Result<H256, EthApiError<T::Error>> {
+        let transaction_result =
+            self.starknet_provider.add_invoke_transaction(&BroadcastedInvokeTransaction::V1(request)).await?;
+
+        Ok(H256::from(transaction_result.transaction_hash.to_bytes_be()))
     }
 
     /// Returns the EVM address associated with a given Starknet address for a given block id

--- a/crates/core/src/client/mod.rs
+++ b/crates/core/src/client/mod.rs
@@ -77,11 +77,9 @@ impl<T: JsonRpcTransport + Send + Sync> KakarotEthApi<T> for KakarotClient<JsonR
     }
 
     /// Returns the bytecode of a contract given its address and a block id.
-    async fn get_code(
-        &self,
-        ethereum_address: Address,
-        starknet_block_id: StarknetBlockId,
-    ) -> Result<Bytes, EthApiError<T::Error>> {
+    async fn get_code(&self, ethereum_address: Address, block_id: BlockId) -> Result<Bytes, EthApiError<T::Error>> {
+        let starknet_block_id = EthBlockId::new(block_id).to_starknet_block_id::<T>()?;
+
         // Convert the hex-encoded string to a FieldElement
         let ethereum_address: Felt252Wrapper = ethereum_address.into();
         let ethereum_address = ethereum_address.into();
@@ -129,8 +127,10 @@ impl<T: JsonRpcTransport + Send + Sync> KakarotEthApi<T> for KakarotClient<JsonR
         &self,
         ethereum_address: Address,
         calldata: Bytes,
-        starknet_block_id: StarknetBlockId,
+        block_id: BlockId,
     ) -> Result<Bytes, EthApiError<T::Error>> {
+        let starknet_block_id = EthBlockId::new(block_id).to_starknet_block_id::<T>()?;
+
         let ethereum_address: Felt252Wrapper = ethereum_address.into();
         let ethereum_address = ethereum_address.into();
 
@@ -190,21 +190,19 @@ impl<T: JsonRpcTransport + Send + Sync> KakarotEthApi<T> for KakarotClient<JsonR
 
     /// Get the number of transactions in a block given a block number.
     async fn block_transaction_count_by_number(&self, number: BlockNumberOrTag) -> Result<U64, EthApiError<T::Error>> {
-        let starknet_block_id = EthBlockId::new(BlockId::Number(number)).to_starknet_block_id::<T>()?;
-        self.get_transaction_count_by_block(starknet_block_id).await
+        let block_id = BlockId::Number(number);
+        self.get_transaction_count_by_block(block_id).await
     }
 
     /// Get the number of transactions in a block given a block hash.
     async fn block_transaction_count_by_hash(&self, hash: H256) -> Result<U64, EthApiError<T::Error>> {
-        let starknet_block_id = EthBlockId::new(BlockId::Hash(hash.into())).to_starknet_block_id::<T>()?;
-        self.get_transaction_count_by_block(starknet_block_id).await
+        let block_id = BlockId::Hash(hash.into());
+        self.get_transaction_count_by_block(block_id).await
     }
 
     /// Returns the number of transactions in a block given a block id.
-    async fn get_transaction_count_by_block(
-        &self,
-        starknet_block_id: StarknetBlockId,
-    ) -> Result<U64, EthApiError<T::Error>> {
+    async fn get_transaction_count_by_block(&self, block_id: BlockId) -> Result<U64, EthApiError<T::Error>> {
+        let starknet_block_id = EthBlockId::new(block_id).to_starknet_block_id::<T>()?;
         let starknet_block = self.starknet_provider.get_block_with_txs(starknet_block_id).await?;
 
         let block_transactions = match starknet_block {
@@ -230,13 +228,14 @@ impl<T: JsonRpcTransport + Send + Sync> KakarotEthApi<T> for KakarotClient<JsonR
     /// Returns the transaction for a given block id and transaction index.
     async fn transaction_by_block_id_and_index(
         &self,
-        block_id: StarknetBlockId,
+        block_id: BlockId,
         tx_index: Index,
     ) -> Result<EtherTransaction, EthApiError<T::Error>> {
         let index: u64 = usize::from(tx_index) as u64;
+        let starknet_block_id = EthBlockId::new(block_id).to_starknet_block_id::<T>()?;
 
         let starknet_tx: StarknetTransaction =
-            self.starknet_provider.get_transaction_by_block_id_and_index(block_id, index).await?.into();
+            self.starknet_provider.get_transaction_by_block_id_and_index(starknet_block_id, index).await?.into();
 
         let tx_hash: FieldElement = starknet_tx.transaction_hash()?.into();
 
@@ -373,21 +372,19 @@ impl<T: JsonRpcTransport + Send + Sync> KakarotEthApi<T> for KakarotClient<JsonR
     }
 
     /// Returns the nonce for a given ethereum address
-    async fn nonce(&self, ethereum_address: Address, block_id: StarknetBlockId) -> Result<U256, EthApiError<T::Error>> {
-        let starknet_address = self.compute_starknet_address(ethereum_address, &block_id).await?;
+    async fn nonce(&self, ethereum_address: Address, block_id: BlockId) -> Result<U256, EthApiError<T::Error>> {
+        let starknet_block_id = EthBlockId::new(block_id).to_starknet_block_id::<T>()?;
+        let starknet_address = self.compute_starknet_address(ethereum_address, &starknet_block_id).await?;
 
-        let nonce: Felt252Wrapper = self.starknet_provider.get_nonce(block_id, starknet_address).await?.into();
+        let nonce: Felt252Wrapper = self.starknet_provider.get_nonce(starknet_block_id, starknet_address).await?.into();
 
         Ok(nonce.into())
     }
 
     /// Returns the balance in Starknet's native token of a specific EVM address.
-    async fn balance(
-        &self,
-        ethereum_address: Address,
-        block_id: StarknetBlockId,
-    ) -> Result<U256, EthApiError<T::Error>> {
-        let starknet_address = self.compute_starknet_address(ethereum_address, &block_id).await?;
+    async fn balance(&self, ethereum_address: Address, block_id: BlockId) -> Result<U256, EthApiError<T::Error>> {
+        let starknet_block_id = EthBlockId::new(block_id).to_starknet_block_id::<T>()?;
+        let starknet_address = self.compute_starknet_address(ethereum_address, &starknet_block_id).await?;
 
         let request = FunctionCall {
             // This FieldElement::from_hex_be cannot fail as the value is a constant
@@ -396,7 +393,7 @@ impl<T: JsonRpcTransport + Send + Sync> KakarotEthApi<T> for KakarotClient<JsonR
             calldata: vec![starknet_address],
         };
 
-        let balance = self.starknet_provider.call(request, block_id).await?;
+        let balance = self.starknet_provider.call(request, starknet_block_id).await?;
 
         let balance = balance
             .first()
@@ -430,7 +427,7 @@ impl<T: JsonRpcTransport + Send + Sync> KakarotEthApi<T> for KakarotClient<JsonR
             self.call_view(
                 token_address,
                 Bytes::from(vec_felt_to_bytes(calldata).0),
-                StarknetBlockId::Tag(BlockTag::Latest),
+                BlockId::from(BlockNumberOrTag::Latest),
             )
         });
         let token_balances = join_all(handles)

--- a/crates/core/src/client/tests/mod.rs
+++ b/crates/core/src/client/tests/mod.rs
@@ -1,6 +1,5 @@
 use dojo_test_utils::rpc::MockJsonRpcTransport;
-use reth_primitives::{U256, U64};
-use starknet::core::types::{BlockId, BlockTag};
+use reth_primitives::{BlockId, BlockNumberOrTag, U256, U64};
 use starknet::providers::jsonrpc::JsonRpcMethod;
 use starknet::providers::JsonRpcClient;
 
@@ -37,7 +36,7 @@ async fn test_nonce() {
     let client = init_client(Some(fixtures));
 
     // When
-    let nonce = client.nonce(*ABDEL_ADDRESS, BlockId::Tag(BlockTag::Latest)).await.unwrap();
+    let nonce = client.nonce(*ABDEL_ADDRESS, BlockId::from(BlockNumberOrTag::Latest)).await.unwrap();
 
     // Then
     assert_eq!(U256::from(1), nonce);

--- a/crates/eth-rpc/src/eth_rpc.rs
+++ b/crates/eth-rpc/src/eth_rpc.rs
@@ -13,7 +13,6 @@ use reth_rpc_types::{
     Transaction as EtherTransaction, TransactionReceipt, TransactionRequest, Work,
 };
 use serde_json::Value;
-use starknet::core::types::BlockId as StarknetBlockId;
 use starknet::providers::jsonrpc::JsonRpcTransport;
 
 use crate::eth_api::EthApiServer;
@@ -110,9 +109,8 @@ impl<T: JsonRpcTransport + 'static> EthApiServer for KakarotEthRpc<T> {
     }
 
     async fn transaction_by_block_hash_and_index(&self, hash: H256, index: Index) -> Result<Option<EtherTransaction>> {
-        let block_id = EthBlockId::new(BlockId::Hash(hash.into()));
-        let starknet_block_id = block_id.to_starknet_block_id::<T>()?;
-        let tx = self.kakarot_client.transaction_by_block_id_and_index(starknet_block_id, index).await?;
+        let block_id = BlockId::Hash(hash.into());
+        let tx = self.kakarot_client.transaction_by_block_id_and_index(block_id, index).await?;
         Ok(Some(tx))
     }
 
@@ -121,9 +119,8 @@ impl<T: JsonRpcTransport + 'static> EthApiServer for KakarotEthRpc<T> {
         number: BlockNumberOrTag,
         index: Index,
     ) -> Result<Option<EtherTransaction>> {
-        let block_id = EthBlockId::new(BlockId::Number(number));
-        let starknet_block_id = block_id.to_starknet_block_id::<T>()?;
-        let tx = self.kakarot_client.transaction_by_block_id_and_index(starknet_block_id, index).await?;
+        let block_id = BlockId::Number(number);
+        let tx = self.kakarot_client.transaction_by_block_id_and_index(block_id, index).await?;
         Ok(Some(tx))
     }
 
@@ -133,9 +130,8 @@ impl<T: JsonRpcTransport + 'static> EthApiServer for KakarotEthRpc<T> {
     }
 
     async fn balance(&self, address: Address, block_number: Option<BlockId>) -> Result<U256> {
-        let block_id = EthBlockId::new(block_number.unwrap_or(BlockId::Number(BlockNumberOrTag::Latest)));
-        let starknet_block_id = block_id.to_starknet_block_id::<T>()?;
-        let balance = self.kakarot_client.balance(address, starknet_block_id).await?;
+        let block_id = block_number.unwrap_or(BlockId::Number(BlockNumberOrTag::Latest));
+        let balance = self.kakarot_client.balance(address, block_id).await?;
         Ok(balance)
     }
 
@@ -144,18 +140,16 @@ impl<T: JsonRpcTransport + 'static> EthApiServer for KakarotEthRpc<T> {
     }
 
     async fn transaction_count(&self, address: Address, block_id: Option<BlockId>) -> Result<U256> {
-        let block_id = EthBlockId::new(block_id.unwrap_or(BlockId::Number(BlockNumberOrTag::Latest)));
-        let starknet_block_id = block_id.to_starknet_block_id::<T>()?;
+        let block_id = block_id.unwrap_or(BlockId::Number(BlockNumberOrTag::Latest));
 
-        let transaction_count = self.kakarot_client.nonce(address, starknet_block_id).await?;
+        let transaction_count = self.kakarot_client.nonce(address, block_id).await?;
 
         Ok(transaction_count)
     }
 
     async fn get_code(&self, address: Address, block_number: Option<BlockId>) -> Result<Bytes> {
-        let block_id = EthBlockId::new(block_number.unwrap_or(BlockId::Number(BlockNumberOrTag::Latest)));
-        let starknet_block_id = block_id.to_starknet_block_id::<T>()?;
-        let code = self.kakarot_client.get_code(address, starknet_block_id).await?;
+        let block_id = block_number.unwrap_or(BlockId::Number(BlockNumberOrTag::Latest));
+        let code = self.kakarot_client.get_code(address, block_id).await?;
         Ok(code)
     }
 
@@ -169,9 +163,8 @@ impl<T: JsonRpcTransport + 'static> EthApiServer for KakarotEthRpc<T> {
             rpc_err(INTERNAL_ERROR_CODE, "CallRequest `data` field is None. Cannot process a Kakarot call")
         })?;
 
-        let block_id = EthBlockId::new(block_number.unwrap_or(BlockId::Number(BlockNumberOrTag::Latest)));
-        let starknet_block_id: StarknetBlockId = block_id.to_starknet_block_id::<T>()?;
-        let result = self.kakarot_client.call_view(to, Bytes::from(calldata.0), starknet_block_id).await?;
+        let block_id = block_number.unwrap_or(BlockId::Number(BlockNumberOrTag::Latest));
+        let result = self.kakarot_client.call_view(to, Bytes::from(calldata.0), block_id).await?;
 
         Ok(result)
     }


### PR DESCRIPTION
`submit_starknet_transaction` method was part of the `KakarotEthApi` trait, but it is better suited to `KakarotStarknetApi` trait, this PR does this refactor.

It also refactors the `KakarotEthApi` trait so that its methods use Reth types as parameter types wherever required to make it consistent with `EthApi` trait.

# Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Testing
- [ ] Other (please describe):

# What is the current behavior?

- `submit_starknet_transaction` method is part of the `KakarotEthApi`. 
- `KakarotEthApi` has methods whose parameters aren't of `Reth` types, creating inconsistency with the `EthApi` trait's method signatures.

Resolves: #233 , #237 

# What is the new behavior?

- `submit_starknet_transaction` method is part of the `KakarotStarknetApi` 
- `KakarotEthApi` has been refactored for methods to use `Reth` types wherever possible.

# Does this introduce a breaking change?

- [ ] Yes
- [x] No