### PR TITLE
consolidated flow of building kakarot and deploy and start rpc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,16 @@
 HURL_FILES = $(shell find ./rpc-call-examples/ -name '*.hurl')
 
+NETWORK?=katana
+
 pull-kakarot: .gitmodules 
 	git submodule update --init --recursive
 	cd lib/kakarot && make setup
 
 build-kakarot: setup 
 	cd lib/kakarot && make build && make build-sol
+
+deploy-kakarot:
+	cd lib/kakarot && STARKNET_NETWORK=$(NETWORK) make deploy
 
 setup: pull-kakarot build-kakarot
 
@@ -20,6 +25,9 @@ build:
 # run
 run: 
 	source .env && RUST_LOG=debug cargo run -p kakarot-rpc
+
+run-dev: deploy-kakarot
+	source .env && KAKAROT_ADDRESS=$(shell jq -r '.kakarot.address' ./lib/kakarot/deployments/$(NETWORK)/deployments.json) RUST_LOG=debug cargo run -p kakarot-rpc
 
 #run-release
 run-release:


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

Time spent on this PR:

Resolves: #<Issue number>

# Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Testing

# What is the new behavior?

`make run-dev NETWORK=katana` will

- build kakarot evm
- deploy it to the katana network (assumed to be running)
- start kakarot-rpc with the correct kakarot evm address of the resultant deploy

# Does this introduce a breaking change?

- [ ] Yes
- [X] No
