### PR TITLE
changes to allow usage `forge create` and `cast`

### DIFF
--- a/crates/core/src/client/mod.rs
+++ b/crates/core/src/client/mod.rs
@@ -499,7 +499,7 @@ impl<P: Provider + Send + Sync> KakarotEthApi<P> for KakarotClient<P> {
 
         // TODO: transition `reward` hardcoded default out of nearing-demo-day hack and seeing how to
         // properly source/translate this value
-        Ok(FeeHistory { base_fee_per_gas, gas_used_ratio, oldest_block, reward: Some(vec![vec![U256::ZERO]]) })
+        Ok(FeeHistory { base_fee_per_gas, gas_used_ratio, oldest_block, reward: Some(vec![vec![]]) })
     }
 
     /// Returns the estimated gas for a transaction

--- a/crates/core/src/client/mod.rs
+++ b/crates/core/src/client/mod.rs
@@ -315,6 +315,8 @@ impl<P: Provider + Send + Sync> KakarotEthApi<P> for KakarotClient<P> {
 
                     TransactionReceipt {
                         transaction_hash,
+                        // TODO: transition this hardcoded default out of nearing-demo-day hack and seeing how to
+                        // properly source/translate this value
                         transaction_index: Some(U256::ZERO),
                         block_hash,
                         block_number,
@@ -495,6 +497,8 @@ impl<P: Provider + Send + Sync> KakarotEthApi<P> for KakarotClient<P> {
         let newest_block = U256::from(newest_block);
         let oldest_block: U256 = if newest_block >= block_count { newest_block - block_count } else { U256::from(0) };
 
+        // TODO: transition `reward` hardcoded default out of nearing-demo-day hack and seeing how to
+        // properly source/translate this value
         Ok(FeeHistory { base_fee_per_gas, gas_used_ratio, oldest_block, reward: Some(vec![vec![U256::ZERO]]) })
     }
 

--- a/crates/core/src/client/mod.rs
+++ b/crates/core/src/client/mod.rs
@@ -495,7 +495,7 @@ impl<P: Provider + Send + Sync> KakarotEthApi<P> for KakarotClient<P> {
         let newest_block = U256::from(newest_block);
         let oldest_block: U256 = if newest_block >= block_count { newest_block - block_count } else { U256::from(0) };
 
-        Ok(FeeHistory { base_fee_per_gas, gas_used_ratio, oldest_block, reward: None })
+        Ok(FeeHistory { base_fee_per_gas, gas_used_ratio, oldest_block, reward: Some(vec![vec![U256::ZERO]]) })
     }
 
     /// Returns the estimated gas for a transaction

--- a/crates/core/src/client/tests/mod.rs
+++ b/crates/core/src/client/tests/mod.rs
@@ -83,7 +83,7 @@ async fn test_fee_history() {
     assert_eq!(vec![U256::from(1); count + 1], fee_history.base_fee_per_gas);
     assert_eq!(vec![0.9; count], fee_history.gas_used_ratio);
     assert_eq!(U256::from(19630), fee_history.oldest_block);
-    assert_eq!((Some(vec![vec![U256::ZERO]])), fee_history.reward);
+    assert_eq!((Some(vec![vec![]])), fee_history.reward);
 }
 
 #[tokio::test]

--- a/crates/core/src/client/tests/mod.rs
+++ b/crates/core/src/client/tests/mod.rs
@@ -83,7 +83,7 @@ async fn test_fee_history() {
     assert_eq!(vec![U256::from(1); count + 1], fee_history.base_fee_per_gas);
     assert_eq!(vec![0.9; count], fee_history.gas_used_ratio);
     assert_eq!(U256::from(19630), fee_history.oldest_block);
-    assert_eq!(None, fee_history.reward);
+    assert_eq!((Some(vec![vec![U256::ZERO]])), fee_history.reward);
 }
 
 #[tokio::test]

--- a/foundry.toml
+++ b/foundry.toml
@@ -1,6 +1,7 @@
 [profile.default]
 out = 'lib/kakarot/tests/integration/solidity_contracts/build'
 libs = ['lib']
+src = "lib/kakarot/tests/integration/solidity_contracts"
 eth_rpc_url = "localhost"
 legacy = true
 


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

Time spent on this PR:

Resolves: #<Issue number>

# Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Testing

# What is the new behavior?

I previously justified the changes to the `transaction_index` default return value in TransactionReceipt. 

A similar deserializatior error happens when trying to use forge create like so:

`forge create  "Counter" --private-key 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80`

You would see something like:

```
Deserialization Error: invalid type: null, expected a sequence at line 1 column 177. Response: {"baseFeePerGas":["0x1","0x1","0x1","0x1","0x1","0x1","0x1","0x1","0x1","0x1","0x1"],"gasUsedRatio":[0.9,0.9,0.9,0.9,0.9,0.9,0.9,0.9,0.9,0.9],"oldestBlock":"0x2b3","reward":null}
```

So we do a similar change to the default value for the 'reward' field. 

I also included a `src` dimension in the `foundry.yml`, which `forge create` needs to locate contracts.

You can see a manual session I did that shows contract deployment/interaction from the command line: https://gist.github.com/jobez/f1c3f655308d080757569f0c10fb4ba3

# Does this introduce a breaking change?

- [ ] Yes
- [X] No
