### PR TITLE
fix: refactor errors

### DIFF
--- a/crates/core/src/client/api.rs
+++ b/crates/core/src/client/api.rs
@@ -115,7 +115,7 @@ pub trait KakarotStarknetApi<T: JsonRpcTransport>: Send + Sync {
         initial_transactions: StarknetTransactions,
         blockhash_opt: Option<H256>,
         blocknum_opt: Option<U256>,
-    ) -> Result<BlockTransactions, EthApiError<T::Error>>;
+    ) -> BlockTransactions;
 
     async fn get_eth_block_from_starknet_block(
         &self,

--- a/crates/core/src/client/errors.rs
+++ b/crates/core/src/client/errors.rs
@@ -45,9 +45,12 @@ pub enum EthApiError<T: std::error::Error> {
     /// Data decoding into ETH types failed.
     #[error(transparent)]
     DataDecodingError(#[from] DataDecodingError),
+    /// Data not part of Kakarot.
+    #[error("{0} not from Kakarot")]
+    KakarotDataFilteringError(String),
     /// Other error.
     #[error(transparent)]
-    OtherError(#[from] anyhow::Error),
+    Other(#[from] anyhow::Error),
 }
 
 impl<T: std::error::Error> From<EthApiError<T>> for ErrorObject<'static> {
@@ -83,7 +86,8 @@ impl<T: std::error::Error> From<EthApiError<T>> for ErrorObject<'static> {
             },
             EthApiError::ConversionError(err) => rpc_err(INTERNAL_ERROR_CODE, err.to_string()),
             EthApiError::DataDecodingError(err) => rpc_err(INTERNAL_ERROR_CODE, err.to_string()),
-            EthApiError::OtherError(err) => rpc_err(INTERNAL_ERROR_CODE, err.to_string()),
+            EthApiError::KakarotDataFilteringError(err) => rpc_err(INTERNAL_ERROR_CODE, err),
+            EthApiError::Other(err) => rpc_err(INTERNAL_ERROR_CODE, err.to_string()),
         }
     }
 }

--- a/crates/core/src/client/helpers.rs
+++ b/crates/core/src/client/helpers.rs
@@ -11,6 +11,7 @@ use thiserror::Error;
 use super::constants::{CUMULATIVE_GAS_USED, EFFECTIVE_GAS_PRICE, GAS_USED, TRANSACTION_TYPE};
 use crate::client::constants::selectors::ETH_SEND_TRANSACTION;
 use crate::client::errors::EthApiError;
+use crate::models::ConversionError;
 
 #[derive(Debug, Error)]
 pub enum DataDecodingError {
@@ -68,34 +69,38 @@ impl TryFrom<Vec<FieldElement>> for Calls {
     }
 }
 
