### PR TITLE
`run_kakarot_integration` takes a client callback for integration tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,6 +171,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bddcadddf5e9015d310179a59bb28c4d4b9920ad0f11e8e14dbadf654890c9a6"
 
 [[package]]
+name = "ariadne"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "367fd0ad87307588d087544707bc5fbf4805ded96c7db922b70d368fa1cb5702"
+dependencies = [
+ "unicode-width",
+ "yansi",
+]
+
+[[package]]
 name = "ark-ec"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -392,9 +402,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.69"
+version = "0.1.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b2d0f03b3640e3a630367e40c468cb7f309529c708ed1d88597047b0e7c6ef7"
+checksum = "a564d521dd56509c4c47480d00b80ee55f7e385ae48db5744c67ad50c92d2ebf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -668,13 +678,12 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "1.5.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a246e68bb43f6cd9db24bea052a53e40405417c5fb372e3d1a8a7f770a564ef5"
+checksum = "6798148dccfbff0fae41c7574d2fa8f1ef3492fba0face179de5d8d447d67b05"
 dependencies = [
  "memchr",
- "once_cell",
- "regex-automata",
+ "regex-automata 0.3.1",
  "serde",
 ]
 
@@ -1337,9 +1346,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.3.10"
+version = "4.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "384e169cc618c613d5e3ca6404dda77a8685a63e08660dcc64abaf7da7cb0c7a"
+checksum = "1640e5cc7fb47dbb8338fd471b105e7ed6c3cb2aeb00c2e067127ffd3764a05d"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1358,14 +1367,17 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.3.10"
+version = "4.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef137bbe35aab78bdb468ccfba75a5f4d8321ae011d34063770780545176af2d"
+checksum = "98c59138d527eeaf9b53f35a77fcc1fad9d883116070c63d5de1c7dc7b00c72b"
 dependencies = [
  "anstream",
  "anstyle",
  "clap_lex",
  "strsim",
+ "terminal_size",
+ "unicase",
+ "unicode-width",
 ]
 
 [[package]]
