### PR TITLE
map `NoContractError` to zero for `eth_getTransactionCount`

### DIFF
--- a/crates/core/tests/client.rs
+++ b/crates/core/tests/client.rs
@@ -51,47 +51,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_constructable() {
-        // initial setup of Constructable to test we can deploy contracts w/ constructor arguments
-        let starknet_test_sequencer = TestSequencer::start().await;
-
-        let expected_funded_amount = FieldElement::from_dec_str("1000000000000000000").unwrap();
-
-        let deployed_kakarot =
-            deploy_kakarot_system(&starknet_test_sequencer, EOA_WALLET.clone(), expected_funded_amount).await;
-
-        let (_constructable_abi, deployed_addresses) = deployed_kakarot
-            .deploy_evm_contract(
-                starknet_test_sequencer.url(),
-                "Constructable",
-                // more than one argument to a constructor needs to be conveyed as a tuple
-                (EthersU256::from(100), EthersAddress::zero()),
-            )
-            .await
-            .unwrap();
-
-        let kakarot_client = KakarotClient::new(
-            StarknetConfig::new(
-                starknet_test_sequencer.url().as_ref().to_string(),
-                deployed_kakarot.kakarot,
-                deployed_kakarot.kakarot_proxy,
-            ),
-            JsonRpcClient::new(HttpTransport::new(starknet_test_sequencer.url())),
-        )
-        .unwrap();
-
-        let constructable_eth_address = {
-            let address: Felt252Wrapper = (*deployed_addresses.first().unwrap()).into();
-            address.try_into().unwrap()
-        };
-
-        kakarot_client
-            .get_code(constructable_eth_address, BlockId::Number(reth_primitives::BlockNumberOrTag::Latest))
-            .await
-            .expect("contract not deployed");
-    }
-
-    #[tokio::test]
     async fn test_counter() {
         let starknet_test_sequencer = TestSequencer::start().await;
 

--- a/scripts/PlainOpcodes.s.sol
+++ b/scripts/PlainOpcodes.s.sol
@@ -5,7 +5,7 @@ import "forge-std/Script.sol";
 import "kakarot/PlainOpcodes/Counter.sol";
 import "kakarot/PlainOpcodes/PlainOpcodes.sol";
 
-contract EvmsheetScript is Script {
+contract PlainOpcodesScript is Script {
     Counter public counter;
     PlainOpcodes public plainOpcodes;
 


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->
<!-- Give an estimate of the time you spent on this PR in terms of work days. Did you spend 0.5 days on this PR or rather 2 days?  -->

Time spent on this PR: .1

# Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Testing
- [ ] Other (please describe):

# What is the current behavior?

An EOA address is mapped to a starknet address w/ `compute_starknet_address`, then looked up for a nonce against the provider. When the mapped address doesn't exist, we get a NoContractError.

Resolves: #259 

We match for NoContractError's and map it to a zero, per the evm tooling norms.


-
-
-

# Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

# Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->
