### PR TITLE
Fix getCode should not raise when contract doesn't exist

### DIFF
--- a/crates/core/src/client/mod.rs
+++ b/crates/core/src/client/mod.rs
@@ -113,8 +113,6 @@ impl<P: Provider + Send + Sync> KakarotEthApi<P> for KakarotClient<P> {
             calldata: vec![],
         };
 
-        dbg!(&request);
-
         // Make the function call to get the contract bytecode
         let contract_bytecode =
             self.starknet_provider.call(request, starknet_block_id).await.or_else(|err| match err {


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

Time spent on this PR: 0.3

Resolves: #277

# Pull Request type

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Testing

# What is the new behavior?

When using the RPC with madara, eth_getCode doesn't raise when the queried contract doesn't exist.

# Does this introduce a breaking change?

- [ ] Yes
- [x] No