@@ -1469,13 +1481,25 @@ checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "colored"
-version = "2.0.1"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17bfac9400fe632590700de801b5dfbdca8b6944073832d1284bdbeef7f00e45"
+checksum = "2674ec482fbc38012cf31e6c42ba0177b431a0cb6f15fe40efa5aab1bda516f6"
 dependencies = [
- "atty",
+ "is-terminal",
  "lazy_static",
- "winapi",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "comfy-table"
+version = "6.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e959d788268e3bf9d35ace83e81b124190378e4c91c9067524675e33394b8ba"
+dependencies = [
+ "crossterm",
+ "strum 0.24.1",
+ "strum_macros 0.24.3",
+ "unicode-width",
 ]
 
 [[package]]
@@ -1551,9 +1575,9 @@ checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03e69e28e9f7f77debdedbaafa2866e1de9ba56df55a8bd7cfc724c25a09987c"
+checksum = "a17b76ff3a4162b0b27f354a0c87015ddad39d35f9c0c36607a3bdd175dde1f1"
 dependencies = [
  "libc",
 ]
@@ -1585,8 +1609,7 @@ dependencies = [
 [[package]]
 name = "create-output-dir"
 version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f163b5f0a28dc76f9c7d71a337a28aa36a6e77d0df92ca33d6121561ca622347"
+source = "git+https://github.com/software-mansion/scarb#775538b91f4a7f877e97871080f503d9978fb80a"
 dependencies = [
  "anyhow",
  "core-foundation",
@@ -1659,6 +1682,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a22b2d63d4d1dc0b7f1b6b2747dd0088008a9be28b6ddf0b1e7d335e3037294"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "crossterm"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a84cda67535339806297f1b331d6dd6320470d2a0fe65381e79ee9e156dd3d13"
+dependencies = [
+ "bitflags 1.3.2",
+ "crossterm_winapi",
+ "libc",
+ "mio",
+ "parking_lot 0.12.1",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]
@@ -1977,7 +2025,7 @@ checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 [[package]]
 name = "dojo-lang"
 version = "0.1.0"
-source = "git+https://github.com/dojoengine/dojo?rev=24e8a78#24e8a781e1fd9e94528835c2000202afc5f91edf"
+source = "git+https://github.com/jobez/dojo?branch=custom-steps-and-get-block-potential-fix#2e40087f7cd0b5dd59d3e7ad4e80febba8fd71c4"
 dependencies = [
  "anyhow",
  "assert_fs",
@@ -2016,7 +2064,7 @@ dependencies = [
 [[package]]
 name = "dojo-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/dojoengine/dojo?rev=24e8a78#24e8a781e1fd9e94528835c2000202afc5f91edf"
+source = "git+https://github.com/jobez/dojo?branch=custom-steps-and-get-block-potential-fix#2e40087f7cd0b5dd59d3e7ad4e80febba8fd71c4"
 dependencies = [
  "anyhow",
  "assert_fs",
@@ -2038,7 +2086,7 @@ dependencies = [
  "starknet",
  "thiserror",
  "tokio",
- "toml 0.7.5",
+ "toml 0.7.6",
  "tracing",
  "url",
 ]
@@ -2046,7 +2094,7 @@ dependencies = [
 [[package]]
 name = "dojo-types"
 version = "0.1.0"
-source = "git+https://github.com/dojoengine/dojo?rev=24e8a78#24e8a781e1fd9e94528835c2000202afc5f91edf"
+source = "git+https://github.com/jobez/dojo?branch=custom-steps-and-get-block-potential-fix#2e40087f7cd0b5dd59d3e7ad4e80febba8fd71c4"
 dependencies = [
  "serde",
  "starknet",
@@ -2055,7 +2103,7 @@ dependencies = [
 [[package]]
 name = "dojo-world"
 version = "0.1.0"
-source = "git+https://github.com/dojoengine/dojo?rev=24e8a78#24e8a781e1fd9e94528835c2000202afc5f91edf"
+source = "git+https://github.com/jobez/dojo?branch=custom-steps-and-get-block-potential-fix#2e40087f7cd0b5dd59d3e7ad4e80febba8fd71c4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2065,6 +2113,7 @@ dependencies = [
  "camino",
  "convert_case 0.6.0",
  "dojo-types",
+ "futures",
  "reqwest",
  "serde",
  "serde_json",
@@ -2072,6 +2121,7 @@ dependencies = [
  "smol_str",
  "starknet",
  "thiserror",
+ "tokio",
  "tracing",
  "url",
 ]
@@ -2177,9 +2227,9 @@ dependencies = [
 
 [[package]]
 name = "enumn"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fe4d538b570fd4ee7a01377f3e88069ecaee79e50bdc93c8895898dd2b47e37"
+checksum = "c9838a970f5de399d3070ae1739e131986b2f5dcc223c7423ca0927e3a878522"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2315,14 +2365,29 @@ version = "2.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a58ce802c65cf3d0756dee5a61094a92cde53c1583b246e9ee5b37226c7fc15"
 dependencies = [
- "ethers-addressbook",
- "ethers-contract",
+ "ethers-addressbook 2.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ethers-contract 2.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "ethers-core 2.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "ethers-etherscan 2.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "ethers-middleware",
- "ethers-providers",
- "ethers-signers",
+ "ethers-middleware 2.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ethers-providers 2.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ethers-signers 2.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "ethers-solc 2.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "ethers"
+version = "2.0.7"
+source = "git+https://github.com/gakonst/ethers-rs#311086466871204c3965065b8c81e47418261412"
+dependencies = [
+ "ethers-addressbook 2.0.7 (git+https://github.com/gakonst/ethers-rs)",
+ "ethers-contract 2.0.7 (git+https://github.com/gakonst/ethers-rs)",
+ "ethers-core 2.0.7 (git+https://github.com/gakonst/ethers-rs)",
+ "ethers-etherscan 2.0.7 (git+https://github.com/gakonst/ethers-rs)",
+ "ethers-middleware 2.0.7 (git+https://github.com/gakonst/ethers-rs)",
+ "ethers-providers 2.0.7 (git+https://github.com/gakonst/ethers-rs)",
+ "ethers-signers 2.0.7 (git+https://github.com/gakonst/ethers-rs)",
+ "ethers-solc 2.0.7 (git+https://github.com/gakonst/ethers-rs)",
 ]
 
 [[package]]
@@ -2338,15 +2403,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "ethers-addressbook"
+version = "2.0.7"
+source = "git+https://github.com/gakonst/ethers-rs#311086466871204c3965065b8c81e47418261412"
+dependencies = [
+ "ethers-core 2.0.7 (git+https://github.com/gakonst/ethers-rs)",
+ "once_cell",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "ethers-contract"
 version = "2.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e066a0d9cfc70c454672bf16bb433b0243427420076dc5b2f49c448fb5a10628"
 dependencies = [
- "ethers-contract-abigen",
- "ethers-contract-derive",
+ "ethers-contract-abigen 2.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ethers-contract-derive 2.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "ethers-core 2.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "ethers-providers",
+ "ethers-providers 2.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-util",
+ "hex",
+ "once_cell",
+ "pin-project",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
+name = "ethers-contract"
+version = "2.0.7"
+source = "git+https://github.com/gakonst/ethers-rs#311086466871204c3965065b8c81e47418261412"
+dependencies = [
+ "ethers-contract-abigen 2.0.7 (git+https://github.com/gakonst/ethers-rs)",
+ "ethers-contract-derive 2.0.7 (git+https://github.com/gakonst/ethers-rs)",
+ "ethers-core 2.0.7 (git+https://github.com/gakonst/ethers-rs)",
+ "ethers-providers 2.0.7 (git+https://github.com/gakonst/ethers-rs)",
+ "ethers-signers 2.0.7 (git+https://github.com/gakonst/ethers-rs)",
  "futures-util",
  "hex",
  "once_cell",
@@ -2376,7 +2471,28 @@ dependencies = [
  "serde",
  "serde_json",
  "syn 2.0.23",
- "toml 0.7.5",
+ "toml 0.7.6",
+ "walkdir",
+]
+
+[[package]]
+name = "ethers-contract-abigen"
+version = "2.0.7"
+source = "git+https://github.com/gakonst/ethers-rs#311086466871204c3965065b8c81e47418261412"
+dependencies = [
+ "Inflector",
+ "dunce",
+ "ethers-core 2.0.7 (git+https://github.com/gakonst/ethers-rs)",
+ "eyre",
+ "hex",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "serde",
+ "serde_json",
+ "syn 2.0.23",
+ "toml 0.7.6",
  "walkdir",
 ]
 
@@ -2387,8 +2503,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c3fb5adee25701c79ec58fcf2c63594cd8829bc9ad6037ff862d5a111101ed2"
 dependencies = [
  "Inflector",
- "ethers-contract-abigen",
+ "ethers-contract-abigen 2.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "ethers-core 2.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hex",
+ "proc-macro2",
+ "quote",
+ "serde_json",
+ "syn 2.0.23",
+]
+
+[[package]]
+name = "ethers-contract-derive"
+version = "2.0.7"
+source = "git+https://github.com/gakonst/ethers-rs#311086466871204c3965065b8c81e47418261412"
+dependencies = [
+ "Inflector",
+ "ethers-contract-abigen 2.0.7 (git+https://github.com/gakonst/ethers-rs)",
+ "ethers-core 2.0.7 (git+https://github.com/gakonst/ethers-rs)",
  "hex",
  "proc-macro2",
  "quote",
@@ -2433,6 +2564,7 @@ source = "git+https://github.com/gakonst/ethers-rs#311086466871204c3965065b8c81e
 dependencies = [
  "arrayvec",
  "bytes",
+ "cargo_metadata",
  "chrono",
  "elliptic-curve",
  "ethabi",
@@ -2440,12 +2572,14 @@ dependencies = [
  "hex",
  "k256",
  "num_enum",
+ "once_cell",
  "open-fastrlp",
  "rand 0.8.5",
  "rlp",
  "serde",
  "serde_json",
  "strum 0.25.0",
+ "syn 2.0.23",
  "tempfile",
  "thiserror",
  "tiny-keccak",
@@ -2473,6 +2607,7 @@ version = "2.0.7"
 source = "git+https://github.com/gakonst/ethers-rs#311086466871204c3965065b8c81e47418261412"
 dependencies = [
  "ethers-core 2.0.7 (git+https://github.com/gakonst/ethers-rs)",
+ "ethers-solc 2.0.7 (git+https://github.com/gakonst/ethers-rs)",
  "reqwest",
  "semver",
  "serde",
@@ -2489,11 +2624,37 @@ checksum = "740f4a773c19dd6d6a68c8c2e0996c096488d38997d524e21dc612c55da3bd24"
 dependencies = [
  "async-trait",
  "auto_impl",
- "ethers-contract",
+ "ethers-contract 2.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "ethers-core 2.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "ethers-etherscan 2.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "ethers-providers",
- "ethers-signers",
+ "ethers-providers 2.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ethers-signers 2.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-channel",
+ "futures-locks",
+ "futures-util",
+ "instant",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "tracing-futures",
+ "url",
+]
+
+[[package]]
+name = "ethers-middleware"
+version = "2.0.7"
+source = "git+https://github.com/gakonst/ethers-rs#311086466871204c3965065b8c81e47418261412"
+dependencies = [
+ "async-trait",
+ "auto_impl",
+ "ethers-contract 2.0.7 (git+https://github.com/gakonst/ethers-rs)",
+ "ethers-core 2.0.7 (git+https://github.com/gakonst/ethers-rs)",
+ "ethers-etherscan 2.0.7 (git+https://github.com/gakonst/ethers-rs)",
+ "ethers-providers 2.0.7 (git+https://github.com/gakonst/ethers-rs)",
+ "ethers-signers 2.0.7 (git+https://github.com/gakonst/ethers-rs)",
  "futures-channel",
  "futures-locks",
  "futures-util",
@@ -2545,6 +2706,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "ethers-providers"
+version = "2.0.7"
+source = "git+https://github.com/gakonst/ethers-rs#311086466871204c3965065b8c81e47418261412"
+dependencies = [
+ "async-trait",
+ "auto_impl",
+ "base64 0.21.2",
+ "bytes",
+ "enr",
+ "ethers-core 2.0.7 (git+https://github.com/gakonst/ethers-rs)",
+ "futures-core",
+ "futures-timer",
+ "futures-util",
+ "hashers",
+ "hex",
+ "http",
+ "instant",
+ "once_cell",
+ "pin-project",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "tracing-futures",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "ws_stream_wasm",
+]
+
+[[package]]
 name = "ethers-signers"
 version = "2.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2556,6 +2751,24 @@ dependencies = [
  "elliptic-curve",
  "eth-keystore",
  "ethers-core 2.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hex",
+ "rand 0.8.5",
+ "sha2 0.10.7",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
+name = "ethers-signers"
+version = "2.0.7"
+source = "git+https://github.com/gakonst/ethers-rs#311086466871204c3965065b8c81e47418261412"
+dependencies = [
+ "async-trait",
+ "coins-bip32",
+ "coins-bip39",
+ "elliptic-curve",
+ "eth-keystore",
+ "ethers-core 2.0.7 (git+https://github.com/gakonst/ethers-rs)",
  "hex",
  "rand 0.8.5",
  "sha2 0.10.7",
@@ -2677,7 +2890,7 @@ dependencies = [
  "atomic",
  "pear",
  "serde",
- "toml 0.7.5",
+ "toml 0.7.6",
  "uncased",
  "version_check",
 ]
@@ -2744,6 +2957,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
+name = "forge"
+version = "0.2.0"
+source = "git+https://github.com/foundry-rs/foundry?branch=master#c78a811a8af95fb1e029427583a07b2ca3a3fa51"
+dependencies = [
+ "comfy-table",
+ "ethers 2.0.7 (git+https://github.com/gakonst/ethers-rs)",
+ "eyre",
+ "foundry-common",
+ "foundry-config",
+ "foundry-evm",
+ "foundry-utils",
+ "glob",
+ "hex",
+ "once_cell",
+ "parking_lot 0.12.1",
+ "proptest",
+ "rayon",
+ "regex",
+ "rlp",
+ "semver",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+ "yansi",
+]
+
+[[package]]
+name = "forge-fmt"
+version = "0.2.0"
+source = "git+https://github.com/foundry-rs/foundry?branch=master#c78a811a8af95fb1e029427583a07b2ca3a3fa51"
+dependencies = [
+ "ariadne",
+ "ethers-core 2.0.7 (git+https://github.com/gakonst/ethers-rs)",
+ "foundry-config",
+ "itertools 0.10.5",
+ "semver",
+ "solang-parser",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2753,9 +3010,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "foundry-abi"
+version = "0.1.0"
+source = "git+https://github.com/foundry-rs/foundry?branch=master#c78a811a8af95fb1e029427583a07b2ca3a3fa51"
+dependencies = [
+ "ethers-contract 2.0.7 (git+https://github.com/gakonst/ethers-rs)",
+ "ethers-contract-abigen 2.0.7 (git+https://github.com/gakonst/ethers-rs)",
+ "ethers-core 2.0.7 (git+https://github.com/gakonst/ethers-rs)",
+ "ethers-providers 2.0.7 (git+https://github.com/gakonst/ethers-rs)",
+ "eyre",
+ "foundry-macros",
+ "syn 2.0.23",
+]
+
+[[package]]
+name = "foundry-common"
+version = "0.1.0"
+source = "git+https://github.com/foundry-rs/foundry?branch=master#c78a811a8af95fb1e029427583a07b2ca3a3fa51"
+dependencies = [
+ "auto_impl",
+ "clap",
+ "comfy-table",
+ "dunce",
+ "ethers-core 2.0.7 (git+https://github.com/gakonst/ethers-rs)",
+ "ethers-etherscan 2.0.7 (git+https://github.com/gakonst/ethers-rs)",
+ "ethers-middleware 2.0.7 (git+https://github.com/gakonst/ethers-rs)",
+ "ethers-providers 2.0.7 (git+https://github.com/gakonst/ethers-rs)",
+ "ethers-solc 2.0.7 (git+https://github.com/gakonst/ethers-rs)",
+ "eyre",
+ "foundry-config",
+ "foundry-macros",
+ "globset",
+ "is-terminal",
+ "once_cell",
+ "regex",
+ "reqwest",
+ "semver",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "thiserror",
+ "tracing",
+ "walkdir",
+ "yansi",
+]
+
+[[package]]
 name = "foundry-config"
 version = "0.2.0"
-source = "git+https://github.com/foundry-rs/foundry?branch=master#bf56869aaf61e58be1dd4058159268c4529d73f6"
+source = "git+https://github.com/foundry-rs/foundry?branch=master#c78a811a8af95fb1e029427583a07b2ca3a3fa51"
 dependencies = [
  "Inflector",
  "dirs-next",
@@ -2776,10 +3079,93 @@ dependencies = [
  "serde_json",
  "serde_regex",
  "thiserror",
- "toml 0.7.5",
+ "toml 0.7.6",
  "toml_edit",
  "tracing",
  "walkdir",
+]
+
+[[package]]
+name = "foundry-evm"
+version = "0.2.0"
+source = "git+https://github.com/foundry-rs/foundry?branch=master#c78a811a8af95fb1e029427583a07b2ca3a3fa51"
+dependencies = [
+ "auto_impl",
+ "bytes",
+ "ethers 2.0.7 (git+https://github.com/gakonst/ethers-rs)",
+ "eyre",
+ "foundry-abi",
+ "foundry-common",
+ "foundry-config",
+ "foundry-macros",
+ "foundry-utils",
+ "futures",
+ "hashbrown 0.13.2",
+ "hex",
+ "itertools 0.10.5",
+ "jsonpath_lib",
+ "once_cell",
+ "ordered-float",
+ "parking_lot 0.12.1",
+ "proptest",
+ "revm",
+ "semver",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "url",
+ "walkdir",
+ "yansi",
+]
+
+[[package]]
+name = "foundry-macros"
+version = "0.1.0"
+source = "git+https://github.com/foundry-rs/foundry?branch=master#c78a811a8af95fb1e029427583a07b2ca3a3fa51"
+dependencies = [
+ "ethers-core 2.0.7 (git+https://github.com/gakonst/ethers-rs)",
+ "foundry-macros-impl",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "foundry-macros-impl"
+version = "0.0.0"
+source = "git+https://github.com/foundry-rs/foundry?branch=master#c78a811a8af95fb1e029427583a07b2ca3a3fa51"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.23",
+]
+
+[[package]]
+name = "foundry-utils"
+version = "0.2.0"
+source = "git+https://github.com/foundry-rs/foundry?branch=master#c78a811a8af95fb1e029427583a07b2ca3a3fa51"
+dependencies = [
+ "ethers-addressbook 2.0.7 (git+https://github.com/gakonst/ethers-rs)",
+ "ethers-contract 2.0.7 (git+https://github.com/gakonst/ethers-rs)",
+ "ethers-core 2.0.7 (git+https://github.com/gakonst/ethers-rs)",
+ "ethers-etherscan 2.0.7 (git+https://github.com/gakonst/ethers-rs)",
+ "ethers-providers 2.0.7 (git+https://github.com/gakonst/ethers-rs)",
+ "ethers-solc 2.0.7 (git+https://github.com/gakonst/ethers-rs)",
+ "eyre",
+ "forge-fmt",
+ "futures",
+ "glob",
+ "hex",
+ "once_cell",
+ "rand 0.8.5",
+ "reqwest",
+ "rlp",
+ "rustc-hex",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -2798,7 +3184,7 @@ version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2eeb4ed9e12f43b7fa0baae3f9cdda28352770132ef2e09a23760c29cae8bd47"
 dependencies = [
- "rustix 0.38.2",
+ "rustix 0.38.3",
  "windows-sys 0.48.0",
 ]
 
@@ -3435,7 +3821,7 @@ dependencies = [
  "gix-command",
  "gix-config-value",
  "parking_lot 0.12.1",
- "rustix 0.37.22",
+ "rustix 0.37.23",
  "thiserror",
 ]
 
@@ -3951,33 +4337,18 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.23.2"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1788965e61b367cd03a62950836d5cd41560c3577d90e40e0819373194d1661c"
+checksum = "8d78e1e73ec14cf7375674f74d7dde185c8206fd9dea6fb6295e8a98098aaa97"
 dependencies = [
+ "futures-util",
  "http",
  "hyper",
  "log",
- "rustls 0.20.8",
+ "rustls",
  "rustls-native-certs",
  "tokio",
- "tokio-rustls 0.23.4",
- "webpki-roots 0.22.6",
-]
-
-[[package]]
-name = "hyper-rustls"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0646026eb1b3eea4cd9ba47912ea5ce9cc07713d105b1a14698f4e6433d348b7"
-dependencies = [
- "http",
- "hyper",
- "log",
- "rustls 0.21.2",
- "rustls-native-certs",
- "tokio",
- "tokio-rustls 0.24.1",
+ "tokio-rustls",
 ]
 
 [[package]]
@@ -4237,12 +4608,12 @@ dependencies = [
 
 [[package]]
 name = "is-terminal"
-version = "0.4.8"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24fddda5af7e54bf7da53067d6e802dbcc381d0a8eef629df528e3ebf68755cb"
+checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
 dependencies = [
  "hermit-abi 0.3.2",
- "rustix 0.38.2",
+ "rustix 0.38.3",
  "windows-sys 0.48.0",
 ]
 
@@ -4289,19 +4660,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonpath_lib"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaa63191d68230cccb81c5aa23abd53ed64d83337cacbb25a7b8c7979523774f"
+dependencies = [
+ "log",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "jsonrpsee"
 version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d291e3a5818a2384645fd9756362e6d89cf0541b0b916fa7702ea4a9833608e"
 dependencies = [
- "jsonrpsee-client-transport 0.16.2",
  "jsonrpsee-core 0.16.2",
- "jsonrpsee-http-client 0.16.2",
  "jsonrpsee-proc-macros 0.16.2",
  "jsonrpsee-server 0.16.2",
  "jsonrpsee-types 0.16.2",
- "jsonrpsee-wasm-client 0.16.2",
- "jsonrpsee-ws-client 0.16.2",
  "tracing",
 ]
 
@@ -4311,40 +4689,15 @@ version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1822d18e4384a5e79d94dc9e4d1239cfa9fad24e55b44d2efeff5b394c9fece4"
 dependencies = [
- "jsonrpsee-client-transport 0.18.2",
+ "jsonrpsee-client-transport",
  "jsonrpsee-core 0.18.2",
- "jsonrpsee-http-client 0.18.2",
+ "jsonrpsee-http-client",
  "jsonrpsee-proc-macros 0.18.2",
  "jsonrpsee-server 0.18.2",
  "jsonrpsee-types 0.18.2",
- "jsonrpsee-wasm-client 0.18.2",
- "jsonrpsee-ws-client 0.18.2",
+ "jsonrpsee-wasm-client",
+ "jsonrpsee-ws-client",
  "tracing",
-]
-
-[[package]]
-name = "jsonrpsee-client-transport"
-version = "0.16.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "965de52763f2004bc91ac5bcec504192440f0b568a5d621c59d9dbd6f886c3fb"
-dependencies = [
- "anyhow",
- "futures-channel",
- "futures-timer",
- "futures-util",
- "gloo-net",
- "http",
- "jsonrpsee-core 0.16.2",
- "jsonrpsee-types 0.16.2",
- "pin-project",
- "rustls-native-certs",
- "soketto",
- "thiserror",
- "tokio",
- "tokio-rustls 0.23.4",
- "tokio-util",
- "tracing",
- "webpki-roots 0.22.6",
 ]
 
 [[package]]
@@ -4363,7 +4716,7 @@ dependencies = [
  "soketto",
  "thiserror",
  "tokio",
- "tokio-rustls 0.24.1",
+ "tokio-rustls",
  "tokio-util",
  "tracing",
  "webpki-roots 0.23.1",
@@ -4377,11 +4730,9 @@ checksum = "a4e70b4439a751a5de7dd5ed55eacff78ebf4ffe0fc009cb1ebb11417f5b536b"
 dependencies = [
  "anyhow",
  "arrayvec",
- "async-lock",
  "async-trait",
  "beef",
  "futures-channel",
- "futures-timer",
  "futures-util",
  "globset",
  "hyper",
@@ -4395,7 +4746,6 @@ dependencies = [
  "thiserror",
  "tokio",
  "tracing",
- "wasm-bindgen-futures",
 ]
 
 [[package]]
@@ -4428,32 +4778,13 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-http-client"
-version = "0.16.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc345b0a43c6bc49b947ebeb936e886a419ee3d894421790c969cc56040542ad"
-dependencies = [
- "async-trait",
- "hyper",
- "hyper-rustls 0.23.2",
- "jsonrpsee-core 0.16.2",
- "jsonrpsee-types 0.16.2",
- "rustc-hash",
- "serde",
- "serde_json",
- "thiserror",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "jsonrpsee-http-client"
 version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1705c65069729e3dccff6fd91ee431d5d31cabcf00ce68a62a2c6435ac713af9"
 dependencies = [
  "async-trait",
  "hyper",
- "hyper-rustls 0.24.0",
+ "hyper-rustls",
  "jsonrpsee-core 0.18.2",
  "jsonrpsee-types 0.18.2",
  "serde",
@@ -4562,36 +4893,13 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-wasm-client"
-version = "0.16.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a77310456f43c6c89bcba1f6b2fc2a28300da7c341f320f5128f8c83cc63232d"
-dependencies = [
- "jsonrpsee-client-transport 0.16.2",
- "jsonrpsee-core 0.16.2",
- "jsonrpsee-types 0.16.2",
-]
-
-[[package]]
-name = "jsonrpsee-wasm-client"
 version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34e6ea7c6d862e60f8baebd946c037b70c6808a4e4e31e792a4029184e3ce13a"
 dependencies = [
- "jsonrpsee-client-transport 0.18.2",
+ "jsonrpsee-client-transport",
  "jsonrpsee-core 0.18.2",
  "jsonrpsee-types 0.18.2",
-]
-
-[[package]]
-name = "jsonrpsee-ws-client"
-version = "0.16.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b83daeecfc6517cfe210df24e570fb06213533dfb990318fae781f4c7119dd9"
-dependencies = [
- "http",
- "jsonrpsee-client-transport 0.16.2",
- "jsonrpsee-core 0.16.2",
- "jsonrpsee-types 0.16.2",
 ]
 
 [[package]]
@@ -4601,7 +4909,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a64b2589680ba1ad7863f279cd2d5083c1dc0a7c0ea959d22924553050f8ab9f"
 dependencies = [
  "http",
- "jsonrpsee-client-transport 0.18.2",
+ "jsonrpsee-client-transport",
  "jsonrpsee-core 0.18.2",
  "jsonrpsee-types 0.18.2",
 ]
@@ -4637,9 +4945,13 @@ dependencies = [
  "anyhow",
  "async-trait",
  "cargo-husky",
+ "dojo-test-utils",
  "dotenv",
  "env_logger 0.10.0",
+ "ethers 2.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "eyre",
+ "forge",
+ "foundry-config",
  "hex",
  "jsonrpsee 0.18.2",
  "kakarot_rpc_core",
@@ -4671,7 +4983,7 @@ dependencies = [
  "dojo-test-utils",
  "dotenv",
  "env_logger 0.10.0",
- "ethers",
+ "ethers 2.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "eyre",
  "foundry-config",
  "futures",
@@ -4692,7 +5004,7 @@ dependencies = [
  "starknet-crypto 0.5.1",
  "thiserror",
  "tokio",
- "toml 0.7.5",
+ "toml 0.7.6",
  "url",
  "wiremock",
 ]
@@ -4700,10 +5012,11 @@ dependencies = [
 [[package]]
 name = "katana-core"
 version = "0.1.0"
-source = "git+https://github.com/dojoengine/dojo?rev=24e8a78#24e8a781e1fd9e94528835c2000202afc5f91edf"
+source = "git+https://github.com/jobez/dojo?branch=custom-steps-and-get-block-potential-fix#2e40087f7cd0b5dd59d3e7ad4e80febba8fd71c4"
 dependencies = [
  "anyhow",
  "async-trait",
+ "auto_impl",
  "blockifier",
  "cairo-lang-casm",
  "cairo-lang-starknet",
@@ -4724,7 +5037,7 @@ dependencies = [
 [[package]]
 name = "katana-rpc"
 version = "0.1.0"
-source = "git+https://github.com/dojoengine/dojo?rev=24e8a78#24e8a781e1fd9e94528835c2000202afc5f91edf"
+source = "git+https://github.com/jobez/dojo?branch=custom-steps-and-get-block-potential-fix#2e40087f7cd0b5dd59d3e7ad4e80febba8fd71c4"
 dependencies = [
  "anyhow",
  "blockifier",
@@ -4812,6 +5125,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
 
 [[package]]
+name = "libm"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7012b1bbb0719e1097c47611d3898568c546d597c2e74d66f6087edd5233ff4"
+
+[[package]]
 name = "libmimalloc-sys"
 version = "0.1.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4888,7 +5207,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
 dependencies = [
- "regex-automata",
+ "regex-automata 0.1.10",
 ]
 
 [[package]]
@@ -4999,6 +5318,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "927a765cd3fc26206e66b296465fa9d3e5ab003e651c1b3c060e7956d96b19d2"
 dependencies = [
  "libc",
+ "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.48.0",
 ]
@@ -5055,7 +5375,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac06db03ec2f46ee0ecdca1a1c34a99c0d188a0d83439b84bf0cb4b386e4ab09"
 dependencies = [
  "matrixmultiply",
- "num-complex",
+ "num-complex 0.2.4",
  "num-integer",
  "num-traits 0.2.15",
  "rawpointer",
@@ -5088,6 +5408,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43db66d1170d347f9a065114077f7dccb00c1b9478c89384490a3425279a4606"
+dependencies = [
+ "num-bigint",
+ "num-complex 0.4.3",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits 0.2.15",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5111,12 +5445,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-complex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02e0d21255c828d6f128a1e41534206671e8c3ea0c62f32291e808dc82cff17d"
+dependencies = [
+ "num-traits 0.2.15",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
 dependencies = [
  "autocfg",
+ "num-traits 0.2.15",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d03e6c028c5dc5cac6e2dec0efda81fc887605bb3d884578bb6d6bf7514e252"
+dependencies = [
+ "autocfg",
+ "num-integer",
  "num-traits 0.2.15",
 ]
 
@@ -5148,6 +5502,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-rational"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0638a1c9d0a3c0914158145bc76cff373a75a627e6ecbfb71cbe6f453a5a19b0"
+dependencies = [
+ "autocfg",
+ "num-bigint",
+ "num-integer",
+ "num-traits 0.2.15",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5163,6 +5529,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -5318,6 +5685,15 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "ordered-float"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fc2dbde8f8a79f2102cc474ceb0ad68e3b80b85289ea62389b60e66777e4213"
+dependencies = [
+ "num-traits 0.2.15",
+]
 
 [[package]]
 name = "os_pipe"
@@ -5710,9 +6086,9 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.9"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9825a04601d60621feed79c4e6b56d65db77cdca55cef43b46b0de1096d1c282"
+checksum = "92139198957b410250d43fad93e630d956499a625c527eda65175c8680f83387"
 dependencies = [
  "proc-macro2",
  "syn 2.0.23",
@@ -5797,6 +6173,32 @@ dependencies = [
  "bytesize",
  "human_format",
 ]
+
+[[package]]
+name = "proptest"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e35c06b98bf36aba164cc17cb25f7e232f5c4aeea73baa14b8a9f0d92dbfa65"
+dependencies = [
+ "bit-set",
+ "bitflags 1.3.2",
+ "byteorder",
+ "lazy_static",
+ "num-traits 0.2.15",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
+ "rand_xorshift",
+ "regex-syntax 0.6.29",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quick-xml"
@@ -5900,6 +6302,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_xorshift"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
+dependencies = [
+ "rand_core 0.6.4",
+]
+
+[[package]]
 name = "rawpointer"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5958,13 +6369,14 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.8.4"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0ab3ca65655bb1e41f2a8c8cd662eb4fb035e67c3f78da1d61dffe89d07300f"
+checksum = "b2eae68fc220f7cf2532e4494aded17545fce192d59cd996e0fe7887f4ceb575"
 dependencies = [
  "aho-corasick 1.0.2",
  "memchr",
- "regex-syntax 0.7.2",
+ "regex-automata 0.3.1",
+ "regex-syntax 0.7.3",
 ]
 
 [[package]]
@@ -5974,6 +6386,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
 dependencies = [
  "regex-syntax 0.6.29",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9aaecc05d5c4b5f7da074b9a0d1a0867e71fd36e7fc0482d8bcfe8e8fc56290"
+dependencies = [
+ "aho-corasick 1.0.2",
+ "memchr",
+ "regex-syntax 0.7.3",
 ]
 
 [[package]]
@@ -5996,9 +6419,9 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "436b050e76ed2903236f032a59761c1eb99e1b0aead2c257922771dab1fc8c78"
+checksum = "2ab07dc67230e4a4718e70fd5c20055a4334b121f1f9db8fe63ef39ce9b8c846"
 
 [[package]]
 name = "relative-path"
@@ -6021,7 +6444,7 @@ dependencies = [
  "http",
  "http-body",
  "hyper",
- "hyper-rustls 0.24.0",
+ "hyper-rustls",
  "hyper-tls",
  "ipnet",
  "js-sys",
@@ -6031,14 +6454,14 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls 0.21.2",
+ "rustls",
  "rustls-pemfile",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "tokio",
  "tokio-native-tls",
- "tokio-rustls 0.24.1",
+ "tokio-rustls",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -6150,6 +6573,48 @@ dependencies = [
  "serde_json",
  "thiserror",
  "tokio",
+]
+
+[[package]]
+name = "revm"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f293f351c4c203d321744e54ed7eed3d2b6eef4c140228910dde3ac9a5ea8031"
+dependencies = [
+ "auto_impl",
+ "revm-interpreter",
+ "revm-precompile",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "revm-interpreter"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a53980a26f9b5a66d13511c35074d4b53631e157850a1d7cf1af4efc2c2b72c9"
+dependencies = [
+ "derive_more",
+ "enumn",
+ "revm-primitives",
+ "serde",
+ "sha3",
+]
+
+[[package]]
+name = "revm-precompile"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41320af3bd6a65153d38eb1d3638ba89104cc9513c7feedb2d8510e8307dab29"
+dependencies = [
+ "k256",
+ "num",
+ "once_cell",
+ "revm-primitives",
+ "ripemd",
+ "sha2 0.10.7",
+ "sha3",
+ "substrate-bn",
 ]
 
 [[package]]
@@ -6280,9 +6745,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.37.22"
+version = "0.37.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8818fa822adcc98b18fedbb3632a6a33213c070556b5aa7c4c8cc21cff565c4c"
+checksum = "4d69718bf81c6127a49dc64e44a742e8bb9213c0ff8869a22c308f84c1d4ab06"
 dependencies = [
  "bitflags 1.3.2",
  "errno",
@@ -6294,9 +6759,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.2"
+version = "0.38.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aabcb0461ebd01d6b79945797c27f8529082226cb630a9865a71870ff63532a4"
+checksum = "ac5ffa1efe7548069688cd7028f32591853cd7b5b756d41bcffd2353e4fc75b4"
 dependencies = [
  "bitflags 2.3.3",
  "errno",
@@ -6307,25 +6772,13 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.20.8"
+version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fff78fc74d175294f4e83b28343315ffcfb114b156f0185e9741cb5570f50e2f"
+checksum = "b19faa85ecb5197342b54f987b142fb3e30d0c90da40f80ef4fa9a726e6676ed"
 dependencies = [
  "log",
  "ring",
- "sct",
- "webpki",
-]
-
-[[package]]
-name = "rustls"
-version = "0.21.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e32ca28af694bc1bbf399c33a516dbdf1c90090b8ab23c2bc24f834aa2247f5f"
-dependencies = [
- "log",
- "ring",
- "rustls-webpki",
+ "rustls-webpki 0.101.1",
  "sct",
 ]
 
@@ -6361,10 +6814,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-webpki"
+version = "0.101.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15f36a6828982f422756984e47912a7a51dcbc2a197aa791158f8ca61cd8204e"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc31bd9b61a32c31f9650d18add92aa83a49ba979c143eefd27fe7177b05bd5f"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb3dcc6e454c328bb824492db107ab7c0ae8fcffe4ad210136ef014458c1bc4f"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "ryu"
@@ -6469,9 +6944,8 @@ dependencies = [
 
 [[package]]
 name = "scarb"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a3f158fb14ee5027aaa3db544ff774ae84f7c0da868045a5cab600c24d6aa7f"
+version = "0.5.1"
+source = "git+https://github.com/software-mansion/scarb#775538b91f4a7f877e97871080f503d9978fb80a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6512,7 +6986,7 @@ dependencies = [
  "smol_str",
  "thiserror",
  "tokio",
- "toml 0.7.5",
+ "toml 0.7.6",
  "toml_edit",
  "tracing",
  "tracing-futures",
@@ -6529,8 +7003,7 @@ dependencies = [
 [[package]]
 name = "scarb-metadata"
 version = "1.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26ba10c59bd4ebde82de954e3a3d6d503eb17bd634106ef144af1356b28b8f0f"
+source = "git+https://github.com/software-mansion/scarb#775538b91f4a7f877e97871080f503d9978fb80a"
 dependencies = [
  "camino",
  "clap",
@@ -6682,27 +7155,27 @@ checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
 
 [[package]]
 name = "serde"
-version = "1.0.166"
+version = "1.0.167"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d01b7404f9d441d3ad40e6a636a7782c377d2abdbe4fa2440e2edcc2f4f10db8"
+checksum = "7daf513456463b42aa1d94cff7e0c24d682b429f020b9afa4f5ba5c40a22b237"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_bytes"
-version = "0.11.10"
+version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3c5113243e4a3a1c96587342d067f3e6b0f50790b6cf40d2868eb647a3eef0e"
+checksum = "5a16be4fe5320ade08736447e3198294a5ea9a6d44dde6f35f0a5e06859c427a"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.166"
+version = "1.0.167"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dd83d6dde2b6b2d466e14d9d1acce8816dedee94f735eac6395808b3483c6d6"
+checksum = "b69b106b68bc8054f0e974e70d19984040f8a5cf9215ca82626ea4853f82c4b9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6722,9 +7195,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.99"
+version = "1.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46266871c240a00b8f503b877622fe33430b3c7d963bdc0f2adc511e54a1eae3"
+checksum = "0f1e14e89be7aa4c4b78bdbdc9eb5bf8517829a600ae8eaa39a6e1d960b5185c"
 dependencies = [
  "indexmap 2.0.0",
  "itoa",
@@ -6897,6 +7370,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "signal-hook-mio"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29ad2e15f37ec9a6cc544097b78a1ec90001e9f71b81338ca39f430adaca99af"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6932,9 +7416,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
+checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
 
 [[package]]
 name = "smol_str"
@@ -7008,7 +7492,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec63571489873d4506683915840eeb1bb16b3198ee4894cc6f2fe3013d505e56"
 dependencies = [
  "ndarray",
- "num-complex",
+ "num-complex 0.2.4",
  "num-traits 0.1.43",
 ]
 
@@ -7169,9 +7653,9 @@ dependencies = [
 
 [[package]]
 name = "starknet-providers"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "759f577c787ec9ae75daa591ece0150f7e655fa9f73c58152ce267cd8e5db068"
+checksum = "4554a49009d0a9414f6958edaaa337bc03a7ac5a8630c5162ab9cd5a417c6b1d"
 dependencies = [
  "async-trait",
  "auto_impl",
@@ -7289,6 +7773,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "substrate-bn"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b5bbfa79abbae15dd642ea8176a21a635ff3c00059961d1ea27ad04e5b441c"
+dependencies = [
+ "byteorder",
+ "crunchy",
+ "lazy_static",
+ "rand 0.8.5",
+ "rustc-hex",
+]
+
+[[package]]
 name = "subtle"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7374,7 +7871,7 @@ dependencies = [
  "cfg-if",
  "fastrand 1.9.0",
  "redox_syscall 0.3.5",
- "rustix 0.37.22",
+ "rustix 0.37.23",
  "windows-sys 0.48.0",
 ]
 
@@ -7399,6 +7896,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "terminal_size"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e6bf6f19e9f8ed8d4048dc22981458ebcf406d67e94cd422e5ecd73d63b3237"
+dependencies = [
+ "rustix 0.37.23",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "termtree"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7406,18 +7913,18 @@ checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 
 [[package]]
 name = "thiserror"
-version = "1.0.40"
+version = "1.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac"
+checksum = "a35fc5b8971143ca348fa6df4f024d4d55264f3468c71ad1c2f365b0a4d58c42"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.40"
+version = "1.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
+checksum = "463fe12d7993d3b327787537ce8dd4dfa058de32fc2b195ef3cde03dc4771e8f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7550,22 +8057,11 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.23.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c43ee83903113e03984cb9e5cebe6c04a5116269e900e3ddba8f068a62adda59"
-dependencies = [
- "rustls 0.20.8",
- "tokio",
- "webpki",
-]
-
-[[package]]
-name = "tokio-rustls"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
 dependencies = [
- "rustls 0.21.2",
+ "rustls",
  "tokio",
 ]
 
@@ -7588,9 +8084,9 @@ checksum = "ec509ac96e9a0c43427c74f003127d953a265737636129424288d27cb5c4b12c"
 dependencies = [
  "futures-util",
  "log",
- "rustls 0.21.2",
+ "rustls",
  "tokio",
- "tokio-rustls 0.24.1",
+ "tokio-rustls",
  "tungstenite",
  "webpki-roots 0.23.1",
 ]
@@ -7621,9 +8117,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ebafdf5ad1220cb59e7d17cf4d2c72015297b75b19a10472f99b89225089240"
+checksum = "c17e963a819c331dcacd7ab957d80bc2b9a9c1e71c804826d2f283dd65306542"
 dependencies = [
  "indexmap 2.0.0",
  "serde",
@@ -7643,9 +8139,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.19.11"
+version = "0.19.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "266f016b7f039eec8a1a80dfe6156b633d208b9fccca5e4db1d6775b0c4e34a7"
+checksum = "c500344a19072298cd05a7224b3c0c629348b78692bf48466c5238656e315a78"
 dependencies = [
  "indexmap 2.0.0",
  "serde",
@@ -7819,7 +8315,7 @@ dependencies = [
  "httparse",
  "log",
  "rand 0.8.5",
- "rustls 0.21.2",
+ "rustls",
  "sha1",
  "thiserror",
  "url",
@@ -7864,6 +8360,12 @@ checksum = "794a32261a1f5eb6a4462c81b59cec87b5c27d5deea7dd1ac8fc781c41d226db"
 dependencies = [
  "arrayvec",
 ]
+
+[[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "uncased"
@@ -8005,6 +8507,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
+name = "wait-timeout"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "waker-fn"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8142,7 +8653,7 @@ version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b03058f88386e5ff5310d9111d53f48b17d732b401aeb83a8d5190f2ac459338"
 dependencies = [
- "rustls-webpki",
+ "rustls-webpki 0.100.1",
 ]
 
 [[package]]
@@ -8330,9 +8841,9 @@ checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
 
 [[package]]
 name = "winnow"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca0ace3845f0d96209f0375e6d367e3eb87eb65d27d445bdc9f1843a26f39448"
+checksum = "a9482fe6ceabdf32f3966bfdd350ba69256a97c30253dc616fe0005af24f164e"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ readme = "./README.md"
 license = "MIT"
 
 [workspace.dependencies]
+ethers = "2.0"  
 starknet = "0.4.0"
 starknet-crypto = "0.5.1"
 reth-rpc-api = { git = "https://github.com/paradigmxyz/reth.git", rev = "fb710e5" }
@@ -30,12 +31,14 @@ async-trait = "0.1.58"
 jsonrpsee = { version = "0.18.2", features = ["full"] }
 lazy_static = "1.4.0"
 dotenv = "0.15.0"  
+foundry-config = { git = "https://github.com/foundry-rs/foundry", branch = "master" }
+forge = { git = "https://github.com/foundry-rs/foundry", branch = "master" }  
 
 
 # In order to use dojo-test-utils, we need to explicitly declare the same patches as them in our Cargo.toml
 # Otherwise, underlying dependencies of dojo will not be patched and we will get a compilation error
 # see https://github.com/dojoengine/dojo/issues/563
-dojo-test-utils = { git = 'https://github.com/dojoengine/dojo', rev = "24e8a78" }
+dojo-test-utils = { git = "https://github.com/jobez/dojo", branch = "custom-steps-and-get-block-potential-fix"  }
 [patch.crates-io]
 cairo-felt = { git = "https://github.com/dojoengine/cairo-rs.git", rev = "9edddbc" }
 cairo-vm = { git = "https://github.com/dojoengine/cairo-rs.git", rev = "9edddbc" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,8 @@ forge = { git = "https://github.com/foundry-rs/foundry", branch = "master" }
 # see https://github.com/dojoengine/dojo/issues/563
 dojo-test-utils = { git = "https://github.com/jobez/dojo", branch = "custom-steps-and-get-block-potential-fix"  }
 [patch.crates-io]
+# patched for quantity U256 responses <https://github.com/recmo/uint/issues/224>
+ruint = { git = "https://github.com/paradigmxyz/uint" }  
 cairo-felt = { git = "https://github.com/dojoengine/cairo-rs.git", rev = "9edddbc" }
 cairo-vm = { git = "https://github.com/dojoengine/cairo-rs.git", rev = "9edddbc" }
 

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -37,8 +37,8 @@ lazy_static = "1.4.0"
 
 dotenv = { workspace = true }  
 bytes = "1"  
-ethers = "2.0"
-foundry-config = { git = "https://github.com/foundry-rs/foundry", branch = "master" }  
+ethers = { workspace = true }
+foundry-config = { workspace = true }
 
 [dev-dependencies]
 dojo-test-utils = { workspace = true }

--- a/crates/core/src/test_utils/deploy_helpers.rs
+++ b/crates/core/src/test_utils/deploy_helpers.rs
@@ -3,7 +3,7 @@ use std::fs;
 use std::sync::Arc;
 
 use bytes::BytesMut;
-use dojo_test_utils::sequencer::TestSequencer;
+use dojo_test_utils::sequencer::{Environment, SequencerConfig, StarknetConfig, TestSequencer};
 use dotenv::dotenv;
 use ethers::abi::{Abi, Tokenize};
 use ethers::signers::{LocalWallet as EthersLocalWallet, Signer};
@@ -534,6 +534,45 @@ impl DeployedKakarot {
         .await
         .ok_or_else(|| "Evm contract deployment failed.".into())
     }
+}
+
+/// Returns a `StarknetConfig` instance customized for "Kakarot".
+///
+/// This function generates a `StarknetConfig` instance with `allow_zero_max_fee` set to `true`
+/// and a custom `Environment` object with its `chain_id` set to "SN_GOERLI".
+/// It also sets `invoke_max_steps` and `validate_max_steps` to `2**24` to facilitate
+/// computations associated with the "Kakarot" environment.
+/// Any other configuration fields in `StarknetConfig` and `Environment` are filled with default
+/// values.
+///
+/// This function is intended to provide a convenient way to obtain a Starknet configuration
+/// specifically tailored for testing or running "Kakarot"-centric applications.
+pub fn get_kakarot_starknet_config() -> StarknetConfig {
+    let kakarot_steps = 2u32.pow(24);
+    StarknetConfig {
+        allow_zero_max_fee: true,
+        env: Environment {
+            chain_id: "SN_GOERLI".into(),
+            invoke_max_steps: kakarot_steps,
+            validate_max_steps: kakarot_steps,
+            ..Default::default()
+        },
+        ..Default::default()
+    }
+}
+
+/// Constructs a test sequencer with the Starknet configuration tailored for "Kakarot".
+///
+/// This function initializes a `TestSequencer` instance with the default `SequencerConfig`
+/// and a custom `StarknetConfig` obtained from the `get_kakarot_starknet_config()` function.
+/// The custom `StarknetConfig` sets the chain_id to "SN_GOERLI" and both the `invoke_max_steps`
+/// and `validate_max_steps` to `2**24`. It also sets `allow_zero_max_fee` to true in
+/// `StarknetConfig`. This setup is aimed to provide an appropriate environment for testing
+/// "Kakarot" based applications.
+///
+/// Returns a `TestSequencer` configured for "Kakarot".
+pub async fn construct_kakarot_test_sequencer() -> TestSequencer {
+    TestSequencer::start(SequencerConfig::default(), get_kakarot_starknet_config()).await
 }
 
 /// Asynchronously deploys a Kakarot system to the StarkNet network and returns the

--- a/crates/core/src/test_utils/deploy_helpers.rs
+++ b/crates/core/src/test_utils/deploy_helpers.rs
@@ -536,7 +536,7 @@ impl DeployedKakarot {
     }
 }
 
-/// Returns a `StarknetConfig` instance customized for "Kakarot".
+/// Returns a `StarknetConfig` instance customized for Kakarot.
 ///
 /// This function generates a `StarknetConfig` instance with `allow_zero_max_fee` set to `true`
 /// and a custom `Environment` object with its `chain_id` set to "SN_GOERLI".
@@ -561,7 +561,7 @@ pub fn get_kakarot_starknet_config() -> StarknetConfig {
     }
 }
 
-/// Constructs a test sequencer with the Starknet configuration tailored for "Kakarot".
+/// Constructs a test sequencer with the Starknet configuration tailored for Kakarot.
 ///
 /// This function initializes a `TestSequencer` instance with the default `SequencerConfig`
 /// and a custom `StarknetConfig` obtained from the `get_kakarot_starknet_config()` function.

--- a/crates/core/tests/client.rs
+++ b/crates/core/tests/client.rs
@@ -3,7 +3,6 @@ mod tests {
 
     use std::str::FromStr;
 
-    use dojo_test_utils::sequencer::TestSequencer;
     use ethers::types::Address as EthersAddress;
     use kakarot_rpc_core::client::api::{KakarotEthApi, KakarotStarknetApi};
     use kakarot_rpc_core::client::config::StarknetConfig;
@@ -16,7 +15,9 @@ mod tests {
     use kakarot_rpc_core::models::felt::Felt252Wrapper;
     use kakarot_rpc_core::models::ConversionError;
     use kakarot_rpc_core::test_utils::constants::EOA_WALLET;
-    use kakarot_rpc_core::test_utils::deploy_helpers::{create_raw_ethereum_tx, deploy_kakarot_system};
+    use kakarot_rpc_core::test_utils::deploy_helpers::{
+        construct_kakarot_test_sequencer, create_raw_ethereum_tx, deploy_kakarot_system,
+    };
     use reth_primitives::{Address, BlockId, BlockNumberOrTag, Bytes, H256, U256};
     use reth_rpc_types::Log;
     use starknet::core::types::{BlockId as StarknetBlockId, BlockTag, Event, FieldElement};
@@ -26,7 +27,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_rpc_should_not_raise_when_eoa_not_deployed() {
-        let starknet_test_sequencer = TestSequencer::start().await;
+        let starknet_test_sequencer = construct_kakarot_test_sequencer().await;
 
         let expected_funded_amount = FieldElement::from_dec_str("1000000000000000000").unwrap();
 
@@ -51,7 +52,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_counter() {
-        let starknet_test_sequencer = TestSequencer::start().await;
+        let starknet_test_sequencer = construct_kakarot_test_sequencer().await;
 
         let expected_funded_amount = FieldElement::from_dec_str("10000000000000000000").unwrap();
 
@@ -129,8 +130,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_plain_opcodes() {
-        // initial setup of PlainOpcodes to test we can deploy contracts w/ constructor arguments
-        let starknet_test_sequencer = TestSequencer::start().await;
+        let starknet_test_sequencer = construct_kakarot_test_sequencer().await;
 
         let expected_funded_amount = FieldElement::from_dec_str("1000000000000000000").unwrap();
 

--- a/crates/eth-rpc/Cargo.toml
+++ b/crates/eth-rpc/Cargo.toml
@@ -37,6 +37,12 @@ tracing = "0.1.34"
 tracing-subscriber = { version = "0.3.3", features = ["env-filter"] }
 lazy_static = { workspace = true }
 
+[dev-dependencies]
+foundry-config = { workspace = true }
+forge = { workspace = true }    
+dojo-test-utils = { workspace = true }
+ethers = { workspace = true } 
+  
 [dev-dependencies.cargo-husky]
 version = "1.5.0"
 default-features = false

--- a/crates/eth-rpc/tests/utils.rs
+++ b/crates/eth-rpc/tests/utils.rs
@@ -1,10 +1,20 @@
+use std::future::Future;
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use dojo_test_utils::sequencer::TestSequencer;
+use jsonrpsee::server::ServerHandle;
+use kakarot_rpc::config::RPCConfig;
 use kakarot_rpc::eth_rpc::KakarotEthRpc;
+use kakarot_rpc::run_server;
 use kakarot_rpc_core::client::config::{JsonRpcClientBuilder, StarknetConfig};
 use kakarot_rpc_core::client::KakarotClient;
 use kakarot_rpc_core::mock::wiremock_utils::setup_wiremock;
+use kakarot_rpc_core::test_utils::constants::EOA_WALLET;
+use kakarot_rpc_core::test_utils::deploy_helpers::{construct_kakarot_test_sequencer, deploy_kakarot_system};
 use starknet::core::types::FieldElement;
-use starknet::providers::jsonrpc::HttpTransport;
-use starknet::providers::JsonRpcClient;
+use starknet::providers::jsonrpc::{HttpTransport, HttpTransport as StarknetHttpTransport};
+use starknet::providers::{JsonRpcClient, JsonRpcClient as StarknetJsonRpcClient};
 
 /// Run wiremock to fake starknet rpc and then run our own `kakarot_rpc_server`.
 ///
@@ -44,4 +54,98 @@ pub async fn setup_kakarot_eth_rpc() -> KakarotEthRpc<JsonRpcClient<HttpTranspor
     let kakarot_client = KakarotClient::new(config, provider);
 
     KakarotEthRpc::new(Box::new(kakarot_client))
+}
+
+pub async fn setup_kakarot_integration(starknet_test_sequencer: &Arc<TestSequencer>) -> (SocketAddr, ServerHandle) {
+    // SUMMON THE STARKNET TEST SEQUENCER
+
+    let expected_funded_amount = FieldElement::from_dec_str("1000000000000000000").unwrap();
+
+    // UNLEASH THE MIGHTY KAKAROT
+    let deployed_kakarot =
+        deploy_kakarot_system(starknet_test_sequencer, EOA_WALLET.clone(), expected_funded_amount).await;
+
+    // INITIATE THE ALMIGHTY KAKAROT CLIENT
+    let kakarot_client = KakarotClient::new(
+        StarknetConfig::new(
+            starknet_test_sequencer.url().as_ref().to_string(),
+            deployed_kakarot.kakarot,
+            deployed_kakarot.kakarot_proxy,
+        ),
+        StarknetJsonRpcClient::new(StarknetHttpTransport::new(starknet_test_sequencer.url())),
+    );
+
+    let rpc_config = RPCConfig::from_env().expect("config not found");
+
+    // AND NOW THE RPC SERVER
+    let (server_addr, server_handle) = run_server(Box::new(kakarot_client), rpc_config).await.unwrap();
+
+    (server_addr, server_handle)
+}
+
+/// Asynchronously runs a Kakarot test using the provided client code.
+///
+/// This function creates a Starknet test sequencer, sets up a Kakarot RPC server, and then runs the
+/// client code with the server's port number as an argument. It then spawns two tasks: one to run
+/// the server until it's stopped, and one to run the client code. The server and client code are
+/// run concurrently.
+///
+/// The function panics if the server task finishes before the client task. If the client task
+/// returns an error, that error is propagated as a panic.
+///
+/// # Arguments
+///
+/// * `client_code` - A closure which takes a port number (u16) and returns a `Future` that yields
+///   `()`. This is the code to be run as the client for the test. The future must be `'static` and
+///   `Send` to allow it to be run across threads.
+///
+/// # Type Parameters
+///
+/// * `F`: The type of the closure `client_code`.
+/// * `Fut`: The type of the future returned by `client_code`.
+///
+/// # Panics
+///
+/// Panics if the server task finishes before the client task, or if the client task returns an
+/// error.
+///
+/// # Returns
+///
+/// This function is `async` and does not return a value. It should be `await`ed.
+pub async fn run_kakarot_integration<F, Fut>(client_code: F)
+where
+    F: FnOnce(u16) -> Fut,
+    Fut: Future<Output = ()> + Send + 'static,
+{
+    let starknet_test_sequencer = Arc::new(construct_kakarot_test_sequencer().await);
+
+    let (server_addr, server_handle) = setup_kakarot_integration(&starknet_test_sequencer).await;
+
+    let client_code = client_code(server_addr.port());
+
+    // without this extra touch, the starknet provider thread willl complete before
+    // our client task can make its necessary interaction with the kakarot rpc
+    let starknet_test_sequencer_clone = Arc::clone(&starknet_test_sequencer);
+    let server_task = tokio::spawn(async move {
+        let _ = starknet_test_sequencer_clone;
+        server_handle.stopped().await
+    });
+
+    let client_task = tokio::spawn(client_code);
+
+    // Wait for both the server and client to finish.
+    tokio::select! {
+        _ = server_task => {
+            panic!("Server task finished first (this shouldn't happen).");
+        }
+        result = client_task => {
+
+            if let Err(e) = result {
+                std::panic::resume_unwind(e.into_panic())
+            } else {
+                println!("Client task finished, proceeding to shut down server.");
+            }
+
+        }
+    };
 }


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

Time spent on this PR:

Resolves: #253 

# Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Testing

# What is the new behavior?

`run_kakarot_integration` tales a callback that has the rpc port as argument

# Does this introduce a breaking change?

- [ ] Yes
- [X] No

# Additional info

I hit a blocker using forge, will revisit when the types are lined up. I recreated the bug with the ethers client as an initial first test, will iterate a better one
