### PR TITLE
Exploration forge cli against katana branch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,6 +171,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bddcadddf5e9015d310179a59bb28c4d4b9920ad0f11e8e14dbadf654890c9a6"
 
 [[package]]
+name = "ariadne"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "367fd0ad87307588d087544707bc5fbf4805ded96c7db922b70d368fa1cb5702"
+dependencies = [
+ "unicode-width",
+ "yansi",
+]
+
+[[package]]
 name = "ark-ec"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1365,6 +1375,9 @@ dependencies = [
  "anstyle",
  "clap_lex",
  "strsim",
+ "terminal_size",
+ "unicase",
+ "unicode-width",
 ]
 
 [[package]]
@@ -1584,8 +1597,7 @@ dependencies = [
 [[package]]
 name = "create-output-dir"
 version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f163b5f0a28dc76f9c7d71a337a28aa36a6e77d0df92ca33d6121561ca622347"
+source = "git+https://github.com/software-mansion/scarb#775538b91f4a7f877e97871080f503d9978fb80a"
 dependencies = [
  "anyhow",
  "core-foundation",
@@ -1658,6 +1670,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a22b2d63d4d1dc0b7f1b6b2747dd0088008a9be28b6ddf0b1e7d335e3037294"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "crossterm"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a84cda67535339806297f1b331d6dd6320470d2a0fe65381e79ee9e156dd3d13"
+dependencies = [
+ "bitflags 1.3.2",
+ "crossterm_winapi",
+ "libc",
+ "mio",
+ "parking_lot 0.12.1",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]
@@ -1976,7 +2013,7 @@ checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 [[package]]
 name = "dojo-lang"
 version = "0.1.0"
-source = "git+https://github.com/dojoengine/dojo?rev=24e8a78#24e8a781e1fd9e94528835c2000202afc5f91edf"
+source = "git+https://github.com/jobez/dojo?branch=custom-steps-and-get-block-potential-fix#2e40087f7cd0b5dd59d3e7ad4e80febba8fd71c4"
 dependencies = [
  "anyhow",
  "assert_fs",
@@ -2015,7 +2052,7 @@ dependencies = [
 [[package]]
 name = "dojo-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/dojoengine/dojo?rev=24e8a78#24e8a781e1fd9e94528835c2000202afc5f91edf"
+source = "git+https://github.com/jobez/dojo?branch=custom-steps-and-get-block-potential-fix#2e40087f7cd0b5dd59d3e7ad4e80febba8fd71c4"
 dependencies = [
  "anyhow",
  "assert_fs",
@@ -2045,7 +2082,7 @@ dependencies = [
 [[package]]
 name = "dojo-types"
 version = "0.1.0"
-source = "git+https://github.com/dojoengine/dojo?rev=24e8a78#24e8a781e1fd9e94528835c2000202afc5f91edf"
+source = "git+https://github.com/jobez/dojo?branch=custom-steps-and-get-block-potential-fix#2e40087f7cd0b5dd59d3e7ad4e80febba8fd71c4"
 dependencies = [
  "serde",
  "starknet",
@@ -2054,7 +2091,7 @@ dependencies = [
 [[package]]
 name = "dojo-world"
 version = "0.1.0"
-source = "git+https://github.com/dojoengine/dojo?rev=24e8a78#24e8a781e1fd9e94528835c2000202afc5f91edf"
+source = "git+https://github.com/jobez/dojo?branch=custom-steps-and-get-block-potential-fix#2e40087f7cd0b5dd59d3e7ad4e80febba8fd71c4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2064,6 +2101,7 @@ dependencies = [
  "camino",
  "convert_case 0.6.0",
  "dojo-types",
+ "futures",
  "reqwest",
  "serde",
  "serde_json",
@@ -2071,6 +2109,7 @@ dependencies = [
  "smol_str",
  "starknet",
  "thiserror",
+ "tokio",
  "tracing",
  "url",
 ]
@@ -2314,14 +2353,29 @@ version = "2.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a58ce802c65cf3d0756dee5a61094a92cde53c1583b246e9ee5b37226c7fc15"
 dependencies = [
- "ethers-addressbook",
- "ethers-contract",
+ "ethers-addressbook 2.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ethers-contract 2.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "ethers-core 2.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "ethers-etherscan 2.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "ethers-middleware",
- "ethers-providers",
- "ethers-signers",
+ "ethers-middleware 2.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ethers-providers 2.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ethers-signers 2.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "ethers-solc 2.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "ethers"
+version = "2.0.7"
+source = "git+https://github.com/gakonst/ethers-rs#311086466871204c3965065b8c81e47418261412"
+dependencies = [
+ "ethers-addressbook 2.0.7 (git+https://github.com/gakonst/ethers-rs)",
+ "ethers-contract 2.0.7 (git+https://github.com/gakonst/ethers-rs)",
+ "ethers-core 2.0.7 (git+https://github.com/gakonst/ethers-rs)",
+ "ethers-etherscan 2.0.7 (git+https://github.com/gakonst/ethers-rs)",
+ "ethers-middleware 2.0.7 (git+https://github.com/gakonst/ethers-rs)",
+ "ethers-providers 2.0.7 (git+https://github.com/gakonst/ethers-rs)",
+ "ethers-signers 2.0.7 (git+https://github.com/gakonst/ethers-rs)",
+ "ethers-solc 2.0.7 (git+https://github.com/gakonst/ethers-rs)",
 ]
 
 [[package]]
@@ -2337,15 +2391,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "ethers-addressbook"
+version = "2.0.7"
+source = "git+https://github.com/gakonst/ethers-rs#311086466871204c3965065b8c81e47418261412"
+dependencies = [
+ "ethers-core 2.0.7 (git+https://github.com/gakonst/ethers-rs)",
+ "once_cell",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "ethers-contract"
 version = "2.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e066a0d9cfc70c454672bf16bb433b0243427420076dc5b2f49c448fb5a10628"
 dependencies = [
- "ethers-contract-abigen",
- "ethers-contract-derive",
+ "ethers-contract-abigen 2.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ethers-contract-derive 2.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "ethers-core 2.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "ethers-providers",
+ "ethers-providers 2.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-util",
+ "hex",
+ "once_cell",
+ "pin-project",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
+name = "ethers-contract"
+version = "2.0.7"
+source = "git+https://github.com/gakonst/ethers-rs#311086466871204c3965065b8c81e47418261412"
+dependencies = [
+ "ethers-contract-abigen 2.0.7 (git+https://github.com/gakonst/ethers-rs)",
+ "ethers-contract-derive 2.0.7 (git+https://github.com/gakonst/ethers-rs)",
+ "ethers-core 2.0.7 (git+https://github.com/gakonst/ethers-rs)",
+ "ethers-providers 2.0.7 (git+https://github.com/gakonst/ethers-rs)",
+ "ethers-signers 2.0.7 (git+https://github.com/gakonst/ethers-rs)",
  "futures-util",
  "hex",
  "once_cell",
@@ -2386,13 +2470,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c3fb5adee25701c79ec58fcf2c63594cd8829bc9ad6037ff862d5a111101ed2"
 dependencies = [
  "Inflector",
- "ethers-contract-abigen",
+ "ethers-contract-abigen 2.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "ethers-core 2.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex",
  "proc-macro2",
  "quote",
  "serde_json",
  "syn 2.0.25",
+]
+
+[[package]]
+name = "ethers-contract-derive"
+version = "2.0.7"
+source = "git+https://github.com/gakonst/ethers-rs#311086466871204c3965065b8c81e47418261412"
+dependencies = [
+ "Inflector",
+ "ethers-contract-abigen 2.0.7 (git+https://github.com/gakonst/ethers-rs)",
+ "ethers-core 2.0.7 (git+https://github.com/gakonst/ethers-rs)",
+ "hex",
+ "proc-macro2",
+ "quote",
+ "serde_json",
+ "syn 2.0.23",
 ]
 
 [[package]]
@@ -2432,6 +2531,7 @@ source = "git+https://github.com/gakonst/ethers-rs#311086466871204c3965065b8c81e
 dependencies = [
  "arrayvec",
  "bytes",
+ "cargo_metadata",
  "chrono",
  "elliptic-curve",
  "ethabi",
@@ -2439,12 +2539,14 @@ dependencies = [
  "hex",
  "k256",
  "num_enum",
+ "once_cell",
  "open-fastrlp",
  "rand 0.8.5",
  "rlp",
  "serde",
  "serde_json",
  "strum 0.25.0",
+ "syn 2.0.23",
  "tempfile",
  "thiserror",
  "tiny-keccak",
@@ -2472,6 +2574,7 @@ version = "2.0.7"
 source = "git+https://github.com/gakonst/ethers-rs#311086466871204c3965065b8c81e47418261412"
 dependencies = [
  "ethers-core 2.0.7 (git+https://github.com/gakonst/ethers-rs)",
+ "ethers-solc 2.0.7 (git+https://github.com/gakonst/ethers-rs)",
  "reqwest",
  "semver",
  "serde",
@@ -2488,11 +2591,37 @@ checksum = "740f4a773c19dd6d6a68c8c2e0996c096488d38997d524e21dc612c55da3bd24"
 dependencies = [
  "async-trait",
  "auto_impl",
- "ethers-contract",
+ "ethers-contract 2.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "ethers-core 2.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "ethers-etherscan 2.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "ethers-providers",
- "ethers-signers",
+ "ethers-providers 2.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ethers-signers 2.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-channel",
+ "futures-locks",
+ "futures-util",
+ "instant",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "tracing-futures",
+ "url",
+]
+
+[[package]]
+name = "ethers-middleware"
+version = "2.0.7"
+source = "git+https://github.com/gakonst/ethers-rs#311086466871204c3965065b8c81e47418261412"
+dependencies = [
+ "async-trait",
+ "auto_impl",
+ "ethers-contract 2.0.7 (git+https://github.com/gakonst/ethers-rs)",
+ "ethers-core 2.0.7 (git+https://github.com/gakonst/ethers-rs)",
+ "ethers-etherscan 2.0.7 (git+https://github.com/gakonst/ethers-rs)",
+ "ethers-providers 2.0.7 (git+https://github.com/gakonst/ethers-rs)",
+ "ethers-signers 2.0.7 (git+https://github.com/gakonst/ethers-rs)",
  "futures-channel",
  "futures-locks",
  "futures-util",
@@ -2544,6 +2673,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "ethers-providers"
+version = "2.0.7"
+source = "git+https://github.com/gakonst/ethers-rs#311086466871204c3965065b8c81e47418261412"
+dependencies = [
+ "async-trait",
+ "auto_impl",
+ "base64 0.21.2",
+ "bytes",
+ "enr",
+ "ethers-core 2.0.7 (git+https://github.com/gakonst/ethers-rs)",
+ "futures-core",
+ "futures-timer",
+ "futures-util",
+ "hashers",
+ "hex",
+ "http",
+ "instant",
+ "once_cell",
+ "pin-project",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "tracing-futures",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "ws_stream_wasm",
+]
+
+[[package]]
 name = "ethers-signers"
 version = "2.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2555,6 +2718,24 @@ dependencies = [
  "elliptic-curve",
  "eth-keystore",
  "ethers-core 2.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hex",
+ "rand 0.8.5",
+ "sha2 0.10.7",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
+name = "ethers-signers"
+version = "2.0.7"
+source = "git+https://github.com/gakonst/ethers-rs#311086466871204c3965065b8c81e47418261412"
+dependencies = [
+ "async-trait",
+ "coins-bip32",
+ "coins-bip39",
+ "elliptic-curve",
+ "eth-keystore",
+ "ethers-core 2.0.7 (git+https://github.com/gakonst/ethers-rs)",
  "hex",
  "rand 0.8.5",
  "sha2 0.10.7",
@@ -2743,12 +2924,102 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
+name = "forge"
+version = "0.2.0"
+source = "git+https://github.com/foundry-rs/foundry?branch=master#c78a811a8af95fb1e029427583a07b2ca3a3fa51"
+dependencies = [
+ "comfy-table",
+ "ethers 2.0.7 (git+https://github.com/gakonst/ethers-rs)",
+ "eyre",
+ "foundry-common",
+ "foundry-config",
+ "foundry-evm",
+ "foundry-utils",
+ "glob",
+ "hex",
+ "once_cell",
+ "parking_lot 0.12.1",
+ "proptest",
+ "rayon",
+ "regex",
+ "rlp",
+ "semver",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+ "yansi",
+]
+
+[[package]]
+name = "forge-fmt"
+version = "0.2.0"
+source = "git+https://github.com/foundry-rs/foundry?branch=master#c78a811a8af95fb1e029427583a07b2ca3a3fa51"
+dependencies = [
+ "ariadne",
+ "ethers-core 2.0.7 (git+https://github.com/gakonst/ethers-rs)",
+ "foundry-config",
+ "itertools 0.10.5",
+ "semver",
+ "solang-parser",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a62bc1cf6f830c2ec14a513a9fb124d0a213a629668a4186f329db21fe045652"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "foundry-abi"
+version = "0.1.0"
+source = "git+https://github.com/foundry-rs/foundry?branch=master#c78a811a8af95fb1e029427583a07b2ca3a3fa51"
+dependencies = [
+ "ethers-contract 2.0.7 (git+https://github.com/gakonst/ethers-rs)",
+ "ethers-contract-abigen 2.0.7 (git+https://github.com/gakonst/ethers-rs)",
+ "ethers-core 2.0.7 (git+https://github.com/gakonst/ethers-rs)",
+ "ethers-providers 2.0.7 (git+https://github.com/gakonst/ethers-rs)",
+ "eyre",
+ "foundry-macros",
+ "syn 2.0.23",
+]
+
+[[package]]
+name = "foundry-common"
+version = "0.1.0"
+source = "git+https://github.com/foundry-rs/foundry?branch=master#c78a811a8af95fb1e029427583a07b2ca3a3fa51"
+dependencies = [
+ "auto_impl",
+ "clap",
+ "comfy-table",
+ "dunce",
+ "ethers-core 2.0.7 (git+https://github.com/gakonst/ethers-rs)",
+ "ethers-etherscan 2.0.7 (git+https://github.com/gakonst/ethers-rs)",
+ "ethers-middleware 2.0.7 (git+https://github.com/gakonst/ethers-rs)",
+ "ethers-providers 2.0.7 (git+https://github.com/gakonst/ethers-rs)",
+ "ethers-solc 2.0.7 (git+https://github.com/gakonst/ethers-rs)",
+ "eyre",
+ "foundry-config",
+ "foundry-macros",
+ "globset",
+ "is-terminal",
+ "once_cell",
+ "regex",
+ "reqwest",
+ "semver",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "thiserror",
+ "tracing",
+ "walkdir",
+ "yansi",
 ]
 
 [[package]]
@@ -2779,6 +3050,89 @@ dependencies = [
  "toml_edit",
  "tracing",
  "walkdir",
+]
+
+[[package]]
+name = "foundry-evm"
+version = "0.2.0"
+source = "git+https://github.com/foundry-rs/foundry?branch=master#c78a811a8af95fb1e029427583a07b2ca3a3fa51"
+dependencies = [
+ "auto_impl",
+ "bytes",
+ "ethers 2.0.7 (git+https://github.com/gakonst/ethers-rs)",
+ "eyre",
+ "foundry-abi",
+ "foundry-common",
+ "foundry-config",
+ "foundry-macros",
+ "foundry-utils",
+ "futures",
+ "hashbrown 0.13.2",
+ "hex",
+ "itertools 0.10.5",
+ "jsonpath_lib",
+ "once_cell",
+ "ordered-float",
+ "parking_lot 0.12.1",
+ "proptest",
+ "revm",
+ "semver",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "url",
+ "walkdir",
+ "yansi",
+]
+
+[[package]]
+name = "foundry-macros"
+version = "0.1.0"
+source = "git+https://github.com/foundry-rs/foundry?branch=master#c78a811a8af95fb1e029427583a07b2ca3a3fa51"
+dependencies = [
+ "ethers-core 2.0.7 (git+https://github.com/gakonst/ethers-rs)",
+ "foundry-macros-impl",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "foundry-macros-impl"
+version = "0.0.0"
+source = "git+https://github.com/foundry-rs/foundry?branch=master#c78a811a8af95fb1e029427583a07b2ca3a3fa51"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.23",
+]
+
+[[package]]
+name = "foundry-utils"
+version = "0.2.0"
+source = "git+https://github.com/foundry-rs/foundry?branch=master#c78a811a8af95fb1e029427583a07b2ca3a3fa51"
+dependencies = [
+ "ethers-addressbook 2.0.7 (git+https://github.com/gakonst/ethers-rs)",
+ "ethers-contract 2.0.7 (git+https://github.com/gakonst/ethers-rs)",
+ "ethers-core 2.0.7 (git+https://github.com/gakonst/ethers-rs)",
+ "ethers-etherscan 2.0.7 (git+https://github.com/gakonst/ethers-rs)",
+ "ethers-providers 2.0.7 (git+https://github.com/gakonst/ethers-rs)",
+ "ethers-solc 2.0.7 (git+https://github.com/gakonst/ethers-rs)",
+ "eyre",
+ "forge-fmt",
+ "futures",
+ "glob",
+ "hex",
+ "once_cell",
+ "rand 0.8.5",
+ "reqwest",
+ "rlp",
+ "rustc-hex",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -3950,14 +4304,15 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.23.2"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1788965e61b367cd03a62950836d5cd41560c3577d90e40e0819373194d1661c"
+checksum = "8d78e1e73ec14cf7375674f74d7dde185c8206fd9dea6fb6295e8a98098aaa97"
 dependencies = [
+ "futures-util",
  "http",
  "hyper",
  "log",
- "rustls 0.20.8",
+ "rustls",
  "rustls-native-certs",
  "tokio",
  "tokio-rustls 0.23.4",
@@ -4289,19 +4644,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonpath_lib"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaa63191d68230cccb81c5aa23abd53ed64d83337cacbb25a7b8c7979523774f"
+dependencies = [
+ "log",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "jsonrpsee"
 version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d291e3a5818a2384645fd9756362e6d89cf0541b0b916fa7702ea4a9833608e"
 dependencies = [
- "jsonrpsee-client-transport 0.16.2",
  "jsonrpsee-core 0.16.2",
- "jsonrpsee-http-client 0.16.2",
  "jsonrpsee-proc-macros 0.16.2",
  "jsonrpsee-server 0.16.2",
  "jsonrpsee-types 0.16.2",
- "jsonrpsee-wasm-client 0.16.2",
- "jsonrpsee-ws-client 0.16.2",
  "tracing",
 ]
 
@@ -4311,40 +4673,15 @@ version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1822d18e4384a5e79d94dc9e4d1239cfa9fad24e55b44d2efeff5b394c9fece4"
 dependencies = [
- "jsonrpsee-client-transport 0.18.2",
+ "jsonrpsee-client-transport",
  "jsonrpsee-core 0.18.2",
- "jsonrpsee-http-client 0.18.2",
+ "jsonrpsee-http-client",
  "jsonrpsee-proc-macros 0.18.2",
  "jsonrpsee-server 0.18.2",
  "jsonrpsee-types 0.18.2",
- "jsonrpsee-wasm-client 0.18.2",
- "jsonrpsee-ws-client 0.18.2",
+ "jsonrpsee-wasm-client",
+ "jsonrpsee-ws-client",
  "tracing",
-]
-
-[[package]]
-name = "jsonrpsee-client-transport"
-version = "0.16.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "965de52763f2004bc91ac5bcec504192440f0b568a5d621c59d9dbd6f886c3fb"
-dependencies = [
- "anyhow",
- "futures-channel",
- "futures-timer",
- "futures-util",
- "gloo-net",
- "http",
- "jsonrpsee-core 0.16.2",
- "jsonrpsee-types 0.16.2",
- "pin-project",
- "rustls-native-certs",
- "soketto",
- "thiserror",
- "tokio",
- "tokio-rustls 0.23.4",
- "tokio-util",
- "tracing",
- "webpki-roots 0.22.6",
 ]
 
 [[package]]
@@ -4363,7 +4700,7 @@ dependencies = [
  "soketto",
  "thiserror",
  "tokio",
- "tokio-rustls 0.24.1",
+ "tokio-rustls",
  "tokio-util",
  "tracing",
  "webpki-roots 0.23.1",
@@ -4377,11 +4714,9 @@ checksum = "a4e70b4439a751a5de7dd5ed55eacff78ebf4ffe0fc009cb1ebb11417f5b536b"
 dependencies = [
  "anyhow",
  "arrayvec",
- "async-lock",
  "async-trait",
  "beef",
  "futures-channel",
- "futures-timer",
  "futures-util",
  "globset",
  "hyper",
@@ -4395,7 +4730,6 @@ dependencies = [
  "thiserror",
  "tokio",
  "tracing",
- "wasm-bindgen-futures",
 ]
 
 [[package]]
@@ -4424,25 +4758,6 @@ dependencies = [
  "tokio-stream",
  "tracing",
  "wasm-bindgen-futures",
-]
-
-[[package]]
-name = "jsonrpsee-http-client"
-version = "0.16.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc345b0a43c6bc49b947ebeb936e886a419ee3d894421790c969cc56040542ad"
-dependencies = [
- "async-trait",
- "hyper",
- "hyper-rustls 0.23.2",
- "jsonrpsee-core 0.16.2",
- "jsonrpsee-types 0.16.2",
- "rustc-hash",
- "serde",
- "serde_json",
- "thiserror",
- "tokio",
- "tracing",
 ]
 
 [[package]]
@@ -4562,36 +4877,13 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-wasm-client"
-version = "0.16.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a77310456f43c6c89bcba1f6b2fc2a28300da7c341f320f5128f8c83cc63232d"
-dependencies = [
- "jsonrpsee-client-transport 0.16.2",
- "jsonrpsee-core 0.16.2",
- "jsonrpsee-types 0.16.2",
-]
-
-[[package]]
-name = "jsonrpsee-wasm-client"
 version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34e6ea7c6d862e60f8baebd946c037b70c6808a4e4e31e792a4029184e3ce13a"
 dependencies = [
- "jsonrpsee-client-transport 0.18.2",
+ "jsonrpsee-client-transport",
  "jsonrpsee-core 0.18.2",
  "jsonrpsee-types 0.18.2",
-]
-
-[[package]]
-name = "jsonrpsee-ws-client"
-version = "0.16.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b83daeecfc6517cfe210df24e570fb06213533dfb990318fae781f4c7119dd9"
-dependencies = [
- "http",
- "jsonrpsee-client-transport 0.16.2",
- "jsonrpsee-core 0.16.2",
- "jsonrpsee-types 0.16.2",
 ]
 
 [[package]]
@@ -4601,7 +4893,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a64b2589680ba1ad7863f279cd2d5083c1dc0a7c0ea959d22924553050f8ab9f"
 dependencies = [
  "http",
- "jsonrpsee-client-transport 0.18.2",
+ "jsonrpsee-client-transport",
  "jsonrpsee-core 0.18.2",
  "jsonrpsee-types 0.18.2",
 ]
@@ -4637,9 +4929,13 @@ dependencies = [
  "anyhow",
  "async-trait",
  "cargo-husky",
+ "dojo-test-utils",
  "dotenv",
  "env_logger 0.10.0",
+ "ethers 2.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "eyre",
+ "forge",
+ "foundry-config",
  "hex",
  "jsonrpsee 0.18.2",
  "kakarot_rpc_core",
@@ -4671,7 +4967,7 @@ dependencies = [
  "dojo-test-utils",
  "dotenv",
  "env_logger 0.10.0",
- "ethers",
+ "ethers 2.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "eyre",
  "foundry-config",
  "futures",
@@ -4700,10 +4996,11 @@ dependencies = [
 [[package]]
 name = "katana-core"
 version = "0.1.0"
-source = "git+https://github.com/dojoengine/dojo?rev=24e8a78#24e8a781e1fd9e94528835c2000202afc5f91edf"
+source = "git+https://github.com/jobez/dojo?branch=custom-steps-and-get-block-potential-fix#2e40087f7cd0b5dd59d3e7ad4e80febba8fd71c4"
 dependencies = [
  "anyhow",
  "async-trait",
+ "auto_impl",
  "blockifier",
  "cairo-lang-casm",
  "cairo-lang-starknet",
@@ -4724,7 +5021,7 @@ dependencies = [
 [[package]]
 name = "katana-rpc"
 version = "0.1.0"
-source = "git+https://github.com/dojoengine/dojo?rev=24e8a78#24e8a781e1fd9e94528835c2000202afc5f91edf"
+source = "git+https://github.com/jobez/dojo?branch=custom-steps-and-get-block-potential-fix#2e40087f7cd0b5dd59d3e7ad4e80febba8fd71c4"
 dependencies = [
  "anyhow",
  "blockifier",
@@ -4810,6 +5107,12 @@ name = "libc"
 version = "0.2.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
+
+[[package]]
+name = "libm"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7012b1bbb0719e1097c47611d3898568c546d597c2e74d66f6087edd5233ff4"
 
 [[package]]
 name = "libmimalloc-sys"
@@ -4999,6 +5302,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "927a765cd3fc26206e66b296465fa9d3e5ab003e651c1b3c060e7956d96b19d2"
 dependencies = [
  "libc",
+ "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.48.0",
 ]
@@ -5055,7 +5359,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac06db03ec2f46ee0ecdca1a1c34a99c0d188a0d83439b84bf0cb4b386e4ab09"
 dependencies = [
  "matrixmultiply",
- "num-complex",
+ "num-complex 0.2.4",
  "num-integer",
  "num-traits 0.2.15",
  "rawpointer",
@@ -5088,6 +5392,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43db66d1170d347f9a065114077f7dccb00c1b9478c89384490a3425279a4606"
+dependencies = [
+ "num-bigint",
+ "num-complex 0.4.3",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits 0.2.15",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5111,12 +5429,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-complex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02e0d21255c828d6f128a1e41534206671e8c3ea0c62f32291e808dc82cff17d"
+dependencies = [
+ "num-traits 0.2.15",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
 dependencies = [
  "autocfg",
+ "num-traits 0.2.15",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d03e6c028c5dc5cac6e2dec0efda81fc887605bb3d884578bb6d6bf7514e252"
+dependencies = [
+ "autocfg",
+ "num-integer",
  "num-traits 0.2.15",
 ]
 
@@ -5148,6 +5486,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-rational"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0638a1c9d0a3c0914158145bc76cff373a75a627e6ecbfb71cbe6f453a5a19b0"
+dependencies = [
+ "autocfg",
+ "num-bigint",
+ "num-integer",
+ "num-traits 0.2.15",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5163,6 +5513,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -5318,6 +5669,15 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "ordered-float"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fc2dbde8f8a79f2102cc474ceb0ad68e3b80b85289ea62389b60e66777e4213"
+dependencies = [
+ "num-traits 0.2.15",
+]
 
 [[package]]
 name = "os_pipe"
@@ -5799,6 +6159,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e35c06b98bf36aba164cc17cb25f7e232f5c4aeea73baa14b8a9f0d92dbfa65"
+dependencies = [
+ "bit-set",
+ "bitflags 1.3.2",
+ "byteorder",
+ "lazy_static",
+ "num-traits 0.2.15",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
+ "rand_xorshift",
+ "regex-syntax 0.6.29",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
 name = "quick-xml"
 version = "0.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5897,6 +6283,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 dependencies = [
  "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
+dependencies = [
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -6050,7 +6445,7 @@ dependencies = [
  "serde_urlencoded",
  "tokio",
  "tokio-native-tls",
- "tokio-rustls 0.24.1",
+ "tokio-rustls",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -6162,6 +6557,48 @@ dependencies = [
  "serde_json",
  "thiserror",
  "tokio",
+]
+
+[[package]]
+name = "revm"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f293f351c4c203d321744e54ed7eed3d2b6eef4c140228910dde3ac9a5ea8031"
+dependencies = [
+ "auto_impl",
+ "revm-interpreter",
+ "revm-precompile",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "revm-interpreter"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a53980a26f9b5a66d13511c35074d4b53631e157850a1d7cf1af4efc2c2b72c9"
+dependencies = [
+ "derive_more",
+ "enumn",
+ "revm-primitives",
+ "serde",
+ "sha3",
+]
+
+[[package]]
+name = "revm-precompile"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41320af3bd6a65153d38eb1d3638ba89104cc9513c7feedb2d8510e8307dab29"
+dependencies = [
+ "k256",
+ "num",
+ "once_cell",
+ "revm-primitives",
+ "ripemd",
+ "sha2 0.10.7",
+ "sha3",
+ "substrate-bn",
 ]
 
 [[package]]
@@ -6317,9 +6754,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.20.8"
+version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fff78fc74d175294f4e83b28343315ffcfb114b156f0185e9741cb5570f50e2f"
+checksum = "b19faa85ecb5197342b54f987b142fb3e30d0c90da40f80ef4fa9a726e6676ed"
 dependencies = [
  "log",
  "ring",
@@ -6385,6 +6822,18 @@ name = "rustversion"
 version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc31bd9b61a32c31f9650d18add92aa83a49ba979c143eefd27fe7177b05bd5f"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb3dcc6e454c328bb824492db107ab7c0ae8fcffe4ad210136ef014458c1bc4f"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "ryu"
@@ -6489,9 +6938,8 @@ dependencies = [
 
 [[package]]
 name = "scarb"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a3f158fb14ee5027aaa3db544ff774ae84f7c0da868045a5cab600c24d6aa7f"
+version = "0.5.1"
+source = "git+https://github.com/software-mansion/scarb#775538b91f4a7f877e97871080f503d9978fb80a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6549,8 +6997,7 @@ dependencies = [
 [[package]]
 name = "scarb-metadata"
 version = "1.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26ba10c59bd4ebde82de954e3a3d6d503eb17bd634106ef144af1356b28b8f0f"
+source = "git+https://github.com/software-mansion/scarb#775538b91f4a7f877e97871080f503d9978fb80a"
 dependencies = [
  "camino",
  "clap",
@@ -6917,6 +7364,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "signal-hook-mio"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29ad2e15f37ec9a6cc544097b78a1ec90001e9f71b81338ca39f430adaca99af"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7028,7 +7486,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec63571489873d4506683915840eeb1bb16b3198ee4894cc6f2fe3013d505e56"
 dependencies = [
  "ndarray",
- "num-complex",
+ "num-complex 0.2.4",
  "num-traits 0.1.43",
 ]
 
@@ -7309,6 +7767,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "substrate-bn"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b5bbfa79abbae15dd642ea8176a21a635ff3c00059961d1ea27ad04e5b441c"
+dependencies = [
+ "byteorder",
+ "crunchy",
+ "lazy_static",
+ "rand 0.8.5",
+ "rustc-hex",
+]
+
+[[package]]
 name = "subtle"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7416,6 +7887,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "terminal_size"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e6bf6f19e9f8ed8d4048dc22981458ebcf406d67e94cd422e5ecd73d63b3237"
+dependencies = [
+ "rustix 0.37.23",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -7570,17 +8051,6 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.23.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c43ee83903113e03984cb9e5cebe6c04a5116269e900e3ddba8f068a62adda59"
-dependencies = [
- "rustls 0.20.8",
- "tokio",
- "webpki",
-]
-
-[[package]]
-name = "tokio-rustls"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
@@ -7610,7 +8080,7 @@ dependencies = [
  "log",
  "rustls 0.21.3",
  "tokio",
- "tokio-rustls 0.24.1",
+ "tokio-rustls",
  "tungstenite",
  "webpki-roots 0.23.1",
 ]
@@ -7886,6 +8356,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "uncased"
 version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8023,6 +8499,15 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "waker-fn"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -177,7 +177,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "367fd0ad87307588d087544707bc5fbf4805ded96c7db922b70d368fa1cb5702"
 dependencies = [
  "unicode-width",
- "yansi",
+ "yansi 0.5.1",
 ]
 
 [[package]]
@@ -1532,9 +1532,9 @@ checksum = "32b13ea120a812beba79e34316b3942a857c86ec1593cb34f27bb28272ce2cca"
 
 [[package]]
 name = "const-oid"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6340df57935414636969091153f35f68d9f00bbc8fb4a9c6054706c213e6c6bc"
+checksum = "795bc6e66a8e340f075fcf6227e417a2dc976b92b91f3cdc778bb858778b6747"
 
 [[package]]
 name = "constant_time_eq"
@@ -2264,9 +2264,9 @@ dependencies = [
 
 [[package]]
 name = "equivalent"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88bffebc5d80432c9b140ee17875ff173a8ab62faad5b257da912bd2f6c1c0a1"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
@@ -2804,7 +2804,7 @@ dependencies = [
  "tokio",
  "tracing",
  "walkdir",
- "yansi",
+ "yansi 0.5.1",
 ]
 
 [[package]]
@@ -2837,7 +2837,7 @@ dependencies = [
  "tokio",
  "tracing",
  "walkdir",
- "yansi",
+ "yansi 0.5.1",
 ]
 
 [[package]]
@@ -2982,7 +2982,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "yansi",
+ "yansi 0.5.1",
 ]
 
 [[package]]
@@ -3052,7 +3052,7 @@ dependencies = [
  "thiserror",
  "tracing",
  "walkdir",
- "yansi",
+ "yansi 0.5.1",
 ]
 
 [[package]]
@@ -3117,7 +3117,7 @@ dependencies = [
  "tracing",
  "url",
  "walkdir",
- "yansi",
+ "yansi 0.5.1",
 ]
 
 [[package]]
@@ -5863,20 +5863,20 @@ dependencies = [
 
 [[package]]
 name = "pear"
-version = "0.2.4"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ec95680a7087503575284e5063e14b694b7a9c0b065e5dceec661e0497127e8"
+checksum = "61a386cd715229d399604b50d1361683fe687066f42d56f54be995bc6868f71c"
 dependencies = [
  "inlinable_string",
  "pear_codegen",
- "yansi",
+ "yansi 1.0.0-rc",
 ]
 
 [[package]]
 name = "pear_codegen"
-version = "0.2.4"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9661a3a53f93f09f2ea882018e4d7c88f6ff2956d809a276060476fd8c879d3c"
+checksum = "da9f0f13dac8069c139e8300a6510e3f4143ecf5259c60b116a9b271b4ca0d54"
 dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
@@ -6153,15 +6153,15 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2-diagnostics"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "606c4ba35817e2922a308af55ad51bab3645b59eae5c570d4a6cf07e36bd493b"
+checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.25",
  "version_check",
- "yansi",
+ "yansi 1.0.0-rc",
 ]
 
 [[package]]
@@ -6770,9 +6770,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.4"
+version = "0.21.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8620e6b3ea4348874f156afce0032895cb1d483d6ab6bee37543b71ce3cbd01f"
+checksum = "79ea77c539259495ce8ca47f53e66ae0330a8819f67e23ac96ca02f50e7b7d36"
 dependencies = [
  "log",
  "ring",
@@ -8931,6 +8931,12 @@ name = "yansi"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
+
+[[package]]
+name = "yansi"
+version = "1.0.0-rc"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ee746ad3851dd3bc40e4a028ab3b00b99278d929e48957bcb2d111874a7e43e"
 
 [[package]]
 name = "zeroize"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1491,6 +1491,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "comfy-table"
+version = "6.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e959d788268e3bf9d35ace83e81b124190378e4c91c9067524675e33394b8ba"
+dependencies = [
+ "crossterm",
+ "strum 0.24.1",
+ "strum_macros 0.24.3",
+ "unicode-width",
+]
+
+[[package]]
 name = "concurrent-queue"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2013,7 +2025,7 @@ checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 [[package]]
 name = "dojo-lang"
 version = "0.1.0"
-source = "git+https://github.com/jobez/dojo?branch=custom-steps-and-get-block-potential-fix#2e40087f7cd0b5dd59d3e7ad4e80febba8fd71c4"
+source = "git+https://github.com/jobez/dojo?branch=custom-steps-and-get-block-potential-fix#cca4b11ca8fab724365c9a4da78438d605cb9c3a"
 dependencies = [
  "anyhow",
  "assert_fs",
@@ -2052,7 +2064,7 @@ dependencies = [
 [[package]]
 name = "dojo-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/jobez/dojo?branch=custom-steps-and-get-block-potential-fix#2e40087f7cd0b5dd59d3e7ad4e80febba8fd71c4"
+source = "git+https://github.com/jobez/dojo?branch=custom-steps-and-get-block-potential-fix#cca4b11ca8fab724365c9a4da78438d605cb9c3a"
 dependencies = [
  "anyhow",
  "assert_fs",
@@ -2082,7 +2094,7 @@ dependencies = [
 [[package]]
 name = "dojo-types"
 version = "0.1.0"
-source = "git+https://github.com/jobez/dojo?branch=custom-steps-and-get-block-potential-fix#2e40087f7cd0b5dd59d3e7ad4e80febba8fd71c4"
+source = "git+https://github.com/jobez/dojo?branch=custom-steps-and-get-block-potential-fix#cca4b11ca8fab724365c9a4da78438d605cb9c3a"
 dependencies = [
  "serde",
  "starknet",
@@ -2091,7 +2103,7 @@ dependencies = [
 [[package]]
 name = "dojo-world"
 version = "0.1.0"
-source = "git+https://github.com/jobez/dojo?branch=custom-steps-and-get-block-potential-fix#2e40087f7cd0b5dd59d3e7ad4e80febba8fd71c4"
+source = "git+https://github.com/jobez/dojo?branch=custom-steps-and-get-block-potential-fix#cca4b11ca8fab724365c9a4da78438d605cb9c3a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2464,6 +2476,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "ethers-contract-abigen"
+version = "2.0.7"
+source = "git+https://github.com/gakonst/ethers-rs#311086466871204c3965065b8c81e47418261412"
+dependencies = [
+ "Inflector",
+ "dunce",
+ "ethers-core 2.0.7 (git+https://github.com/gakonst/ethers-rs)",
+ "eyre",
+ "hex",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "serde",
+ "serde_json",
+ "syn 2.0.25",
+ "toml 0.7.6",
+ "walkdir",
+]
+
+[[package]]
 name = "ethers-contract-derive"
 version = "2.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2491,7 +2524,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_json",
- "syn 2.0.23",
+ "syn 2.0.25",
 ]
 
 [[package]]
@@ -2546,7 +2579,7 @@ dependencies = [
  "serde",
  "serde_json",
  "strum 0.25.0",
- "syn 2.0.23",
+ "syn 2.0.25",
  "tempfile",
  "thiserror",
  "tiny-keccak",
@@ -2925,8 +2958,8 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "forge"
-version = "0.2.0"
-source = "git+https://github.com/foundry-rs/foundry?branch=master#c78a811a8af95fb1e029427583a07b2ca3a3fa51"
+version = "1.0.0"
+source = "git+https://github.com/foundry-rs/foundry?branch=master#afdbbc05cc479468b15a6f42b577b62e0fd4895e"
 dependencies = [
  "comfy-table",
  "ethers 2.0.7 (git+https://github.com/gakonst/ethers-rs)",
@@ -2954,8 +2987,8 @@ dependencies = [
 
 [[package]]
 name = "forge-fmt"
-version = "0.2.0"
-source = "git+https://github.com/foundry-rs/foundry?branch=master#c78a811a8af95fb1e029427583a07b2ca3a3fa51"
+version = "1.0.0"
+source = "git+https://github.com/foundry-rs/foundry?branch=master#afdbbc05cc479468b15a6f42b577b62e0fd4895e"
 dependencies = [
  "ariadne",
  "ethers-core 2.0.7 (git+https://github.com/gakonst/ethers-rs)",
@@ -2978,8 +3011,8 @@ dependencies = [
 
 [[package]]
 name = "foundry-abi"
-version = "0.1.0"
-source = "git+https://github.com/foundry-rs/foundry?branch=master#c78a811a8af95fb1e029427583a07b2ca3a3fa51"
+version = "1.0.0"
+source = "git+https://github.com/foundry-rs/foundry?branch=master#afdbbc05cc479468b15a6f42b577b62e0fd4895e"
 dependencies = [
  "ethers-contract 2.0.7 (git+https://github.com/gakonst/ethers-rs)",
  "ethers-contract-abigen 2.0.7 (git+https://github.com/gakonst/ethers-rs)",
@@ -2987,13 +3020,13 @@ dependencies = [
  "ethers-providers 2.0.7 (git+https://github.com/gakonst/ethers-rs)",
  "eyre",
  "foundry-macros",
- "syn 2.0.23",
+ "syn 2.0.25",
 ]
 
 [[package]]
 name = "foundry-common"
-version = "0.1.0"
-source = "git+https://github.com/foundry-rs/foundry?branch=master#c78a811a8af95fb1e029427583a07b2ca3a3fa51"
+version = "1.0.0"
+source = "git+https://github.com/foundry-rs/foundry?branch=master#afdbbc05cc479468b15a6f42b577b62e0fd4895e"
 dependencies = [
  "auto_impl",
  "clap",
@@ -3024,8 +3057,8 @@ dependencies = [
 
 [[package]]
 name = "foundry-config"
-version = "0.2.0"
-source = "git+https://github.com/foundry-rs/foundry?branch=master#e488e2bb2c53434e866b7c0fb1cc68ae6ce5cb07"
+version = "1.0.0"
+source = "git+https://github.com/foundry-rs/foundry?branch=master#afdbbc05cc479468b15a6f42b577b62e0fd4895e"
 dependencies = [
  "Inflector",
  "dirs-next",
@@ -3054,8 +3087,8 @@ dependencies = [
 
 [[package]]
 name = "foundry-evm"
-version = "0.2.0"
-source = "git+https://github.com/foundry-rs/foundry?branch=master#c78a811a8af95fb1e029427583a07b2ca3a3fa51"
+version = "1.0.0"
+source = "git+https://github.com/foundry-rs/foundry?branch=master#afdbbc05cc479468b15a6f42b577b62e0fd4895e"
 dependencies = [
  "auto_impl",
  "bytes",
@@ -3089,8 +3122,8 @@ dependencies = [
 
 [[package]]
 name = "foundry-macros"
-version = "0.1.0"
-source = "git+https://github.com/foundry-rs/foundry?branch=master#c78a811a8af95fb1e029427583a07b2ca3a3fa51"
+version = "1.0.0"
+source = "git+https://github.com/foundry-rs/foundry?branch=master#afdbbc05cc479468b15a6f42b577b62e0fd4895e"
 dependencies = [
  "ethers-core 2.0.7 (git+https://github.com/gakonst/ethers-rs)",
  "foundry-macros-impl",
@@ -3101,17 +3134,17 @@ dependencies = [
 [[package]]
 name = "foundry-macros-impl"
 version = "0.0.0"
-source = "git+https://github.com/foundry-rs/foundry?branch=master#c78a811a8af95fb1e029427583a07b2ca3a3fa51"
+source = "git+https://github.com/foundry-rs/foundry?branch=master#afdbbc05cc479468b15a6f42b577b62e0fd4895e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.23",
+ "syn 2.0.25",
 ]
 
 [[package]]
 name = "foundry-utils"
-version = "0.2.0"
-source = "git+https://github.com/foundry-rs/foundry?branch=master#c78a811a8af95fb1e029427583a07b2ca3a3fa51"
+version = "1.0.0"
+source = "git+https://github.com/foundry-rs/foundry?branch=master#afdbbc05cc479468b15a6f42b577b62e0fd4895e"
 dependencies = [
  "ethers-addressbook 2.0.7 (git+https://github.com/gakonst/ethers-rs)",
  "ethers-contract 2.0.7 (git+https://github.com/gakonst/ethers-rs)",
@@ -4315,24 +4348,7 @@ dependencies = [
  "rustls",
  "rustls-native-certs",
  "tokio",
- "tokio-rustls 0.23.4",
- "webpki-roots 0.22.6",
-]
-
-[[package]]
-name = "hyper-rustls"
-version = "0.24.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d78e1e73ec14cf7375674f74d7dde185c8206fd9dea6fb6295e8a98098aaa97"
-dependencies = [
- "futures-util",
- "http",
- "hyper",
- "log",
- "rustls 0.21.3",
- "rustls-native-certs",
- "tokio",
- "tokio-rustls 0.24.1",
+ "tokio-rustls",
 ]
 
 [[package]]
@@ -4768,7 +4784,7 @@ checksum = "1705c65069729e3dccff6fd91ee431d5d31cabcf00ce68a62a2c6435ac713af9"
 dependencies = [
  "async-trait",
  "hyper",
- "hyper-rustls 0.24.1",
+ "hyper-rustls",
  "jsonrpsee-core 0.18.2",
  "jsonrpsee-types 0.18.2",
  "serde",
@@ -4996,7 +5012,7 @@ dependencies = [
 [[package]]
 name = "katana-core"
 version = "0.1.0"
-source = "git+https://github.com/jobez/dojo?branch=custom-steps-and-get-block-potential-fix#2e40087f7cd0b5dd59d3e7ad4e80febba8fd71c4"
+source = "git+https://github.com/jobez/dojo?branch=custom-steps-and-get-block-potential-fix#cca4b11ca8fab724365c9a4da78438d605cb9c3a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5021,7 +5037,7 @@ dependencies = [
 [[package]]
 name = "katana-rpc"
 version = "0.1.0"
-source = "git+https://github.com/jobez/dojo?branch=custom-steps-and-get-block-potential-fix#2e40087f7cd0b5dd59d3e7ad4e80febba8fd71c4"
+source = "git+https://github.com/jobez/dojo?branch=custom-steps-and-get-block-potential-fix#cca4b11ca8fab724365c9a4da78438d605cb9c3a"
 dependencies = [
  "anyhow",
  "blockifier",
@@ -6428,7 +6444,7 @@ dependencies = [
  "http",
  "http-body",
  "hyper",
- "hyper-rustls 0.24.1",
+ "hyper-rustls",
  "hyper-tls",
  "ipnet",
  "js-sys",
@@ -6438,7 +6454,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls 0.21.3",
+ "rustls",
  "rustls-pemfile",
  "serde",
  "serde_json",
@@ -6754,21 +6770,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.3"
+version = "0.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b19faa85ecb5197342b54f987b142fb3e30d0c90da40f80ef4fa9a726e6676ed"
-dependencies = [
- "log",
- "ring",
- "sct",
- "webpki",
-]
-
-[[package]]
-name = "rustls"
-version = "0.21.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b19faa85ecb5197342b54f987b142fb3e30d0c90da40f80ef4fa9a726e6676ed"
+checksum = "8620e6b3ea4348874f156afce0032895cb1d483d6ab6bee37543b71ce3cbd01f"
 dependencies = [
  "log",
  "ring",
@@ -8055,7 +8059,7 @@ version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
 dependencies = [
- "rustls 0.21.3",
+ "rustls",
  "tokio",
 ]
 
@@ -8078,7 +8082,7 @@ checksum = "ec509ac96e9a0c43427c74f003127d953a265737636129424288d27cb5c4b12c"
 dependencies = [
  "futures-util",
  "log",
- "rustls 0.21.3",
+ "rustls",
  "tokio",
  "tokio-rustls",
  "tungstenite",
@@ -8309,7 +8313,7 @@ dependencies = [
  "httparse",
  "log",
  "rand 0.8.5",
- "rustls 0.21.3",
+ "rustls",
  "sha1",
  "thiserror",
  "url",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ readme = "./README.md"
 license = "MIT"
 
 [workspace.dependencies]
+ethers = "2.0"  
 starknet = "0.4.0"
 starknet-crypto = "0.5.1"
 reth-rpc-api = { git = "https://github.com/paradigmxyz/reth.git", rev = "fb710e5" }
@@ -30,12 +31,14 @@ async-trait = "0.1.58"
 jsonrpsee = { version = "0.18.2", features = ["full"] }
 lazy_static = "1.4.0"
 dotenv = "0.15.0"  
+foundry-config = { git = "https://github.com/foundry-rs/foundry", branch = "master" }
+forge = { git = "https://github.com/foundry-rs/foundry", branch = "master" }  
 
 
 # In order to use dojo-test-utils, we need to explicitly declare the same patches as them in our Cargo.toml
 # Otherwise, underlying dependencies of dojo will not be patched and we will get a compilation error
 # see https://github.com/dojoengine/dojo/issues/563
-dojo-test-utils = { git = 'https://github.com/dojoengine/dojo', rev = "24e8a78" }
+dojo-test-utils = { git = "https://github.com/jobez/dojo", branch = "custom-steps-and-get-block-potential-fix"  }
 [patch.crates-io]
 cairo-felt = { git = "https://github.com/dojoengine/cairo-rs.git", rev = "9edddbc" }
 cairo-vm = { git = "https://github.com/dojoengine/cairo-rs.git", rev = "9edddbc" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,8 +40,6 @@ forge = { git = "https://github.com/foundry-rs/foundry", branch = "master" }
 # see https://github.com/dojoengine/dojo/issues/563
 dojo-test-utils = { git = "https://github.com/jobez/dojo", branch = "custom-steps-and-get-block-potential-fix"  }
 [patch.crates-io]
-# patched for quantity U256 responses <https://github.com/recmo/uint/issues/224>
-ruint = { git = "https://github.com/paradigmxyz/uint" }  
 cairo-felt = { git = "https://github.com/dojoengine/cairo-rs.git", rev = "9edddbc" }
 cairo-vm = { git = "https://github.com/dojoengine/cairo-rs.git", rev = "9edddbc" }
 # patched for quantity U256 responses <https://github.com/recmo/uint/issues/224>

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,8 @@ forge = { git = "https://github.com/foundry-rs/foundry", branch = "master" }
 # see https://github.com/dojoengine/dojo/issues/563
 dojo-test-utils = { git = "https://github.com/jobez/dojo", branch = "custom-steps-and-get-block-potential-fix"  }
 [patch.crates-io]
+# patched for quantity U256 responses <https://github.com/recmo/uint/issues/224>
+ruint = { git = "https://github.com/paradigmxyz/uint" }  
 cairo-felt = { git = "https://github.com/dojoengine/cairo-rs.git", rev = "9edddbc" }
 cairo-vm = { git = "https://github.com/dojoengine/cairo-rs.git", rev = "9edddbc" }
 # patched for quantity U256 responses <https://github.com/recmo/uint/issues/224>

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 HURL_FILES = $(shell find ./rpc-call-examples/ -name '*.hurl')
 
-NETWORK?=katana
+STARKNET_NETWORK?=katana
 
 pull-kakarot: .gitmodules 
 	git submodule update --init --recursive
@@ -10,7 +10,7 @@ build-kakarot: setup
 	cd lib/kakarot && make build && make build-sol
 
 deploy-kakarot:
-	cd lib/kakarot && STARKNET_NETWORK=$(NETWORK) make deploy
+	cd lib/kakarot && STARKNET_NETWORK=$(STARKNET_NETWORK) make deploy
 
 setup: pull-kakarot build-kakarot
 
@@ -24,14 +24,14 @@ build:
 
 # run
 run: 
-	source .env && RUST_LOG=debug cargo run -p kakarot-rpc
+	RUST_LOG=debug cargo run -p kakarot-rpc
 
 run-dev: deploy-kakarot
-	source .env && KAKAROT_ADDRESS=$(shell jq -r '.kakarot.address' ./lib/kakarot/deployments/$(NETWORK)/deployments.json) RUST_LOG=debug cargo run -p kakarot-rpc
+	KAKAROT_ADDRESS=$(shell jq -r '.kakarot.address' ./lib/kakarot/deployments/$(STARKNET_NETWORK)/deployments.json) RUST_LOG=debug cargo run -p kakarot-rpc
 
 #run-release
 run-release:
-	source .env && cargo run --release -p kakarot-rpc
+	cargo run --release -p kakarot-rpc
 
 test:
 	cargo test --all

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -37,8 +37,8 @@ lazy_static = "1.4.0"
 
 dotenv = { workspace = true }  
 bytes = "1"  
-ethers = "2.0"
-foundry-config = { git = "https://github.com/foundry-rs/foundry", branch = "master" }  
+ethers = { workspace = true }
+foundry-config = { workspace = true }
 
 [dev-dependencies]
 dojo-test-utils = { workspace = true }

--- a/crates/core/src/client/mod.rs
+++ b/crates/core/src/client/mod.rs
@@ -355,7 +355,7 @@ impl<P: Provider + Send + Sync> KakarotEthApi<P> for KakarotClient<P> {
 
                     TransactionReceipt {
                         transaction_hash,
-                        transaction_index: None,
+                        transaction_index: Some(U256::from(0)),
                         block_hash,
                         block_number,
                         from,

--- a/crates/core/src/models/transaction.rs
+++ b/crates/core/src/models/transaction.rs
@@ -70,7 +70,7 @@ impl ConvertibleStarknetTransaction for StarknetTransaction {
         client: &dyn KakarotEthApi<P>,
         block_hash: Option<H256>,
         block_number: Option<U256>,
-        transaction_index: Option<U256>,
+        _transaction_index: Option<U256>,
     ) -> Result<EthTransaction, EthApiError<P::Error>> {
         if !self.is_kakarot_tx(client).await? {
             return Err(EthApiError::KakarotDataFilteringError("Transaction".into()));
@@ -101,7 +101,7 @@ impl ConvertibleStarknetTransaction for StarknetTransaction {
             nonce,
             block_hash,
             block_number,
-            transaction_index,
+            transaction_index: Some(U256::from(0)),
             from,
             to,                     // TODO fetch the to
             value: U256::from(100), // TODO fetch the value

--- a/crates/core/src/models/transaction.rs
+++ b/crates/core/src/models/transaction.rs
@@ -70,7 +70,7 @@ impl ConvertibleStarknetTransaction for StarknetTransaction {
         client: &dyn KakarotEthApi<P>,
         block_hash: Option<H256>,
         block_number: Option<U256>,
-        _transaction_index: Option<U256>,
+        transaction_index: Option<U256>,
     ) -> Result<EthTransaction, EthApiError<P::Error>> {
         if !self.is_kakarot_tx(client).await? {
             return Err(EthApiError::KakarotDataFilteringError("Transaction".into()));
@@ -101,7 +101,7 @@ impl ConvertibleStarknetTransaction for StarknetTransaction {
             nonce,
             block_hash,
             block_number,
-            transaction_index: Some(U256::from(0)),
+            transaction_index,
             from,
             to,                     // TODO fetch the to
             value: U256::from(100), // TODO fetch the value

--- a/crates/core/src/test_utils/deploy_helpers.rs
+++ b/crates/core/src/test_utils/deploy_helpers.rs
@@ -3,7 +3,7 @@ use std::fs;
 use std::sync::Arc;
 
 use bytes::BytesMut;
-use dojo_test_utils::sequencer::TestSequencer;
+use dojo_test_utils::sequencer::{Environment, SequencerConfig, StarknetConfig, TestSequencer};
 use dotenv::dotenv;
 use ethers::abi::{Abi, Tokenize};
 use ethers::signers::{LocalWallet as EthersLocalWallet, Signer};
@@ -534,6 +534,45 @@ impl DeployedKakarot {
         .await
         .ok_or_else(|| "Evm contract deployment failed.".into())
     }
+}
+
+/// Returns a `StarknetConfig` instance customized for "Kakarot".
+///
+/// This function generates a `StarknetConfig` instance with `allow_zero_max_fee` set to `true`
+/// and a custom `Environment` object with its `chain_id` set to "SN_GOERLI".
+/// It also sets `invoke_max_steps` and `validate_max_steps` to `2**24` to facilitate
+/// computations associated with the "Kakarot" environment.
+/// Any other configuration fields in `StarknetConfig` and `Environment` are filled with default
+/// values.
+///
+/// This function is intended to provide a convenient way to obtain a Starknet configuration
+/// specifically tailored for testing or running "Kakarot"-centric applications.
+pub fn get_kakarot_starknet_config() -> StarknetConfig {
+    let kakarot_steps = 2u32.pow(24);
+    StarknetConfig {
+        allow_zero_max_fee: true,
+        env: Environment {
+            chain_id: "SN_GOERLI".into(),
+            invoke_max_steps: kakarot_steps,
+            validate_max_steps: kakarot_steps,
+            ..Default::default()
+        },
+        ..Default::default()
+    }
+}
+
+/// Constructs a test sequencer with the Starknet configuration tailored for "Kakarot".
+///
+/// This function initializes a `TestSequencer` instance with the default `SequencerConfig`
+/// and a custom `StarknetConfig` obtained from the `get_kakarot_starknet_config()` function.
+/// The custom `StarknetConfig` sets the chain_id to "SN_GOERLI" and both the `invoke_max_steps`
+/// and `validate_max_steps` to `2**24`. It also sets `allow_zero_max_fee` to true in
+/// `StarknetConfig`. This setup is aimed to provide an appropriate environment for testing
+/// "Kakarot" based applications.
+///
+/// Returns a `TestSequencer` configured for "Kakarot".
+pub async fn construct_kakarot_test_sequencer() -> TestSequencer {
+    TestSequencer::start(SequencerConfig::default(), get_kakarot_starknet_config()).await
 }
 
 /// Asynchronously deploys a Kakarot system to the StarkNet network and returns the

--- a/crates/core/src/test_utils/deploy_helpers.rs
+++ b/crates/core/src/test_utils/deploy_helpers.rs
@@ -536,7 +536,7 @@ impl DeployedKakarot {
     }
 }
 
-/// Returns a `StarknetConfig` instance customized for "Kakarot".
+/// Returns a `StarknetConfig` instance customized for Kakarot.
 ///
 /// This function generates a `StarknetConfig` instance with `allow_zero_max_fee` set to `true`
 /// and a custom `Environment` object with its `chain_id` set to "SN_GOERLI".
@@ -561,7 +561,7 @@ pub fn get_kakarot_starknet_config() -> StarknetConfig {
     }
 }
 
-/// Constructs a test sequencer with the Starknet configuration tailored for "Kakarot".
+/// Constructs a test sequencer with the Starknet configuration tailored for Kakarot.
 ///
 /// This function initializes a `TestSequencer` instance with the default `SequencerConfig`
 /// and a custom `StarknetConfig` obtained from the `get_kakarot_starknet_config()` function.

--- a/crates/core/tests/client.rs
+++ b/crates/core/tests/client.rs
@@ -1,16 +1,21 @@
 #[cfg(test)]
 mod tests {
 
-    use dojo_test_utils::sequencer::TestSequencer;
+    use std::str::FromStr;
+
     use ethers::types::Address as EthersAddress;
     use kakarot_rpc_core::client::api::KakarotEthApi;
     use kakarot_rpc_core::client::config::StarknetConfig;
     use kakarot_rpc_core::client::KakarotClient;
     use kakarot_rpc_core::models::felt::Felt252Wrapper;
     use kakarot_rpc_core::test_utils::constants::EOA_WALLET;
-    use kakarot_rpc_core::test_utils::deploy_helpers::{create_raw_ethereum_tx, deploy_kakarot_system};
-    use reth_primitives::{Address, BlockId, BlockNumberOrTag, U256};
-    use starknet::core::types::FieldElement;
+    use kakarot_rpc_core::test_utils::deploy_helpers::{
+        construct_kakarot_test_sequencer, create_raw_ethereum_tx, deploy_kakarot_system,
+    };
+    use reth_primitives::{Address, BlockId, BlockNumberOrTag, Bytes, H256, U256};
+    use reth_rpc_types::Log;
+    use starknet::core::types::{BlockId as StarknetBlockId, BlockTag, Event, FieldElement};
+    use starknet::core::utils::get_selector_from_name;
     use starknet::providers::jsonrpc::HttpTransport;
     use starknet::providers::JsonRpcClient;
 

--- a/crates/core/tests/client.rs
+++ b/crates/core/tests/client.rs
@@ -1,8 +1,6 @@
 #[cfg(test)]
 mod tests {
 
-    use std::str::FromStr;
-
     use ethers::types::Address as EthersAddress;
     use kakarot_rpc_core::client::api::KakarotEthApi;
     use kakarot_rpc_core::client::config::StarknetConfig;
@@ -12,10 +10,8 @@ mod tests {
     use kakarot_rpc_core::test_utils::deploy_helpers::{
         construct_kakarot_test_sequencer, create_raw_ethereum_tx, deploy_kakarot_system,
     };
-    use reth_primitives::{Address, BlockId, BlockNumberOrTag, Bytes, H256, U256};
-    use reth_rpc_types::Log;
-    use starknet::core::types::{BlockId as StarknetBlockId, BlockTag, Event, FieldElement};
-    use starknet::core::utils::get_selector_from_name;
+    use reth_primitives::{Address, BlockId, BlockNumberOrTag, U256};
+    use starknet::core::types::FieldElement;
     use starknet::providers::jsonrpc::HttpTransport;
     use starknet::providers::JsonRpcClient;
 

--- a/crates/core/tests/client.rs
+++ b/crates/core/tests/client.rs
@@ -16,7 +16,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_rpc_should_not_raise_when_eoa_not_deployed() {
-        let starknet_test_sequencer = TestSequencer::start().await;
+        let starknet_test_sequencer = construct_kakarot_test_sequencer().await;
 
         let expected_funded_amount = FieldElement::from_dec_str("1000000000000000000").unwrap();
 
@@ -41,7 +41,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_counter() {
-        let starknet_test_sequencer = TestSequencer::start().await;
+        let starknet_test_sequencer = construct_kakarot_test_sequencer().await;
 
         let expected_funded_amount = FieldElement::from_dec_str("10000000000000000000").unwrap();
 
@@ -119,8 +119,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_plain_opcodes() {
-        // initial setup of PlainOpcodes to test we can deploy contracts w/ constructor arguments
-        let starknet_test_sequencer = TestSequencer::start().await;
+        let starknet_test_sequencer = construct_kakarot_test_sequencer().await;
 
         let expected_funded_amount = FieldElement::from_dec_str("1000000000000000000").unwrap();
 

--- a/crates/eth-rpc/Cargo.toml
+++ b/crates/eth-rpc/Cargo.toml
@@ -37,6 +37,12 @@ tracing = "0.1.34"
 tracing-subscriber = { version = "0.3.3", features = ["env-filter"] }
 lazy_static = { workspace = true }
 
+[dev-dependencies]
+foundry-config = { workspace = true }
+forge = { workspace = true }    
+dojo-test-utils = { workspace = true }
+ethers = { workspace = true } 
+  
 [dev-dependencies.cargo-husky]
 version = "1.5.0"
 default-features = false

--- a/crates/eth-rpc/tests/rpc.rs
+++ b/crates/eth-rpc/tests/rpc.rs
@@ -5,17 +5,19 @@ mod utils;
 #[cfg(test)]
 mod tests {
     use std::str::FromStr;
+    use std::sync::Arc;
 
     use ethers::prelude::{Block as EthersBlock, Http as EthersHttp, H256 as EthersH256};
     use kakarot_rpc::eth_api::EthApiServer;
     use kakarot_rpc_core::mock::assert_helpers::{assert_block, assert_block_header, assert_transaction};
+    use kakarot_rpc_core::test_utils::deploy_helpers::construct_kakarot_test_sequencer;
     use reth_primitives::{BlockNumberOrTag, H160, H256, U256, U64};
     use reth_rpc_types::Index;
     use serde_json::json;
     use starknet::core::types::{FieldElement, Transaction as StarknetTransaction};
     use starknet::macros::felt;
 
-    use crate::utils::{run_kakarot_integration, setup_kakarot_eth_rpc};
+    use crate::utils::{run_kakarot_integration, setup_kakarot_eth_rpc, setup_kakarot_integration};
 
     fn get_test_tx() -> serde_json::Value {
         json!({
@@ -1014,6 +1016,26 @@ mod tests {
             Some(H256::from(felt!("0x000000000000000000000000000000000000000000000000000000000000000d").to_bytes_be()))
         );
         assert_eq!(U256::from(transaction.block_number.unwrap()), U256::from(13));
+    }
+
+    // elias' version doesn't terminate for me locally
+    #[tokio::test]
+    #[ignore]
+    async fn test_get_block_rpc_bis() {
+        // initialize a starknet sequencer
+        let starknet_test_sequencer = Arc::new(construct_kakarot_test_sequencer().await);
+
+        let (server_addr, server_handle) = setup_kakarot_integration(&starknet_test_sequencer).await;
+
+        // try to run the test
+        let provider = EthersHttp::from_str(format!("http://localhost:{}", server_addr.port()).as_ref()).unwrap();
+        let block_number: U64 =
+            ethers::prelude::JsonRpcClient::request(&provider, "eth_blockNumber", ()).await.unwrap();
+        let params = (block_number, true);
+        let block: std::result::Result<EthersBlock<EthersH256>, _> =
+            ethers::prelude::JsonRpcClient::request(&provider, "eth_getBlockByNumber", params).await;
+        assert!(block.is_ok());
+        server_handle.stopped().await;
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 3)]

--- a/crates/eth-rpc/tests/utils.rs
+++ b/crates/eth-rpc/tests/utils.rs
@@ -1,10 +1,20 @@
+use std::future::Future;
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use dojo_test_utils::sequencer::TestSequencer;
+use jsonrpsee::server::ServerHandle;
+use kakarot_rpc::config::RPCConfig;
 use kakarot_rpc::eth_rpc::KakarotEthRpc;
+use kakarot_rpc::run_server;
 use kakarot_rpc_core::client::config::{JsonRpcClientBuilder, StarknetConfig};
 use kakarot_rpc_core::client::KakarotClient;
 use kakarot_rpc_core::mock::wiremock_utils::setup_wiremock;
+use kakarot_rpc_core::test_utils::constants::EOA_WALLET;
+use kakarot_rpc_core::test_utils::deploy_helpers::{construct_kakarot_test_sequencer, deploy_kakarot_system};
 use starknet::core::types::FieldElement;
-use starknet::providers::jsonrpc::HttpTransport;
-use starknet::providers::JsonRpcClient;
+use starknet::providers::jsonrpc::{HttpTransport, HttpTransport as StarknetHttpTransport};
+use starknet::providers::{JsonRpcClient, JsonRpcClient as StarknetJsonRpcClient};
 
 /// Run wiremock to fake starknet rpc and then run our own `kakarot_rpc_server`.
 ///
@@ -44,4 +54,98 @@ pub async fn setup_kakarot_eth_rpc() -> KakarotEthRpc<JsonRpcClient<HttpTranspor
     let kakarot_client = KakarotClient::new(config, provider);
 
     KakarotEthRpc::new(Box::new(kakarot_client))
+}
+
+pub async fn setup_kakarot_integration(starknet_test_sequencer: &Arc<TestSequencer>) -> (SocketAddr, ServerHandle) {
+    // SUMMON THE STARKNET TEST SEQUENCER
+
+    let expected_funded_amount = FieldElement::from_dec_str("1000000000000000000").unwrap();
+
+    // UNLEASH THE MIGHTY KAKAROT
+    let deployed_kakarot =
+        deploy_kakarot_system(starknet_test_sequencer, EOA_WALLET.clone(), expected_funded_amount).await;
+
+    // INITIATE THE ALMIGHTY KAKAROT CLIENT
+    let kakarot_client = KakarotClient::new(
+        StarknetConfig::new(
+            starknet_test_sequencer.url().as_ref().to_string(),
+            deployed_kakarot.kakarot,
+            deployed_kakarot.kakarot_proxy,
+        ),
+        StarknetJsonRpcClient::new(StarknetHttpTransport::new(starknet_test_sequencer.url())),
+    );
+
+    let rpc_config = RPCConfig::from_env().expect("config not found");
+
+    // AND NOW THE RPC SERVER
+    let (server_addr, server_handle) = run_server(Box::new(kakarot_client), rpc_config).await.unwrap();
+
+    (server_addr, server_handle)
+}
+
+/// Asynchronously runs a Kakarot test using the provided client code.
+///
+/// This function creates a Starknet test sequencer, sets up a Kakarot RPC server, and then runs the
+/// client code with the server's port number as an argument. It then spawns two tasks: one to run
+/// the server until it's stopped, and one to run the client code. The server and client code are
+/// run concurrently.
+///
+/// The function panics if the server task finishes before the client task. If the client task
+/// returns an error, that error is propagated as a panic.
+///
+/// # Arguments
+///
+/// * `client_code` - A closure which takes a port number (u16) and returns a `Future` that yields
+///   `()`. This is the code to be run as the client for the test. The future must be `'static` and
+///   `Send` to allow it to be run across threads.
+///
+/// # Type Parameters
+///
+/// * `F`: The type of the closure `client_code`.
+/// * `Fut`: The type of the future returned by `client_code`.
+///
+/// # Panics
+///
+/// Panics if the server task finishes before the client task, or if the client task returns an
+/// error.
+///
+/// # Returns
+///
+/// This function is `async` and does not return a value. It should be `await`ed.
+pub async fn run_kakarot_integration<F, Fut>(client_code: F)
+where
+    F: FnOnce(u16) -> Fut,
+    Fut: Future<Output = ()> + Send + 'static,
+{
+    let starknet_test_sequencer = Arc::new(construct_kakarot_test_sequencer().await);
+
+    let (server_addr, server_handle) = setup_kakarot_integration(&starknet_test_sequencer).await;
+
+    let client_code = client_code(server_addr.port());
+
+    // without this extra touch, the starknet provider thread willl complete before
+    // our client task can make its necessary interaction with the kakarot rpc
+    let starknet_test_sequencer_clone = Arc::clone(&starknet_test_sequencer);
+    let server_task = tokio::spawn(async move {
+        let _ = starknet_test_sequencer_clone;
+        server_handle.stopped().await
+    });
+
+    let client_task = tokio::spawn(client_code);
+
+    // Wait for both the server and client to finish.
+    tokio::select! {
+        _ = server_task => {
+            panic!("Server task finished first (this shouldn't happen).");
+        }
+        result = client_task => {
+
+            if let Err(e) = result {
+                std::panic::resume_unwind(e.into_panic())
+            } else {
+                println!("Client task finished, proceeding to shut down server.");
+            }
+
+        }
+    };
 }

--- a/foundry.toml
+++ b/foundry.toml
@@ -1,3 +1,9 @@
 [profile.default]
 out = 'lib/kakarot/tests/integration/solidity_contracts/build'
 libs = ['lib']
+eth_rpc_url = "localhost"
+legacy = true
+
+[rpc_endpoints]
+localhost = "http://127.0.0.1:3030"
+anvil = "http://127.0.0.1:8545"

--- a/foundry.toml
+++ b/foundry.toml
@@ -1,5 +1,6 @@
 [profile.default]
 out = 'lib/kakarot/tests/integration/solidity_contracts/build'
+script = 'scripts'  
 libs = ['lib']
 eth_rpc_url = "localhost"
 legacy = true


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->


These are the changes to have the cli forge pass against this branch of katana: https://github.com/jobez/dojo/tree/custom-steps-and-get-block-potential-fix

katana is started with the following cli command from the dojo/crates/kata

```
cargo run -- --validate-max-steps 16777216 --invoke-max-steps 16777216 --gas-price 0
```

kakarot rpc is started with

```
make run-dev STARKNET_NETWORK=katana
```

Forge is ran with the following command from the root of this project

```
RUST_LOG=debug forge script --rpc-url http://0.0.0.0:3031 --broadcast --delay 30 --retries 10 -v scripts/PlainOpcodes.s.sol:PlainOpcodesScript -vvvvv --legacy 
```




Please check the type of change your PR introduces:
- [X] Exploration
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Testing

# What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

# Does this introduce a breaking change?

- [ ] Yes
- [ ] No
