### PR TITLE
Stop deploying Kakarot in run-dev

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ build:
 run: 
 	RUST_LOG=info cargo run -p kakarot-rpc
 
-run-dev: deploy-kakarot
+run-dev:
 	KAKAROT_ADDRESS=$(shell jq -r '.kakarot.address' ./lib/kakarot/deployments/$(STARKNET_NETWORK)/deployments.json) RUST_LOG=trace cargo run -p kakarot-rpc
 
 #run-release


### PR DESCRIPTION
I am suggesting to stop deploying kakarot when running `make run-dev` because I often keep a madara open, with
once-for-all deployed Kakarot, but I do kill and restart the RPC.

wdyt?