-/// Returns the decoded return value of the `eth_call` entrypoint of Kakarot
+/// Returns the decoded return value of the `eth_call` and `eth_send_transaction` entrypoint of
+/// Kakarot
 pub fn decode_eth_call_return<T: std::error::Error>(
     call_result: &[FieldElement],
 ) -> Result<Vec<FeltOrFeltArray>, EthApiError<T>> {
-    // Parse and decode Kakarot's call return data (temporary solution and not scalable - will
+    // Parse and decode Kakarot's return data (temporary solution and not scalable - will
     // fail is Kakarot API changes)
-    // Declare Vec of Result
-    let mut segmented_result: Vec<FeltOrFeltArray> = Vec::new();
-    let mut tmp_array_len: FieldElement = *call_result
-        .first()
-        .ok_or_else(|| DataDecodingError::InvalidReturnArrayLength("stack accesses length".into()))?;
-    let mut tmp_counter = 1_usize;
-    segmented_result.push(FeltOrFeltArray::FeltArray(Vec::new()));
-    // Parse first array: stack_accesses
-    while tmp_array_len != FieldElement::ZERO {
+
+    let mut return_data: Vec<FeltOrFeltArray> = vec![FeltOrFeltArray::FeltArray(vec![])];
+
+    let return_data_len =
+        *call_result.first().ok_or_else(|| DataDecodingError::InvalidReturnArrayLength("call result length".into()))?;
+
+    let mut return_data_len: u64 =
+        return_data_len.try_into().map_err(|e: ValueOutOfRangeError| ConversionError::Other(e.to_string()))?;
+    let mut counter = 1_usize;
+
+    // Parse call result array
+    while return_data_len != 0 {
         let element = call_result
-            .get(tmp_counter)
-            .ok_or_else(|| DataDecodingError::InvalidReturnArrayLength("stack accesses".into()))?;
-        match segmented_result.last_mut() {
+            .get(counter)
+            .ok_or_else(|| DataDecodingError::InvalidReturnArrayLength("call result".into()))?;
+        match return_data.last_mut() {
             Some(FeltOrFeltArray::FeltArray(felt_array)) => felt_array.push(*element),
             Some(FeltOrFeltArray::Felt(_felt)) => (),
             _ => (),
         }
-        tmp_counter += 1;
-        tmp_array_len -= FieldElement::from(1_u64);
+        counter += 1;
+        return_data_len -= 0;
     }
 
-    Ok(segmented_result)
+    Ok(return_data)
 }
 
 pub fn decode_signature_and_to_address_from_tx_calldata(

--- a/crates/core/src/client/mod.rs
+++ b/crates/core/src/client/mod.rs
@@ -449,11 +449,11 @@ impl<T: JsonRpcTransport + Send + Sync> KakarotEthApi<T> for KakarotClient<JsonR
         let entrypoint: Felt252Wrapper = keccak256("balanceOf(address)").try_into()?;
         let entrypoint: FieldElement = entrypoint.into();
 
-        let add: Felt252Wrapper = address.into();
-        let add: FieldElement = add.into();
+        let addr: Felt252Wrapper = address.into();
+        let addr: FieldElement = addr.into();
 
         let handles = contract_addresses.into_iter().map(|token_address| {
-            let calldata = vec![entrypoint, add];
+            let calldata = vec![entrypoint, addr];
 
             self.call_view(
                 token_address,

--- a/crates/core/src/client/mod.rs
+++ b/crates/core/src/client/mod.rs
@@ -447,7 +447,7 @@ impl<T: JsonRpcTransport + Send + Sync> KakarotEthApi<T> for KakarotClient<JsonR
             .map(|token_address| match token_address {
                 Ok(call) => {
                     let balance = U256::try_from_be_slice(call.as_ref())
-                        .ok_or(ConversionError::Other { src: "Bytes".into(), dest: "U256".into() })
+                        .ok_or(ConversionError::Other("error converting from Bytes to U256".into()))
                         .unwrap();
                     TokenBalance { contract_address: address, token_balance: Some(balance), error: None }
                 }
@@ -580,7 +580,7 @@ impl<T: JsonRpcTransport + Send + Sync> KakarotStarknetApi<T> for KakarotClient<
         // Workaround as .get(12..32) does not dynamically size the slice
         let slice: &[u8] = evm_address
             .get(12..32)
-            .ok_or_else(|| ConversionError::Other { src: "[u8;32]".into(), dest: "&[u8]".into() })?;
+            .ok_or_else(|| ConversionError::Other("error converting from [u8; 32] to &[u8]".into()))?;
 
         let evm_address: [u8; 20] = slice.try_into().unwrap(); // safe unwrap as slice is of size 20
 

--- a/crates/core/src/client/mod.rs
+++ b/crates/core/src/client/mod.rs
@@ -6,8 +6,6 @@ pub mod helpers;
 #[cfg(test)]
 pub mod tests;
 
-use std::str::FromStr;
-
 use async_trait::async_trait;
 use constants::selectors::BYTECODE;
 use eyre::Result;
@@ -36,6 +34,7 @@ use self::constants::gas::{BASE_FEE_PER_GAS, MAX_PRIORITY_FEE_PER_GAS};
 use self::constants::selectors::{BALANCE_OF, COMPUTE_STARKNET_ADDRESS, EVM_CONTRACT_DEPLOYED, GET_EVM_ADDRESS};
 use self::constants::{MAX_FEE, STARKNET_NATIVE_TOKEN};
 use self::errors::EthApiError;
+use self::helpers::DataDecodingError;
 use crate::client::constants::selectors::ETH_CALL;
 use crate::models::balance::{TokenBalance, TokenBalances};
 use crate::models::block::{BlockWithTxHashes, BlockWithTxs, EthBlockId};
@@ -43,6 +42,7 @@ use crate::models::convertible::{ConvertibleStarknetBlock, ConvertibleStarknetEv
 use crate::models::event::StarknetEvent;
 use crate::models::felt::Felt252Wrapper;
 use crate::models::transaction::{StarknetTransaction, StarknetTransactions};
+use crate::models::ConversionError;
 
 pub struct KakarotClient<T: Provider> {
     starknet_provider: T,
@@ -97,12 +97,10 @@ impl<T: JsonRpcTransport + Send + Sync> KakarotEthApi<T> for KakarotClient<JsonR
         let starknet_contract_address = self.starknet_provider.call(request, starknet_block_id).await?;
 
         // shadow the variable to FielElement from a Vec<FieldElement>, for use in subsequent code
-        let starknet_contract_address = match starknet_contract_address.get(0) {
+        let starknet_contract_address = match starknet_contract_address.first() {
             Some(x) if starknet_contract_address.len() == 1 => *x,
             _ => {
-                return Err(EthApiError::<T::Error>::OtherError(anyhow::anyhow!(
-                    "Kakarot get_code: starknet_contract_address is empty"
-                )));
+                return Err(DataDecodingError::InvalidReturnArrayLength("starknet_contract_address".into()).into());
             }
         };
 
@@ -154,19 +152,18 @@ impl<T: JsonRpcTransport + Send + Sync> KakarotEthApi<T> for KakarotClient<JsonR
         let segmented_result = decode_eth_call_return(&call_result)?;
 
         // Convert the result of the function call to a vector of bytes
-        let return_data = segmented_result.first().ok_or_else(|| {
-            EthApiError::<T::Error>::OtherError(anyhow::anyhow!(
-                "Cannot parse and decode last argument of Kakarot call",
-            ))
-        })?;
-        if let FeltOrFeltArray::FeltArray(felt_array) = return_data {
-            let result: Vec<u8> = felt_array.iter().filter_map(|f| u8::try_from(*f).ok()).collect();
-            let bytes_result = Bytes::from(result);
-            return Ok(bytes_result);
+        let return_data = segmented_result
+            .first()
+            .ok_or_else(|| DataDecodingError::InvalidReturnArrayLength("return data".into()))?;
+
+        match return_data {
+            FeltOrFeltArray::FeltArray(arr) => {
+                let result: Vec<u8> = arr.iter().filter_map(|f| u8::try_from(*f).ok()).collect();
+                let bytes_result = Bytes::from(result);
+                Ok(bytes_result)
+            }
+            _ => Err(DataDecodingError::InvalidReturnArrayLength("return data".into()).into()),
         }
-        Err(EthApiError::<T::Error>::OtherError(anyhow::anyhow!(
-            "Cannot parse and decode the return data of Kakarot call"
-        )))
     }
 
     /// Get the syncing status of the light client
@@ -217,14 +214,14 @@ impl<T: JsonRpcTransport + Send + Sync> KakarotEthApi<T> for KakarotClient<JsonR
 
         let block_transactions = match starknet_block {
             MaybePendingBlockWithTxs::PendingBlock(pending_block_with_txs) => {
-                self.filter_starknet_into_eth_txs(pending_block_with_txs.transactions.into(), None, None).await?
+                self.filter_starknet_into_eth_txs(pending_block_with_txs.transactions.into(), None, None).await
             }
             MaybePendingBlockWithTxs::Block(block_with_txs) => {
                 let block_hash: Felt252Wrapper = block_with_txs.block_hash.into();
                 let block_hash = Some(block_hash.into());
                 let block_number: Felt252Wrapper = block_with_txs.block_number.into();
                 let block_number = Some(block_number.into());
-                self.filter_starknet_into_eth_txs(block_with_txs.transactions.into(), block_hash, block_number).await?
+                self.filter_starknet_into_eth_txs(block_with_txs.transactions.into(), block_hash, block_number).await
             }
         };
         let len = match block_transactions {
@@ -330,13 +327,14 @@ impl<T: JsonRpcTransport + Send + Sync> KakarotEthApi<T> for KakarotClient<JsonR
                             let event = events
                                 .iter()
                                 .find(|event| event.keys.iter().any(|key| *key == EVM_CONTRACT_DEPLOYED))
-                                .ok_or(EthApiError::OtherError(anyhow::anyhow!(
+                                .ok_or(EthApiError::Other(anyhow::anyhow!(
                                     "Kakarot Core: No contract deployment event found in Kakarot transaction receipt"
                                 )))?;
 
-                            let evm_address = event.data.first().ok_or(EthApiError::OtherError(anyhow::anyhow!(
-                                "Kakarot Core: Failed to get EVM address from Kakarot event"
-                            )))?;
+                            let evm_address = event
+                                .data
+                                .first()
+                                .ok_or(DataDecodingError::InvalidReturnArrayLength("evm address".into()))?;
 
                             let evm_address = Felt252Wrapper::from(*evm_address);
                             Some(evm_address.try_into()?)
@@ -412,14 +410,10 @@ impl<T: JsonRpcTransport + Send + Sync> KakarotEthApi<T> for KakarotClient<JsonR
             calldata: vec![starknet_address],
         };
 
-        let balance_felt = self.starknet_provider.call(request, block_id).await?;
+        let balance = self.starknet_provider.call(request, block_id).await?;
 
-        let balance = balance_felt
-            .first()
-            .ok_or_else(|| {
-                EthApiError::<T::Error>::OtherError(anyhow::anyhow!("Kakarot Core: Failed to get native token balance"))
-            })?
-            .to_bytes_be();
+        let balance =
+            balance.first().ok_or_else(|| DataDecodingError::InvalidReturnArrayLength("balance".into()))?.to_bytes_be();
 
         let balance = U256::from_be_bytes(balance);
 
@@ -434,11 +428,12 @@ impl<T: JsonRpcTransport + Send + Sync> KakarotEthApi<T> for KakarotClient<JsonR
     ) -> Result<TokenBalances, EthApiError<T::Error>> {
         let entrypoint: Felt252Wrapper = keccak256("balanceOf(address)").try_into()?;
         let entrypoint: FieldElement = entrypoint.into();
-        let felt_address = FieldElement::from_str(&address.to_string()).map_err(|e| {
-            EthApiError::<T::Error>::OtherError(anyhow::anyhow!("Failed to convert address to FieldElement: {}", e))
-        })?;
+
+        let add: Felt252Wrapper = address.into();
+        let add: FieldElement = add.into();
+
         let handles = contract_addresses.into_iter().map(|token_address| {
-            let calldata = vec![entrypoint, felt_address];
+            let calldata = vec![entrypoint, add];
 
             self.call_view(
                 token_address,
@@ -451,15 +446,10 @@ impl<T: JsonRpcTransport + Send + Sync> KakarotEthApi<T> for KakarotClient<JsonR
             .into_iter()
             .map(|token_address| match token_address {
                 Ok(call) => {
-                    let hex_balance = U256::from_str_radix(&call.to_string(), 16)
-                        .map_err(|e| {
-                            EthApiError::<T::Error>::OtherError(anyhow::anyhow!(
-                                "Failed to convert token balance to U256: {}",
-                                e
-                            ))
-                        })
+                    let balance = U256::try_from_be_slice(call.as_ref())
+                        .ok_or(ConversionError::Other { src: "Bytes".into(), dest: "U256".into() })
                         .unwrap();
-                    TokenBalance { contract_address: address, token_balance: Some(hex_balance), error: None }
+                    TokenBalance { contract_address: address, token_balance: Some(balance), error: None }
                 }
                 Err(e) => TokenBalance {
                     contract_address: address,
@@ -476,20 +466,10 @@ impl<T: JsonRpcTransport + Send + Sync> KakarotEthApi<T> for KakarotClient<JsonR
     async fn send_transaction(&self, bytes: Bytes) -> Result<H256, EthApiError<T::Error>> {
         let mut data = bytes.as_ref();
 
-        if data.is_empty() {
-            return Err(EthApiError::<T::Error>::OtherError(anyhow::anyhow!(
-                "Kakarot send_transaction: Transaction bytes are empty"
-            )));
-        };
-
-        let transaction = TransactionSigned::decode(&mut data).map_err(|_| {
-            EthApiError::<T::Error>::OtherError(anyhow::anyhow!(
-                "Kakarot send_transaction: transaction bytes failed to be decoded"
-            ))
-        })?;
+        let transaction = TransactionSigned::decode(&mut data).map_err(DataDecodingError::TransactionDecodingError)?;
 
         let evm_address = transaction.recover_signer().ok_or_else(|| {
-            EthApiError::<T::Error>::OtherError(anyhow::anyhow!("Kakarot send_transaction: signature ecrecover failed"))
+            EthApiError::Other(anyhow::anyhow!("Kakarot send_transaction: signature ecrecover failed"))
         })?;
 
         let starknet_block_id = StarknetBlockId::Tag(BlockTag::Latest);
@@ -591,27 +571,20 @@ impl<T: JsonRpcTransport + Send + Sync> KakarotStarknetApi<T> for KakarotClient<
             calldata: vec![],
         };
 
-        let evm_address_felt = self.starknet_provider.call(request, starknet_block_id).await?;
-        let evm_address = evm_address_felt
+        let evm_address = self.starknet_provider.call(request, starknet_block_id).await?;
+        let evm_address = evm_address
             .first()
-            .ok_or_else(|| {
-                EthApiError::OtherError(anyhow::anyhow!(
-                    "Kakarot Core: Failed to get EVM address from smart contract on Kakarot"
-                ))
-            })?
+            .ok_or_else(|| DataDecodingError::InvalidReturnArrayLength("evm address".into()))?
             .to_bytes_be();
 
         // Workaround as .get(12..32) does not dynamically size the slice
-        let slice: &[u8] = evm_address.get(12..32).ok_or_else(|| {
-            EthApiError::OtherError(anyhow::anyhow!(
-                "Kakarot Core: Failed to cast EVM address from 32 bytes to 20 bytes EVM format"
-            ))
-        })?;
-        let mut tmp_slice = [0u8; 20];
-        tmp_slice.copy_from_slice(slice);
-        let evm_address_sliced = &tmp_slice;
+        let slice: &[u8] = evm_address
+            .get(12..32)
+            .ok_or_else(|| ConversionError::Other { src: "[u8;32]".into(), dest: "&[u8]".into() })?;
 
-        Ok(Address::from(evm_address_sliced))
+        let evm_address: [u8; 20] = slice.try_into().unwrap(); // safe unwrap as slice is of size 20
+
+        Ok(Address::from(evm_address))
     }
 
     /// Returns the EVM address associated with a given Starknet address for a given block id
@@ -632,9 +605,9 @@ impl<T: JsonRpcTransport + Send + Sync> KakarotStarknetApi<T> for KakarotClient<
 
         let starknet_contract_address = self.starknet_provider.call(request, starknet_block_id).await?;
 
-        let result = starknet_contract_address.first().ok_or_else(|| {
-            EthApiError::OtherError(anyhow::anyhow!("Kakarot Core: Failed to get Starknet address from Kakarot"))
-        })?;
+        let result = starknet_contract_address
+            .first()
+            .ok_or_else(|| DataDecodingError::InvalidReturnArrayLength("starknet contract address".into()))?;
 
         Ok(*result)
     }
@@ -646,13 +619,13 @@ impl<T: JsonRpcTransport + Send + Sync> KakarotStarknetApi<T> for KakarotClient<
         initial_transactions: StarknetTransactions,
         block_hash: Option<H256>,
         block_number: Option<U256>,
-    ) -> Result<BlockTransactions, EthApiError<T::Error>> {
+    ) -> BlockTransactions {
         let handles = Into::<Vec<TransactionType>>::into(initial_transactions).into_iter().map(|tx| async move {
             let tx = Into::<StarknetTransaction>::into(tx);
             tx.to_eth_transaction(self, block_hash, block_number, None).await
         });
         let transactions_vec = join_all(handles).await.into_iter().filter_map(|transaction| transaction.ok()).collect();
-        Ok(BlockTransactions::Full(transactions_vec))
+        BlockTransactions::Full(transactions_vec)
     }
 
     /// Get the Kakarot eth block provided a Starknet block id.
@@ -664,11 +637,11 @@ impl<T: JsonRpcTransport + Send + Sync> KakarotStarknetApi<T> for KakarotClient<
         if hydrated_tx {
             let block = self.starknet_provider.get_block_with_txs(block_id).await?;
             let starknet_block = BlockWithTxs::new(block);
-            starknet_block.to_eth_block(self).await
+            Ok(starknet_block.to_eth_block(self).await)
         } else {
             let block = self.starknet_provider.get_block_with_tx_hashes(block_id).await?;
             let starknet_block = BlockWithTxHashes::new(block);
-            starknet_block.to_eth_block(self).await
+            Ok(starknet_block.to_eth_block(self).await)
         }
     }
 }

--- a/crates/core/src/models/block.rs
+++ b/crates/core/src/models/block.rs
@@ -13,6 +13,7 @@ use crate::client::api::KakarotEthApi;
 use crate::client::constants::{
     DIFFICULTY, EARLIEST_BLOCK_NUMBER, GAS_LIMIT, GAS_USED, MIX_HASH, NONCE, SIZE, TOTAL_DIFFICULTY,
 };
+use crate::client::errors::EthApiError;
 
 pub struct EthBlockId(EthereumBlockId);
 

--- a/crates/core/src/models/block.rs
+++ b/crates/core/src/models/block.rs
@@ -13,7 +13,6 @@ use crate::client::api::KakarotEthApi;
 use crate::client::constants::{
     DIFFICULTY, EARLIEST_BLOCK_NUMBER, GAS_LIMIT, GAS_USED, MIX_HASH, NONCE, SIZE, TOTAL_DIFFICULTY,
 };
-use crate::client::errors::EthApiError;
 
 pub struct EthBlockId(EthereumBlockId);
 
@@ -122,10 +121,7 @@ impl BlockWithTxs {
 
 #[async_trait]
 impl ConvertibleStarknetBlock for BlockWithTxHashes {
-    async fn to_eth_block<T: JsonRpcTransport>(
-        &self,
-        client: &dyn KakarotEthApi<T>,
-    ) -> Result<RichBlock, EthApiError<T::Error>> {
+    async fn to_eth_block<T: JsonRpcTransport>(&self, client: &dyn KakarotEthApi<T>) -> RichBlock {
         // TODO: Fetch real data
         let gas_limit = *GAS_LIMIT;
 
@@ -195,16 +191,13 @@ impl ConvertibleStarknetBlock for BlockWithTxHashes {
             size,
             withdrawals: Some(vec![]),
         };
-        Ok(block.into())
+        block.into()
     }
 }
 
 #[async_trait]
 impl ConvertibleStarknetBlock for BlockWithTxs {
-    async fn to_eth_block<T: JsonRpcTransport>(
-        &self,
-        client: &dyn KakarotEthApi<T>,
-    ) -> Result<RichBlock, EthApiError<T::Error>> {
+    async fn to_eth_block<T: JsonRpcTransport>(&self, client: &dyn KakarotEthApi<T>) -> RichBlock {
         // TODO: Fetch real data
         let gas_limit = *GAS_LIMIT;
 
@@ -238,7 +231,7 @@ impl ConvertibleStarknetBlock for BlockWithTxs {
         let hash = self.block_hash().as_ref().map(|hash| H256::from_slice(&hash.to_bytes_be()));
         let number = self.block_number().map(U256::from);
 
-        let transactions = client.filter_starknet_into_eth_txs(self.transactions().into(), hash, number).await?;
+        let transactions = client.filter_starknet_into_eth_txs(self.transactions().into(), hash, number).await;
         let header = Header {
             // PendingBlockWithTxs doesn't have a block hash
             hash,
@@ -272,6 +265,6 @@ impl ConvertibleStarknetBlock for BlockWithTxs {
             size,
             withdrawals: Some(vec![]),
         };
-        Ok(block.into())
+        block.into()
     }
 }

--- a/crates/core/src/models/convertible.rs
+++ b/crates/core/src/models/convertible.rs
@@ -8,10 +8,7 @@ use crate::client::errors::EthApiError;
 
 #[async_trait]
 pub trait ConvertibleStarknetBlock {
-    async fn to_eth_block<T: JsonRpcTransport + Send + Sync>(
-        &self,
-        client: &dyn KakarotEthApi<T>,
-    ) -> Result<RichBlock, EthApiError<T::Error>>;
+    async fn to_eth_block<T: JsonRpcTransport + Send + Sync>(&self, client: &dyn KakarotEthApi<T>) -> RichBlock;
 }
 
 pub trait ConvertibleStarknetEvent {

--- a/crates/core/src/models/event.rs
+++ b/crates/core/src/models/event.rs
@@ -38,13 +38,12 @@ impl ConvertibleStarknetEvent for StarknetEvent {
     ) -> Result<Log, EthApiError<T::Error>> {
         // If event `from_address` does not equal kakarot address, return early
         if self.0.from_address != client.kakarot_address() {
-            return Err(EthApiError::OtherError(anyhow::anyhow!("Kakarot Filter: Event is not part of Kakarot")));
+            return Err(EthApiError::KakarotDataFilteringError("Event".into()));
         }
 
         // Derive the evm address from the last item in the `event.keys` vector and remove it
-        let (evm_contract_address, keys) = self.0.keys.split_last().ok_or_else(|| {
-            EthApiError::OtherError(anyhow::anyhow!("Kakarot Filter: Event is not a Kakarot evm event"))
-        })?;
+        let (evm_contract_address, keys) =
+            self.0.keys.split_last().ok_or_else(|| EthApiError::KakarotDataFilteringError("Event".into()))?;
 
         let address: Address = {
             let felt_wrapper: Felt252Wrapper = (*evm_contract_address).into();

--- a/crates/core/src/models/mod.rs
+++ b/crates/core/src/models/mod.rs
@@ -11,6 +11,8 @@ pub mod transaction;
 use starknet::core::types::FromByteArrayError;
 use thiserror::Error;
 
+use crate::client::helpers::DataDecodingError;
+
 #[derive(Debug, Error)]
 /// Conversion error
 pub enum ConversionError {

--- a/crates/core/src/models/mod.rs
+++ b/crates/core/src/models/mod.rs
@@ -11,12 +11,13 @@ pub mod transaction;
 use starknet::core::types::FromByteArrayError;
 use thiserror::Error;
 
-use crate::client::helpers::DataDecodingError;
-
 #[derive(Debug, Error)]
+/// Conversion error
 pub enum ConversionError {
+    /// Ethereum to Starknet transaction conversion error
     #[error("transaction conversion error: {0}")]
     TransactionConversionError(String),
+    /// Felt252Wrapper conversion error
     #[error(transparent)]
     Felt252WrapperConversionError(#[from] FromByteArrayError),
     #[error(transparent)]
@@ -26,4 +27,7 @@ pub enum ConversionError {
          address"
     )]
     ToEthereumAddressError,
+    /// Other conversion error
+    #[error("failed to convert from {src} to {dest}")]
+    Other { src: String, dest: String },
 }

--- a/crates/core/src/models/mod.rs
+++ b/crates/core/src/models/mod.rs
@@ -25,11 +25,11 @@ pub enum ConversionError {
     #[error(transparent)]
     DataDecodingError(#[from] DataDecodingError),
     #[error(
-        "Failed to convert Felt252Wrapper to Ethereum address: the value exceeds the maximum size of an Ethereum \
+        "failed to convert Felt252Wrapper to Ethereum address: the value exceeds the maximum size of an Ethereum \
          address"
     )]
     ToEthereumAddressError,
     /// Other conversion error
-    #[error("failed to convert from {src} to {dest}")]
-    Other { src: String, dest: String },
+    #[error("failed to convert value: {0}")]
+    Other(String),
 }

--- a/crates/core/src/models/transaction.rs
+++ b/crates/core/src/models/transaction.rs
@@ -74,7 +74,7 @@ impl ConvertibleStarknetTransaction for StarknetTransaction {
         transaction_index: Option<U256>,
     ) -> Result<EthTransaction, EthApiError<T::Error>> {
         if !self.is_kakarot_tx(client).await? {
-            return Err(EthApiError::OtherError(anyhow::anyhow!("Kakarot Filter: Tx is not part of Kakarot")));
+            return Err(EthApiError::KakarotDataFilteringError("Transaction".into()));
         }
 
         let starknet_block_latest = StarknetBlockId::Tag(BlockTag::Latest);

--- a/crates/core/tests/client.rs
+++ b/crates/core/tests/client.rs
@@ -21,7 +21,7 @@ mod tests {
         let client = setup_mock_client_crate().await;
         let starknet_client = client.starknet_provider();
         let starknet_block = starknet_client.get_block_with_txs(BlockId::Tag(BlockTag::Latest)).await.unwrap();
-        let eth_block = BlockWithTxs::new(starknet_block).to_eth_block(&client).await.unwrap();
+        let eth_block = BlockWithTxs::new(starknet_block).to_eth_block(&client).await;
 
         // TODO: Add more assertions & refactor into assert helpers
         // assert helpers should allow import of fixture file
@@ -174,8 +174,8 @@ mod tests {
         // `kakarot_address'.
         match resultant_eth_log {
             Ok(_) => panic!("Expected an error due to wrong `from_address`, but got a result."),
-            Err(EthApiError::OtherError(err)) => {
-                assert_eq!(err.to_string(), "Kakarot Filter: Event is not part of Kakarot")
+            Err(EthApiError::KakarotDataFilteringError(err)) => {
+                assert_eq!(err, "Event")
             }
             Err(_) => panic!("Expected a Kakarot Filter error, but got a different error."),
         }


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->
Refactor the errors in order to remove a maximum of instances of `EthApiError::Other`. Also removes a `Result` which wasn't needed.
<!-- Give an estimate of the time you spent on this PR in terms of work days. Did you spend 0.5 days on this PR or rather 2 days?  -->

Time spent on this PR: 1 day

# Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Testing
- [ ] Other (please describe):

# What is the current behavior?
The codebase uses quite a lot of instances of `EthApiError::Other`. Also contains one unused `Result`.
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Resolves: #203 

# What is the new behavior?
Removed as much `EthApiError::Other` as possible, by adding `EthApiError:: KakarotDataFilteringError`, `DataDecodingError:: TransactionDecodingError`, `DataDecodingError:: InvalidReturnArrayLength ` and `ConversionError:: Other`. Also removes the unused `Result`.

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Add `EthApiError:: KakarotDataFilteringError`, `DataDecodingError:: TransactionDecodingError`, `DataDecodingError:: InvalidReturnArrayLength ` and `ConversionError:: Other`.
- Remove unused `Result`.
- Update testing

# Does this introduce a breaking change?

- [ ] Yes
- [x] No
