### PR TITLE
remove branch dependency for blockifier

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,4 +41,4 @@ cairo-felt = { git = "https://github.com/dojoengine/cairo-rs.git", rev = "9edddb
 cairo-vm = { git = "https://github.com/dojoengine/cairo-rs.git", rev = "9edddbc" }
 
 [patch."https://github.com/starkware-libs/blockifier"]
-blockifier = { git = "https://github.com/dojoengine/blockifier", branch = "main" }
+blockifier = { git = "https://github.com/dojoengine/blockifier", rev = "f5b684d" }


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->
<!-- Give an estimate of the time you spent on this PR in terms of work days. Did you spend 0.5 days on this PR or rather 2 days?  -->

Time spent on this PR:

# Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [X] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Testing
- [ ] Other (please describe):

# What is the current behavior?

blockifier points to dojo's fork's mainbranch, whereas they are currently pointing to a specific commit. 

Resolves: #<Issue number>

# What is the new behavior?

We depend on the same commit that they do, so we can rely on the power of anime less for stability.

-
-
-

# Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

# Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->
