### PR TITLE
bug-fix/use correct nonce in `deploy_evm_contract`

### DIFF
--- a/crates/core/src/test_utils/deploy_helpers.rs
+++ b/crates/core/src/test_utils/deploy_helpers.rs
@@ -225,8 +225,9 @@ async fn deploy_evm_contract<T: Tokenize>(
 
     let (abi, contract_bytes) = get_contract(contract_name);
     let contract_bytes = encode_contract(&abi, &contract_bytes, constructor_args);
+    let nonce = eoa_starknet_account.get_nonce().await.unwrap();
     let transaction =
-        to_kakarot_transaction(Default::default(), TransactionKind::Create, contract_bytes.to_vec().into());
+        to_kakarot_transaction(nonce.try_into().unwrap(), TransactionKind::Create, contract_bytes.to_vec().into());
     let signature = sign_message(eoa_secret_key, transaction.signature_hash()).unwrap();
     let signed_transaction = TransactionSigned::from_transaction_and_signature(transaction, signature);
 


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->
<!-- Give an estimate of the time you spent on this PR in terms of work days. Did you spend 0.5 days on this PR or rather 2 days?  -->

Time spent on this PR: .2

# Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Testing
- [ ] Other (please describe):

# What is the current behavior?

was using Default::default() for the nonce value that was being constructed in the ethereum transaction that was being sent in a starknet transaction. this breaks when you try to use the starknet address underpinning the ethereum deploy more than once. 

Resolves: #<Issue number>

# What is the new behavior?

now we retrieve the nonce of the `eoa_starknet_account` per each deploy

-
-
-

# Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

# Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->
