### PR TITLE
feat: simulate transaction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4593,6 +4593,7 @@ dependencies = [
  "reth-rlp",
  "reth-rpc-api",
  "reth-rpc-types",
+ "ruint",
  "serde",
  "serde_json",
  "serde_with",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ async-trait = "0.1.58"
 jsonrpsee = { version = "0.18.2", features = ["full"] }
 lazy_static = "1.4.0"
 dotenv = "0.15.0"  
+ruint = "1.8.0"
 
 
 # In order to use dojo-test-utils, we need to explicitly declare the same patches as them in our Cargo.toml

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -30,6 +30,7 @@ serde = { version = "1.0" }
 serde_json = { version = "1.0", features = ["preserve_order"]}
 serde_with = "2.2.0"
 tokio = { version = "1.21.2", features = ["macros"] }
+ruint = { workspace = true }
 
 wiremock = "0.5.17"
 lazy_static = "1.4.0"

--- a/crates/core/src/client/api.rs
+++ b/crates/core/src/client/api.rs
@@ -21,7 +21,7 @@ pub trait KakarotEthApi<P: Provider + Send + Sync>: KakarotStarknetApi<P> + Send
 
     async fn get_code(&self, ethereum_address: Address, block_id: BlockId) -> Result<Bytes, EthApiError<P::Error>>;
 
-    async fn call_view(&self, to: Address, calldata: Bytes, block_id: BlockId) -> Result<Bytes, EthApiError<P::Error>>;
+    async fn call(&self, to: Address, calldata: Bytes, block_id: BlockId) -> Result<Bytes, EthApiError<P::Error>>;
 
     async fn transaction_by_block_id_and_index(
         &self,
@@ -73,7 +73,7 @@ pub trait KakarotStarknetApi<P: Provider + Send + Sync>: Send + Sync {
 
     fn starknet_provider(&self) -> &P;
 
-    async fn get_block_number(&self, block_id: &StarknetBlockId) -> Result<u64, EthApiError<P::Error>>;
+    async fn map_block_id_to_block_number(&self, block_id: &StarknetBlockId) -> Result<u64, EthApiError<P::Error>>;
 
     async fn submit_starknet_transaction(
         &self,

--- a/crates/core/src/client/api.rs
+++ b/crates/core/src/client/api.rs
@@ -6,6 +6,7 @@ use reth_rpc_types::{
     TransactionReceipt,
 };
 use starknet::core::types::{BlockId as StarknetBlockId, BroadcastedInvokeTransactionV1, FieldElement};
+use starknet::providers::sequencer::models::TransactionSimulationInfo;
 use starknet::providers::Provider;
 
 use super::errors::EthApiError;
@@ -18,18 +19,9 @@ pub trait KakarotEthApi<P: Provider + Send + Sync>: KakarotStarknetApi<P> + Send
 
     async fn transaction_by_hash(&self, hash: H256) -> Result<EtherTransaction, EthApiError<P::Error>>;
 
-    async fn get_code(
-        &self,
-        ethereum_address: Address,
-        starknet_block_id: BlockId,
-    ) -> Result<Bytes, EthApiError<P::Error>>;
+    async fn get_code(&self, ethereum_address: Address, block_id: BlockId) -> Result<Bytes, EthApiError<P::Error>>;
 
-    async fn call_view(
-        &self,
-        ethereum_address: Address,
-        calldata: Bytes,
-        starknet_block_id: BlockId,
-    ) -> Result<Bytes, EthApiError<P::Error>>;
+    async fn call_view(&self, to: Address, calldata: Bytes, block_id: BlockId) -> Result<Bytes, EthApiError<P::Error>>;
 
     async fn transaction_by_block_id_and_index(
         &self,
@@ -57,7 +49,7 @@ pub trait KakarotEthApi<P: Provider + Send + Sync>: KakarotStarknetApi<P> + Send
 
     async fn send_transaction(&self, bytes: Bytes) -> Result<H256, EthApiError<P::Error>>;
 
-    async fn get_transaction_count_by_block(&self, starknet_block_id: BlockId) -> Result<U64, EthApiError<P::Error>>;
+    async fn get_transaction_count_by_block(&self, block_id: BlockId) -> Result<U64, EthApiError<P::Error>>;
 
     fn base_fee_per_gas(&self) -> U256;
 
@@ -70,11 +62,7 @@ pub trait KakarotEthApi<P: Provider + Send + Sync>: KakarotStarknetApi<P> + Send
         _reward_percentiles: Option<Vec<f64>>,
     ) -> Result<FeeHistory, EthApiError<P::Error>>;
 
-    async fn estimate_gas(
-        &self,
-        call_request: CallRequest,
-        block_number: Option<BlockId>,
-    ) -> Result<U256, EthApiError<P::Error>>;
+    async fn estimate_gas(&self, request: CallRequest, block_id: BlockId) -> Result<U256, EthApiError<P::Error>>;
 }
 
 #[async_trait]
@@ -84,6 +72,8 @@ pub trait KakarotStarknetApi<P: Provider + Send + Sync>: Send + Sync {
     fn proxy_account_class_hash(&self) -> FieldElement;
 
     fn starknet_provider(&self) -> &P;
+
+    async fn get_block_number(&self, block_id: &StarknetBlockId) -> Result<u64, EthApiError<P::Error>>;
 
     async fn submit_starknet_transaction(
         &self,
@@ -114,4 +104,11 @@ pub trait KakarotStarknetApi<P: Provider + Send + Sync>: Send + Sync {
         block_id: StarknetBlockId,
         hydrated_tx: bool,
     ) -> Result<RichBlock, EthApiError<P::Error>>;
+
+    async fn simulate_transaction(
+        &self,
+        request: BroadcastedInvokeTransactionV1,
+        block_number: u64,
+        skip_validate: bool,
+    ) -> Result<TransactionSimulationInfo, EthApiError<P::Error>>;
 }

--- a/crates/core/src/client/config.rs
+++ b/crates/core/src/client/config.rs
@@ -11,7 +11,7 @@ fn get_env_var(name: &str) -> Result<String, ConfigError> {
     std::env::var(name).map_err(|_| ConfigError::EnvironmentVariableMissing(name.into()))
 }
 
-#[derive(Default, Clone)]
+#[derive(Default, Clone, Debug)]
 pub enum Network {
     #[default]
     Katana,
@@ -20,6 +20,19 @@ pub enum Network {
     Goerli1Gateway,
     Goerli2Gateway,
     JsonRpcProvider(Url),
+}
+
+impl Network {
+    pub fn get_gateway_url(&self) -> Url {
+        match self {
+            Network::Mainnet => Url::parse("https://alpha-mainnet.starknet.io/feeder_gateway/").unwrap(),
+            Network::Goerli1 => Url::parse("https://alpha4.starknet.io/feeder_gateway/").unwrap(),
+            _ => {
+                log::warn!("Using goerli1 gateway url for network {:?}", self);
+                Url::parse("https://alpha4.starknet.io/feeder_gateway/").unwrap()
+            }
+        }
+    }
 }
 
 #[derive(Default, Clone)]

--- a/crates/core/src/client/config.rs
+++ b/crates/core/src/client/config.rs
@@ -23,15 +23,16 @@ pub enum Network {
 }
 
 impl Network {
-    pub fn get_gateway_url(&self) -> Result<Url, ConfigError> {
+    pub fn gateway_url(&self) -> Result<Url, ConfigError> {
         match self {
             Network::Mainnet => Ok(Url::parse("https://alpha-mainnet.starknet.io/feeder_gateway/").unwrap()),
             Network::Goerli1 => Ok(Url::parse("https://alpha4.starknet.io/feeder_gateway/").unwrap()),
-            _ => Err(ConfigError::InvalidNetwork(format!("Network {:?} is not supported for provider url", self))),
+            Network::Goerli2 => Ok(Url::parse("https://alpha4-2.starknet.io/feeder_gateway/").unwrap()),
+            _ => Err(ConfigError::InvalidNetwork(format!("Network {:?} is not supported for gateway url", self))),
         }
     }
 
-    pub fn get_provider_url(&self) -> Result<Url, ConfigError> {
+    pub fn provider_url(&self) -> Result<Url, ConfigError> {
         match self {
             Network::Katana => Ok(Url::parse(KATANA_RPC_URL)?),
             Network::Madara => Ok(Url::parse(MADARA_RPC_URL)?),
@@ -128,7 +129,7 @@ impl JsonRpcClientBuilder<HttpTransport> {
     ///     JsonRpcClientBuilder::with_http(&config).unwrap().build();
     /// ```
     pub fn with_http(config: &StarknetConfig) -> Result<Self> {
-        let url = config.network.get_provider_url()?;
+        let url = config.network.provider_url()?;
         let transport = HttpTransport::new(url);
         Ok(Self::new(transport))
     }

--- a/crates/core/src/client/config.rs
+++ b/crates/core/src/client/config.rs
@@ -25,9 +25,9 @@ pub enum Network {
 impl Network {
     pub fn gateway_url(&self) -> Result<Url, ConfigError> {
         match self {
-            Network::Mainnet => Ok(Url::parse("https://alpha-mainnet.starknet.io/feeder_gateway/").unwrap()),
-            Network::Goerli1 => Ok(Url::parse("https://alpha4.starknet.io/feeder_gateway/").unwrap()),
-            Network::Goerli2 => Ok(Url::parse("https://alpha4-2.starknet.io/feeder_gateway/").unwrap()),
+            Network::MainnetGateway => Ok(Url::parse("https://alpha-mainnet.starknet.io/feeder_gateway/").unwrap()),
+            Network::Goerli1Gateway => Ok(Url::parse("https://alpha4.starknet.io/feeder_gateway/").unwrap()),
+            Network::Goerli2Gateway => Ok(Url::parse("https://alpha4-2.starknet.io/feeder_gateway/").unwrap()),
             _ => Err(ConfigError::InvalidNetwork(format!("Network {:?} is not supported for gateway url", self))),
         }
     }
@@ -36,7 +36,7 @@ impl Network {
         match self {
             Network::Katana => Ok(Url::parse(KATANA_RPC_URL)?),
             Network::Madara => Ok(Url::parse(MADARA_RPC_URL)?),
-            Network::ProviderUrl(url) => Ok(url.clone()),
+            Network::JsonRpcProvider(url) => Ok(url.clone()),
             _ => Err(ConfigError::InvalidNetwork(format!("Network {:?} is not supported for provider url", self))),
         }
     }
@@ -142,9 +142,9 @@ impl SequencerGatewayProviderBuilder {
     /// Create a new `SequencerGatewayProviderBuilder`.
     pub fn new(network: &Network) -> Self {
         match network {
-            Network::Mainnet => Self(SequencerGatewayProvider::starknet_alpha_mainnet()),
-            Network::Goerli1 => Self(SequencerGatewayProvider::starknet_alpha_goerli()),
-            Network::Goerli2 => Self(SequencerGatewayProvider::starknet_alpha_goerli_2()),
+            Network::MainnetGateway => Self(SequencerGatewayProvider::starknet_alpha_mainnet()),
+            Network::Goerli1Gateway => Self(SequencerGatewayProvider::starknet_alpha_goerli()),
+            Network::Goerli2Gateway => Self(SequencerGatewayProvider::starknet_alpha_goerli_2()),
             _ => panic!("Unsupported network for SequencerGatewayProvider"),
         }
     }

--- a/crates/core/src/client/config.rs
+++ b/crates/core/src/client/config.rs
@@ -25,9 +25,9 @@ pub enum Network {
 impl Network {
     pub fn gateway_url(&self) -> Result<Url, ConfigError> {
         match self {
-            Network::MainnetGateway => Ok(Url::parse("https://alpha-mainnet.starknet.io/feeder_gateway/").unwrap()),
-            Network::Goerli1Gateway => Ok(Url::parse("https://alpha4.starknet.io/feeder_gateway/").unwrap()),
-            Network::Goerli2Gateway => Ok(Url::parse("https://alpha4-2.starknet.io/feeder_gateway/").unwrap()),
+            Network::MainnetGateway => Ok(Url::parse("https://alpha-mainnet.starknet.io/feeder_gateway/")?),
+            Network::Goerli1Gateway => Ok(Url::parse("https://alpha4.starknet.io/feeder_gateway/")?),
+            Network::Goerli2Gateway => Ok(Url::parse("https://alpha4-2.starknet.io/feeder_gateway/")?),
             _ => Err(ConfigError::InvalidNetwork(format!("Network {:?} is not supported for gateway url", self))),
         }
     }

--- a/crates/core/src/client/errors.rs
+++ b/crates/core/src/client/errors.rs
@@ -49,6 +49,12 @@ pub enum EthApiError<E: std::error::Error> {
     /// Data not part of Kakarot.
     #[error("{0} not from Kakarot")]
     KakarotDataFilteringError(String),
+    /// Feeder gateway error.
+    #[error("Feeder gateway error: {0}")]
+    FeederGatewayError(String),
+    /// Missing parameter error.
+    #[error("Missing parameter: {0}")]
+    MissingParameterError(String),
     /// Other error.
     #[error(transparent)]
     Other(#[from] anyhow::Error),
@@ -88,6 +94,8 @@ impl<E: std::error::Error> From<EthApiError<E>> for ErrorObject<'static> {
             EthApiError::ConversionError(err) => rpc_err(INTERNAL_ERROR_CODE, err.to_string()),
             EthApiError::DataDecodingError(err) => rpc_err(INTERNAL_ERROR_CODE, err.to_string()),
             EthApiError::KakarotDataFilteringError(err) => rpc_err(INTERNAL_ERROR_CODE, err),
+            EthApiError::FeederGatewayError(err) => rpc_err(INTERNAL_ERROR_CODE, err),
+            EthApiError::MissingParameterError(err) => rpc_err(INVALID_PARAMS_CODE, err),
             EthApiError::Other(err) => rpc_err(INTERNAL_ERROR_CODE, err.to_string()),
         }
     }

--- a/crates/core/src/client/errors.rs
+++ b/crates/core/src/client/errors.rs
@@ -25,13 +25,18 @@ pub enum EthRpcErrorCode {
 // Error that can accure when preparing configuration.
 #[derive(Debug, Error)]
 pub enum ConfigError {
+    /// Missing mandatory environment variable error.
     #[error("Missing mandatory environment variable: {0}")]
     EnvironmentVariableMissing(String),
-    /// {0} is details of what is wrong with the variable setting.
+    /// Environment variable set wrong error.
     #[error("{0}")]
     EnvironmentVariableSetWrong(String),
+    /// Invalid URL error.
     #[error("Invalid URL: {0}")]
     InvalidUrl(#[from] url::ParseError),
+    /// Invalid network error.
+    #[error("Invalid network: {0}")]
+    InvalidNetwork(String),
 }
 
 /// Error that can accure when interacting with the Kakarot ETH API.
@@ -55,6 +60,9 @@ pub enum EthApiError<E: std::error::Error> {
     /// Missing parameter error.
     #[error("Missing parameter: {0}")]
     MissingParameterError(String),
+    /// Configuration error.
+    #[error(transparent)]
+    ConfigError(#[from] ConfigError),
     /// Other error.
     #[error(transparent)]
     Other(#[from] anyhow::Error),
@@ -96,6 +104,7 @@ impl<E: std::error::Error> From<EthApiError<E>> for ErrorObject<'static> {
             EthApiError::KakarotDataFilteringError(err) => rpc_err(INTERNAL_ERROR_CODE, err),
             EthApiError::FeederGatewayError(err) => rpc_err(INTERNAL_ERROR_CODE, err),
             EthApiError::MissingParameterError(err) => rpc_err(INVALID_PARAMS_CODE, err),
+            EthApiError::ConfigError(err) => rpc_err(INTERNAL_ERROR_CODE, err.to_string()),
             EthApiError::Other(err) => rpc_err(INTERNAL_ERROR_CODE, err.to_string()),
         }
     }

--- a/crates/core/src/client/helpers.rs
+++ b/crates/core/src/client/helpers.rs
@@ -52,7 +52,7 @@ pub fn decode_eth_call_return<T: std::error::Error>(
         actual: 0,
     })?;
     let return_data_len: u64 =
-        return_data_len.try_into().map_err(|e: ValueOutOfRangeError| ConversionError::Other(e.to_string()))?;
+        return_data_len.try_into().map_err(|e: ValueOutOfRangeError| ConversionError::<()>::Other(e.to_string()))?;
 
     let return_data = call_result.get(1..).ok_or_else(|| DataDecodingError::InvalidReturnArrayLength {
         entrypoint: "eth_call or eth_send_transaction".into(),

--- a/crates/core/src/client/mod.rs
+++ b/crates/core/src/client/mod.rs
@@ -53,7 +53,7 @@ pub struct KakarotClient<P: Provider + Send + Sync> {
 
 impl<P: Provider + Send + Sync> KakarotClient<P> {
     /// Create a new `KakarotClient`.
-    pub fn new(starknet_config: StarknetConfig, starknet_provider: P) -> KakarotClient<P> {
+    pub fn new(starknet_config: StarknetConfig, starknet_provider: P) -> Self {
         let StarknetConfig { kakarot_address, proxy_account_class_hash, network } = starknet_config;
 
         let kakarot_contract = KakarotContract::new(kakarot_address, proxy_account_class_hash);

--- a/crates/core/src/client/tests/mod.rs
+++ b/crates/core/src/client/tests/mod.rs
@@ -1,17 +1,16 @@
 use std::str::FromStr;
 
 use dojo_test_utils::rpc::MockJsonRpcTransport;
-use dotenv::dotenv;
 use reth_primitives::{BlockId, BlockNumberOrTag, Bytes, H256, U256, U64};
 use reth_rpc_types::CallRequest;
 use starknet::core::types::{BlockId as StarknetBlockId, BlockTag, BroadcastedInvokeTransactionV1};
 use starknet::macros::selector;
 use starknet::providers::jsonrpc::{HttpTransport, JsonRpcMethod};
-use starknet::providers::{JsonRpcClient, Provider};
+use starknet::providers::{JsonRpcClient, Provider, SequencerGatewayProvider};
 use starknet_crypto::FieldElement;
 use url::Url;
 
-use super::config::GatewayUrl;
+use super::config::{Network, SequencerGatewayProviderBuilder};
 use crate::client::api::{KakarotEthApi, KakarotStarknetApi};
 use crate::client::config::StarknetConfig;
 use crate::client::KakarotClient;
@@ -23,20 +22,18 @@ use crate::mock::constants::{
 use crate::mock::mock_starknet::{fixtures, mock_starknet_provider, AvailableFixtures, StarknetRpcFixture};
 use crate::wrap_kakarot;
 
-pub fn init_testnet_client() -> KakarotClient<JsonRpcClient<HttpTransport>> {
-    dotenv().ok();
+pub fn init_testnet_client() -> KakarotClient<SequencerGatewayProvider> {
     let kakarot_address = FieldElement::from_hex_be(KAKAROT_TESTNET_ADDRESS).unwrap();
     let config = StarknetConfig::new(Network::Goerli1, kakarot_address, Default::default());
 
-    let provider = JsonRpcClientBuilder::with_http(&config).unwrap().build();
-    KakarotClient::new(config, provider).unwrap()
+    let provider = SequencerGatewayProviderBuilder::new(&Network::Goerli1).build();
+    KakarotClient::new(config, provider)
 }
 
 pub fn init_mock_client(
     fixtures: Option<Vec<StarknetRpcFixture>>,
 ) -> KakarotClient<JsonRpcClient<MockJsonRpcTransport>> {
-    dotenv().ok();
-    let config = StarknetConfig::new(Network::Goerli1, *KAKAROT_ADDRESS, *PROXY_ACCOUNT_CLASS_HASH);
+    let config = StarknetConfig::new(Network::Katana, *KAKAROT_ADDRESS, *PROXY_ACCOUNT_CLASS_HASH);
     let starknet_provider = mock_starknet_provider(fixtures);
 
     KakarotClient::new(config, starknet_provider)

--- a/crates/core/src/client/tests/mod.rs
+++ b/crates/core/src/client/tests/mod.rs
@@ -25,9 +25,9 @@ use crate::wrap_kakarot;
 
 pub fn init_testnet_client() -> KakarotClient<SequencerGatewayProvider> {
     let kakarot_address = FieldElement::from_hex_be(KAKAROT_TESTNET_ADDRESS).unwrap();
-    let config = StarknetConfig::new(Network::Goerli1, kakarot_address, Default::default());
+    let config = StarknetConfig::new(Network::Goerli1Gateway, kakarot_address, Default::default());
 
-    let provider = SequencerGatewayProviderBuilder::new(&Network::Goerli1).build();
+    let provider = SequencerGatewayProviderBuilder::new(&Network::Goerli1Gateway).build();
     KakarotClient::new(config, provider)
 }
 

--- a/crates/core/src/client/tests/mod.rs
+++ b/crates/core/src/client/tests/mod.rs
@@ -1,27 +1,42 @@
 use std::str::FromStr;
 
 use dojo_test_utils::rpc::MockJsonRpcTransport;
-use reth_primitives::{BlockId, BlockNumberOrTag, H256, U256, U64};
-use starknet::core::types::{BlockId as StarknetBlockId, BlockTag};
-use starknet::providers::jsonrpc::JsonRpcMethod;
-use starknet::providers::JsonRpcClient;
+use dotenv::dotenv;
+use reth_primitives::{BlockId, BlockNumberOrTag, Bytes, H256, U256, U64};
+use reth_rpc_types::CallRequest;
+use starknet::core::types::{BlockId as StarknetBlockId, BlockTag, BroadcastedInvokeTransactionV1};
+use starknet::macros::selector;
+use starknet::providers::jsonrpc::{HttpTransport, JsonRpcMethod};
+use starknet::providers::{JsonRpcClient, Provider};
+use starknet_crypto::FieldElement;
+use url::Url;
 
+use super::config::GatewayUrl;
 use crate::client::api::{KakarotEthApi, KakarotStarknetApi};
 use crate::client::config::StarknetConfig;
 use crate::client::KakarotClient;
 use crate::mock::constants::{
-    ABDEL_ETHEREUM_ADDRESS, ABDEL_STARKNET_ADDRESS, ABDEL_STARKNET_ADDRESS_HEX, KAKAROT_ADDRESS,
+    ABDEL_ETHEREUM_ADDRESS, ABDEL_STARKNET_ADDRESS, ABDEL_STARKNET_ADDRESS_HEX, ACCOUNT_ADDRESS, ACCOUNT_ADDRESS_EVM,
+    COUNTER_ADDRESS, COUNTER_ADDRESS_EVM, INC_DATA, KAKAROT_ADDRESS, KAKAROT_CHAIN_ID, KAKAROT_TESTNET_ADDRESS,
     PROXY_ACCOUNT_CLASS_HASH, PROXY_ACCOUNT_CLASS_HASH_HEX,
 };
 use crate::mock::mock_starknet::{fixtures, mock_starknet_provider, AvailableFixtures, StarknetRpcFixture};
 use crate::wrap_kakarot;
 
-pub fn init_client(fixtures: Option<Vec<StarknetRpcFixture>>) -> KakarotClient<JsonRpcClient<MockJsonRpcTransport>> {
-    let config = StarknetConfig {
-        kakarot_address: *KAKAROT_ADDRESS,
-        proxy_account_class_hash: *PROXY_ACCOUNT_CLASS_HASH,
-        ..Default::default()
-    };
+pub fn init_testnet_client() -> KakarotClient<JsonRpcClient<HttpTransport>> {
+    dotenv().ok();
+    let kakarot_address = FieldElement::from_hex_be(KAKAROT_TESTNET_ADDRESS).unwrap();
+    let config = StarknetConfig::new(Network::Goerli1, kakarot_address, Default::default());
+
+    let provider = JsonRpcClientBuilder::with_http(&config).unwrap().build();
+    KakarotClient::new(config, provider).unwrap()
+}
+
+pub fn init_mock_client(
+    fixtures: Option<Vec<StarknetRpcFixture>>,
+) -> KakarotClient<JsonRpcClient<MockJsonRpcTransport>> {
+    dotenv().ok();
+    let config = StarknetConfig::new(Network::Goerli1, *KAKAROT_ADDRESS, *PROXY_ACCOUNT_CLASS_HASH);
     let starknet_provider = mock_starknet_provider(fixtures);
 
     KakarotClient::new(config, starknet_provider)
@@ -31,7 +46,7 @@ pub fn init_client(fixtures: Option<Vec<StarknetRpcFixture>>) -> KakarotClient<J
 async fn test_block_number() {
     // Given
     let fixtures = fixtures(vec![wrap_kakarot!(JsonRpcMethod::BlockNumber)]);
-    let client = init_client(Some(fixtures));
+    let client = init_mock_client(Some(fixtures));
 
     // When
     let block_number = client.block_number().await.unwrap();
@@ -44,7 +59,7 @@ async fn test_block_number() {
 async fn test_nonce() {
     // Given
     let fixtures = fixtures(vec![wrap_kakarot!(JsonRpcMethod::GetNonce), AvailableFixtures::ComputeStarknetAddress]);
-    let client = init_client(Some(fixtures));
+    let client = init_mock_client(Some(fixtures));
 
     // When
     let nonce = client.nonce(*ABDEL_ETHEREUM_ADDRESS, BlockId::Number(BlockNumberOrTag::Latest)).await.unwrap();
@@ -57,7 +72,7 @@ async fn test_nonce() {
 async fn test_get_evm_address() {
     // Given
     let fixtures = fixtures(vec![AvailableFixtures::GetEvmAddress]);
-    let client = init_client(Some(fixtures));
+    let client = init_mock_client(Some(fixtures));
 
     // When
     let evm_address =
@@ -71,7 +86,7 @@ async fn test_get_evm_address() {
 async fn test_fee_history() {
     // Given
     let fixtures = fixtures(vec![wrap_kakarot!(JsonRpcMethod::BlockNumber)]);
-    let client = init_client(Some(fixtures));
+    let client = init_mock_client(Some(fixtures));
 
     // When
     let count = 10;
@@ -90,7 +105,7 @@ async fn test_fee_history() {
 async fn test_fee_history_should_return_oldest_block_0() {
     // Given
     let fixtures = fixtures(vec![]);
-    let client = init_client(Some(fixtures));
+    let client = init_mock_client(Some(fixtures));
 
     // When
     let block_count = U256::from(10);
@@ -110,7 +125,7 @@ async fn test_transaction_by_hash() {
         AvailableFixtures::GetClassHashAt(ABDEL_STARKNET_ADDRESS_HEX.into(), PROXY_ACCOUNT_CLASS_HASH_HEX.into()),
         AvailableFixtures::GetEvmAddress,
     ]);
-    let client = init_client(Some(fixtures));
+    let client = init_mock_client(Some(fixtures));
 
     // When
     let tx = client
@@ -123,4 +138,63 @@ async fn test_transaction_by_hash() {
     // Then
     assert_eq!(*ABDEL_ETHEREUM_ADDRESS, tx.from);
     assert_eq!(U256::from(0), tx.nonce);
+}
+
+#[tokio::test]
+async fn test_simulate_transaction() {
+    // Given
+    let client = init_testnet_client();
+    let block_id = StarknetBlockId::Tag(BlockTag::Latest);
+    let rpc_client = JsonRpcClient::new(HttpTransport::new(
+        Url::from_str("https://starknet-goerli.infura.io/v3/f453f09c949a453c9bc03a34efcca010").unwrap(),
+    ));
+
+    let block_number = rpc_client.block_number().await.unwrap();
+    let nonce = rpc_client.get_nonce(block_id, *ACCOUNT_ADDRESS).await.unwrap();
+
+    let calldata = vec![
+        FieldElement::ONE,  // call array length
+        *COUNTER_ADDRESS,   // counter address
+        selector!("inc"),   // selector
+        FieldElement::ZERO, // data offset length
+        FieldElement::ZERO, // data length
+        FieldElement::ZERO, // calldata length
+    ];
+
+    let tx = BroadcastedInvokeTransactionV1 {
+        sender_address: *ACCOUNT_ADDRESS,
+        calldata,
+        max_fee: FieldElement::ZERO,
+        nonce,
+        signature: vec![],
+    };
+
+    // When
+    let simulation = client.simulate_transaction(tx, block_number, true).await.unwrap();
+
+    // Then
+    assert!(simulation.fee_estimation.gas_price > 0);
+    assert!(simulation.fee_estimation.gas_usage > 0);
+    assert!(simulation.fee_estimation.overall_fee > 0);
+}
+
+#[tokio::test]
+async fn test_estimate_gas() {
+    // Given
+    let client = init_testnet_client();
+
+    let request = CallRequest {
+        from: Some(*ACCOUNT_ADDRESS_EVM),               // account address
+        to: Some(*COUNTER_ADDRESS_EVM),                 // counter address
+        data: Some(Bytes::from_str(INC_DATA).unwrap()), // call to inc()
+        chain_id: Some(*KAKAROT_CHAIN_ID),              // "KKRT" chain id
+        ..Default::default()
+    };
+    let block_id = BlockId::Number(BlockNumberOrTag::Latest);
+
+    // When
+    let estimate = client.estimate_gas(request, block_id).await.unwrap();
+
+    // Then
+    assert!(estimate > U256::from(0));
 }

--- a/crates/core/src/kakarot/mod.rs
+++ b/crates/core/src/kakarot/mod.rs
@@ -49,13 +49,13 @@ impl<P: Provider + Send + Sync> KakarotContract<P> {
         &self,
         starknet_provider: &P,
         to: &FieldElement,
-        eth_calldata: &mut Vec<FieldElement>,
+        mut eth_calldata: Vec<FieldElement>,
         block_id: &BlockId,
     ) -> Result<Bytes, EthApiError<P::Error>> {
         let mut calldata =
             vec![*to, FieldElement::MAX, FieldElement::ZERO, FieldElement::ZERO, eth_calldata.len().into()];
 
-        calldata.append(eth_calldata);
+        calldata.append(&mut eth_calldata);
 
         let request = FunctionCall { contract_address: self.address, entry_point_selector: ETH_CALL, calldata };
         let result = starknet_provider.call(request, block_id).await?;

--- a/crates/core/src/kakarot/mod.rs
+++ b/crates/core/src/kakarot/mod.rs
@@ -48,12 +48,12 @@ impl<P: Provider + Send + Sync> KakarotContract<P> {
     pub async fn eth_call(
         &self,
         starknet_provider: &P,
-        eth_address: &FieldElement,
+        to: &FieldElement,
         eth_calldata: &mut Vec<FieldElement>,
         block_id: &BlockId,
     ) -> Result<Bytes, EthApiError<P::Error>> {
         let mut calldata =
-            vec![*eth_address, FieldElement::MAX, FieldElement::ZERO, FieldElement::ZERO, eth_calldata.len().into()];
+            vec![*to, FieldElement::MAX, FieldElement::ZERO, FieldElement::ZERO, eth_calldata.len().into()];
 
         calldata.append(eth_calldata);
 

--- a/crates/core/src/mock/constants.rs
+++ b/crates/core/src/mock/constants.rs
@@ -1,7 +1,7 @@
 use std::str::FromStr;
 
 use lazy_static::lazy_static;
-use reth_primitives::Address;
+use reth_primitives::{Address, U64};
 use starknet_crypto::FieldElement;
 
 pub const PROXY_ACCOUNT_CLASS_HASH_HEX: &str = "0x0775033b738dfe34c48f43a839c3d882ebe521befb3447240f2d218f14816ef5";
@@ -11,6 +11,13 @@ pub const OTHER_PROXY_ACCOUNT_CLASS_HASH_HEX: &str =
     "0x0775033b738dfe34c48f43a839c3d882ebe521befb3447240f2d218f14816ef1";
 pub const OTHER_ADDRESS_HEX: &str = "0x744ed080b42c8883a7e31cd11a14b7ae9ef27698b785486bb75cd116c8f1485";
 
+pub const ACCOUNT_ADDRESS_HEX: &str = "0x044021e020d096bd375bddc0f8d122ecae520003ca4c2691cccaa9ad5b53eed7";
+pub const ACCOUNT_PUBLIC_HEX: &str = "0x05f8d139ff7b7ad69bed4f71a775a3ccb5efaaeedd1cc3a63ff51a725f9b9738";
+
+pub const KAKAROT_TESTNET_ADDRESS: &str = "0x01e98a4d6cadc1e3511d150ef2705b02fccb3fb6f15aba863503af58f4b217ea";
+pub const EXAMPLE_URL: &str = "http://example.net";
+
+// Mock values
 lazy_static! {
     /// Test value for Kakarot contract address.
     pub static ref KAKAROT_ADDRESS: FieldElement =
@@ -22,4 +29,17 @@ lazy_static! {
     /// Test value for proxy account class hash.
     pub static ref PROXY_ACCOUNT_CLASS_HASH: FieldElement =
         FieldElement::from_hex_be(PROXY_ACCOUNT_CLASS_HASH_HEX).unwrap();
+}
+
+// Testnet values
+pub const INC_DATA: &str = "0x371303c0";
+lazy_static! {
+    pub static ref ACCOUNT_ADDRESS: FieldElement = FieldElement::from_hex_be(ACCOUNT_ADDRESS_HEX).unwrap();
+    pub static ref COUNTER_ADDRESS: FieldElement =
+        FieldElement::from_hex_be("0x03c12643f0e9f0b41de95a87e4f03f5fa69601930e9354a206a0b82a02119f2b").unwrap();
+    pub static ref ACCOUNT_ADDRESS_EVM: Address =
+        Address::from_str("0x54B288676B749DEF5FC10EB17244FE2C87375dE1").unwrap();
+    pub static ref COUNTER_ADDRESS_EVM: Address =
+        Address::from_str("0x2e11ed82f5ec165ab8ce3cc094f025fe7527f4d1").unwrap();
+    pub static ref KAKAROT_CHAIN_ID: U64 = U64::from(1263227476);
 }

--- a/crates/core/src/mock/constants.rs
+++ b/crates/core/src/mock/constants.rs
@@ -14,9 +14,6 @@ pub const OTHER_ADDRESS_HEX: &str = "0x744ed080b42c8883a7e31cd11a14b7ae9ef27698b
 pub const ACCOUNT_ADDRESS_HEX: &str = "0x044021e020d096bd375bddc0f8d122ecae520003ca4c2691cccaa9ad5b53eed7";
 pub const ACCOUNT_PUBLIC_HEX: &str = "0x05f8d139ff7b7ad69bed4f71a775a3ccb5efaaeedd1cc3a63ff51a725f9b9738";
 
-pub const KAKAROT_TESTNET_ADDRESS: &str = "0x01e98a4d6cadc1e3511d150ef2705b02fccb3fb6f15aba863503af58f4b217ea";
-pub const EXAMPLE_URL: &str = "http://example.net";
-
 // Mock values
 lazy_static! {
     /// Test value for Kakarot contract address.
@@ -33,6 +30,7 @@ lazy_static! {
 
 // Testnet values
 pub const INC_DATA: &str = "0x371303c0";
+pub const KAKAROT_TESTNET_ADDRESS: &str = "0x01e98a4d6cadc1e3511d150ef2705b02fccb3fb6f15aba863503af58f4b217ea";
 lazy_static! {
     pub static ref ACCOUNT_ADDRESS: FieldElement = FieldElement::from_hex_be(ACCOUNT_ADDRESS_HEX).unwrap();
     pub static ref COUNTER_ADDRESS: FieldElement =

--- a/crates/core/src/mock/constants.rs
+++ b/crates/core/src/mock/constants.rs
@@ -1,7 +1,7 @@
 use std::str::FromStr;
 
 use lazy_static::lazy_static;
-use reth_primitives::{Address, U64};
+use reth_primitives::Address;
 use starknet_crypto::FieldElement;
 
 pub const PROXY_ACCOUNT_CLASS_HASH_HEX: &str = "0x0775033b738dfe34c48f43a839c3d882ebe521befb3447240f2d218f14816ef5";
@@ -39,5 +39,4 @@ lazy_static! {
         Address::from_str("0x54B288676B749DEF5FC10EB17244FE2C87375dE1").unwrap();
     pub static ref COUNTER_ADDRESS_EVM: Address =
         Address::from_str("0x2e11ed82f5ec165ab8ce3cc094f025fe7527f4d1").unwrap();
-    pub static ref KAKAROT_CHAIN_ID: U64 = U64::from(1263227476);
 }

--- a/crates/core/src/mock/wiremock_utils.rs
+++ b/crates/core/src/mock/wiremock_utils.rs
@@ -3,16 +3,10 @@ use std::str::FromStr;
 use reqwest::StatusCode;
 use reth_primitives::{BlockId, H256};
 use serde::{Deserialize, Serialize};
-use starknet::core::types::{BlockId as StarknetBlockId, BlockTag, FieldElement};
-use starknet::providers::jsonrpc::HttpTransport;
-use starknet::providers::JsonRpcClient;
-use url::Url;
+use starknet::core::types::{BlockId as StarknetBlockId, BlockTag};
 use wiremock::matchers::{body_json, method};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
-use crate::client::api::KakarotEthApi;
-use crate::client::config::{JsonRpcClientBuilder, Network, StarknetConfig};
-use crate::client::KakarotClient;
 use crate::models::block::EthBlockId;
 
 #[derive(Serialize, Debug)]
@@ -117,39 +111,6 @@ pub async fn setup_wiremock() -> String {
     // TODO: Use the latest mapping between starknet and EVM addresses
 
     mock_server.uri()
-}
-
-pub async fn setup_mock_client() -> Box<dyn KakarotEthApi<JsonRpcClient<HttpTransport>>> {
-    let provider_url = setup_wiremock().await;
-    let kakarot_address =
-        FieldElement::from_hex_be("0x566864dbc2ae76c2d12a8a5a334913d0806f85b7a4dccea87467c3ba3616e75").unwrap();
-    let proxy_account_class_hash =
-        FieldElement::from_hex_be("0x0775033b738dfe34c48f43a839c3d882ebe521befb3447240f2d218f14816ef5").unwrap();
-
-    let config = StarknetConfig::new(
-        Network::JsonRpcProvider(Url::parse(&provider_url).unwrap()),
-        kakarot_address,
-        proxy_account_class_hash,
-    );
-    let starknet_provider = JsonRpcClientBuilder::with_http(&config).unwrap().build();
-    Box::new(KakarotClient::new(config, starknet_provider))
-}
-
-pub async fn setup_mock_client_crate() -> KakarotClient<JsonRpcClient<HttpTransport>> {
-    let provider_url = setup_wiremock().await;
-    let kakarot_address =
-        FieldElement::from_hex_be("0x566864dbc2ae76c2d12a8a5a334913d0806f85b7a4dccea87467c3ba3616e75").unwrap();
-    let proxy_account_class_hash =
-        FieldElement::from_hex_be("0x0775033b738dfe34c48f43a839c3d882ebe521befb3447240f2d218f14816ef5").unwrap();
-
-    let config = StarknetConfig::new(
-        Network::JsonRpcProvider(Url::parse(&provider_url).unwrap()),
-        kakarot_address,
-        proxy_account_class_hash,
-    );
-    let starknet_provider = JsonRpcClientBuilder::with_http(&config).unwrap().build();
-
-    KakarotClient::new(config, starknet_provider)
 }
 
 fn mock_block_number() -> Mock {

--- a/crates/core/src/models/block.rs
+++ b/crates/core/src/models/block.rs
@@ -277,7 +277,7 @@ impl ConvertibleStarknetBlock for BlockWithTxs {
 mod tests {
 
     use super::*;
-    use crate::client::tests::init_client;
+    use crate::client::tests::init_mock_client;
     use crate::mock::constants::{
         ABDEL_STARKNET_ADDRESS_HEX, OTHER_ADDRESS_HEX, OTHER_PROXY_ACCOUNT_CLASS_HASH_HEX, PROXY_ACCOUNT_CLASS_HASH_HEX,
     };
@@ -291,7 +291,7 @@ mod tests {
         let starknet_block_with_tx_hashes = BlockWithTxHashes::new(starknet_block_with_tx_hashes);
 
         let fixtures = fixtures(vec![]);
-        let client = init_client(Some(fixtures));
+        let client = init_mock_client(Some(fixtures));
 
         // When
         let eth_block_with_tx_hashes = starknet_block_with_tx_hashes.to_eth_block(&client).await.inner;
@@ -314,7 +314,7 @@ mod tests {
             AvailableFixtures::GetClassHashAt(OTHER_ADDRESS_HEX.into(), OTHER_PROXY_ACCOUNT_CLASS_HASH_HEX.into()),
             AvailableFixtures::GetEvmAddress,
         ]);
-        let client = init_client(Some(fixtures));
+        let client = init_mock_client(Some(fixtures));
 
         // When
         let eth_block_with_txs = starknet_block_with_txs.to_eth_block(&client).await.inner;

--- a/crates/core/src/models/block.rs
+++ b/crates/core/src/models/block.rs
@@ -24,8 +24,8 @@ impl EthBlockId {
 }
 
 impl TryFrom<EthBlockId> for StarknetBlockId {
-    type Error = ConversionError;
-    fn try_from(eth_block_id: EthBlockId) -> Result<Self, ConversionError> {
+    type Error = ConversionError<()>;
+    fn try_from(eth_block_id: EthBlockId) -> Result<Self, Self::Error> {
         match eth_block_id.0 {
             EthereumBlockId::Hash(hash) => {
                 let hash: Felt252Wrapper = hash.block_hash.try_into()?;

--- a/crates/core/src/models/call.rs
+++ b/crates/core/src/models/call.rs
@@ -24,7 +24,7 @@ impl From<Vec<Call>> for Calls {
 
 /// Converts a raw starknet transaction calldata to a vector of starknet calls.
 impl TryFrom<Vec<FieldElement>> for Calls {
-    type Error = ConversionError;
+    type Error = ConversionError<()>;
 
     fn try_from(value: Vec<FieldElement>) -> Result<Self, Self::Error> {
         // in account calls, the calldata is first each call as {contract address, selector, data offset,

--- a/crates/core/src/models/event.rs
+++ b/crates/core/src/models/event.rs
@@ -143,7 +143,8 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "ToEthereumAddressError")]
+    #[should_panic(expected = "ConversionError(\"failed to convert Felt252Wrapper to Ethereum address: the value \
+                               exceeds the maximum size of an Ethereum address\")")]
     fn test_to_eth_log_should_fail_on_key_not_convertible_to_eth_address() {
         // Given
         let event: Event =

--- a/crates/core/src/models/event.rs
+++ b/crates/core/src/models/event.rs
@@ -89,7 +89,7 @@ impl ConvertibleStarknetEvent for StarknetEvent {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::client::tests::init_client;
+    use crate::client::tests::init_mock_client;
     use crate::mock::mock_starknet::fixtures;
 
     #[test]
@@ -99,7 +99,7 @@ mod tests {
         let starknet_event = StarknetEvent::new(event);
 
         let fixtures = fixtures(vec![]);
-        let client = init_client(Some(fixtures));
+        let client = init_mock_client(Some(fixtures));
 
         // When
         let eth_log = starknet_event.to_eth_log(&client, None, None, None, None, None).unwrap();
@@ -116,7 +116,7 @@ mod tests {
         let starknet_event = StarknetEvent::new(event);
 
         let fixtures = fixtures(vec![]);
-        let client = init_client(Some(fixtures));
+        let client = init_mock_client(Some(fixtures));
 
         // When
         let eth_log = starknet_event.to_eth_log(&client, None, None, None, None, None).unwrap();
@@ -136,7 +136,7 @@ mod tests {
         let starknet_event = StarknetEvent::new(event);
 
         let fixtures = fixtures(vec![]);
-        let client = init_client(Some(fixtures));
+        let client = init_mock_client(Some(fixtures));
 
         // When
         starknet_event.to_eth_log(&client, None, None, None, None, None).unwrap();
@@ -151,7 +151,7 @@ mod tests {
         let starknet_event = StarknetEvent::new(event);
 
         let fixtures = fixtures(vec![]);
-        let client = init_client(Some(fixtures));
+        let client = init_mock_client(Some(fixtures));
 
         // When
         starknet_event.to_eth_log(&client, None, None, None, None, None).unwrap();
@@ -164,7 +164,7 @@ mod tests {
         let starknet_event = StarknetEvent::new(event);
 
         let fixtures = fixtures(vec![]);
-        let client = init_client(Some(fixtures));
+        let client = init_mock_client(Some(fixtures));
 
         // When
         let block_hash = Some(H256::from_low_u64_be(0xdeadbeef));

--- a/crates/core/src/models/felt.rs
+++ b/crates/core/src/models/felt.rs
@@ -37,7 +37,7 @@ impl From<u64> for Felt252Wrapper {
 }
 
 impl TryFrom<Felt252Wrapper> for u64 {
-    type Error = ConversionError;
+    type Error = ConversionError<()>;
 
     fn try_from(value: Felt252Wrapper) -> Result<Self, Self::Error> {
         u64::try_from(value.0).map_err(|e| ConversionError::ValueOutOfRange(e.to_string()))
@@ -45,7 +45,7 @@ impl TryFrom<Felt252Wrapper> for u64 {
 }
 
 impl TryFrom<Felt252Wrapper> for u128 {
-    type Error = ConversionError;
+    type Error = ConversionError<()>;
 
     fn try_from(value: Felt252Wrapper) -> Result<Self, Self::Error> {
         u128::try_from(value.0).map_err(|e| ConversionError::ValueOutOfRange(e.to_string()))
@@ -60,7 +60,7 @@ impl From<Address> for Felt252Wrapper {
 }
 
 impl TryFrom<Felt252Wrapper> for Address {
-    type Error = ConversionError;
+    type Error = ConversionError<()>;
 
     fn try_from(felt: Felt252Wrapper) -> Result<Self, Self::Error> {
         let felt: FieldElement = felt.into();
@@ -76,7 +76,7 @@ impl TryFrom<Felt252Wrapper> for Address {
 }
 
 impl TryFrom<H256> for Felt252Wrapper {
-    type Error = ConversionError;
+    type Error = ConversionError<()>;
 
     fn try_from(h256: H256) -> Result<Self, Self::Error> {
         let felt = FieldElement::from_bytes_be(&h256)?;
@@ -92,7 +92,7 @@ impl From<Felt252Wrapper> for H256 {
 }
 
 impl TryFrom<U256> for Felt252Wrapper {
-    type Error = ConversionError;
+    type Error = ConversionError<()>;
 
     fn try_from(u256: U256) -> Result<Self, Self::Error> {
         let felt = FieldElement::from_bytes_be(&u256.to_be_bytes())?;

--- a/crates/core/src/models/felt.rs
+++ b/crates/core/src/models/felt.rs
@@ -36,6 +36,22 @@ impl From<u64> for Felt252Wrapper {
     }
 }
 
+impl TryFrom<Felt252Wrapper> for u64 {
+    type Error = ConversionError;
+
+    fn try_from(value: Felt252Wrapper) -> Result<Self, Self::Error> {
+        u64::try_from(value.0).map_err(|e| ConversionError::ValueOutOfRange(e.to_string()))
+    }
+}
+
+impl TryFrom<Felt252Wrapper> for u128 {
+    type Error = ConversionError;
+
+    fn try_from(value: Felt252Wrapper) -> Result<Self, Self::Error> {
+        u128::try_from(value.0).map_err(|e| ConversionError::ValueOutOfRange(e.to_string()))
+    }
+}
+
 impl From<Address> for Felt252Wrapper {
     fn from(address: Address) -> Self {
         let felt = FieldElement::from_byte_slice_be(&address.0).unwrap(); // safe unwrap since H160 is 20 bytes

--- a/crates/core/src/models/felt.rs
+++ b/crates/core/src/models/felt.rs
@@ -1,3 +1,5 @@
+use std::ops::Mul;
+
 use reth_primitives::{Address, H256, U256};
 use starknet::core::types::FieldElement;
 
@@ -14,6 +16,14 @@ impl Felt252Wrapper {
     pub fn troncate_to_ethereum_address(&self) -> Address {
         let bytes = self.0.to_bytes_be();
         Address::from_slice(&bytes[12..])
+    }
+}
+
+impl Mul for Felt252Wrapper {
+    type Output = Self;
+
+    fn mul(self, rhs: Self) -> Self::Output {
+        Self(self.0 * rhs.0)
     }
 }
 

--- a/crates/core/src/models/mod.rs
+++ b/crates/core/src/models/mod.rs
@@ -9,6 +9,7 @@ pub mod signature;
 pub mod tests;
 pub mod transaction;
 
+use ruint::FromUintError;
 use starknet::core::types::FromByteArrayError;
 use thiserror::Error;
 
@@ -16,7 +17,7 @@ use crate::client::helpers::DataDecodingError;
 
 #[derive(Debug, Error)]
 /// Conversion error
-pub enum ConversionError {
+pub enum ConversionError<T> {
     /// Ethereum to Starknet transaction conversion error
     #[error("transaction conversion error: {0}")]
     TransactionConversionError(String),
@@ -35,6 +36,9 @@ pub enum ConversionError {
     /// Value out of range error
     #[error("value out of range: {0}")]
     ValueOutOfRange(String),
+    /// Uint conversion error
+    #[error(transparent)]
+    UintConversionError(#[from] FromUintError<T>),
     /// Other conversion error
     #[error("failed to convert value: {0}")]
     Other(String),

--- a/crates/core/src/models/transaction.rs
+++ b/crates/core/src/models/transaction.rs
@@ -137,7 +137,7 @@ impl StarknetTransaction {
 mod tests {
 
     use super::*;
-    use crate::client::tests::init_client;
+    use crate::client::tests::init_mock_client;
     use crate::mock::constants::{ABDEL_STARKNET_ADDRESS_HEX, PROXY_ACCOUNT_CLASS_HASH_HEX};
     use crate::mock::mock_starknet::{fixtures, AvailableFixtures};
 
@@ -152,7 +152,7 @@ mod tests {
             ABDEL_STARKNET_ADDRESS_HEX.into(),
             PROXY_ACCOUNT_CLASS_HASH_HEX.into(),
         )]);
-        let client = init_client(Some(fixtures));
+        let client = init_mock_client(Some(fixtures));
 
         // When
         let is_kakarot_tx = starknet_transaction.is_kakarot_tx(&client).await.unwrap();
@@ -172,7 +172,7 @@ mod tests {
             AvailableFixtures::GetClassHashAt(ABDEL_STARKNET_ADDRESS_HEX.into(), PROXY_ACCOUNT_CLASS_HASH_HEX.into()),
             AvailableFixtures::GetEvmAddress,
         ]);
-        let client = init_client(Some(fixtures));
+        let client = init_mock_client(Some(fixtures));
 
         // When
         let eth_transaction = starknet_transaction.to_eth_transaction(&client, None, None, None).await.unwrap();

--- a/crates/core/src/models/transaction.rs
+++ b/crates/core/src/models/transaction.rs
@@ -28,7 +28,7 @@ impl From<StarknetTransaction> for Transaction {
 
 macro_rules! get_invoke_transaction_field {
     (($field_v0:ident, $field_v1:ident), $type:ty) => {
-        pub fn $field_v1(&self) -> Result<$type, ConversionError> {
+        pub fn $field_v1(&self) -> Result<$type, ConversionError<()>> {
             match &self.0 {
                 Transaction::Invoke(tx) => match tx {
                     InvokeTransaction::V0(tx) => Ok(tx.$field_v0.clone().into()),

--- a/crates/core/tests/client.rs
+++ b/crates/core/tests/client.rs
@@ -106,7 +106,7 @@ mod tests {
 
         let count_selector = counter_abi.function("count").unwrap().short_signature();
         let counter_bytes = kakarot_client
-            .call_view(
+            .call(
                 counter_eth_address,
                 count_selector.into(),
                 BlockId::Number(reth_primitives::BlockNumberOrTag::Latest),

--- a/crates/core/tests/client.rs
+++ b/crates/core/tests/client.rs
@@ -5,6 +5,7 @@ mod tests {
     use kakarot_rpc_core::client::api::KakarotEthApi;
     use kakarot_rpc_core::client::config::{Network, StarknetConfig};
     use kakarot_rpc_core::client::KakarotClient;
+    use kakarot_rpc_core::mock::constants::EXAMPLE_URL;
     use kakarot_rpc_core::models::felt::Felt252Wrapper;
     use kakarot_rpc_core::test_utils::constants::EOA_WALLET;
     use kakarot_rpc_core::test_utils::deploy_helpers::{
@@ -31,7 +32,8 @@ mod tests {
                 deployed_kakarot.kakarot_proxy,
             ),
             JsonRpcClient::new(HttpTransport::new(starknet_test_sequencer.url())),
-        );
+        )
+        .unwrap();
 
         // Zero address shouldn't throw 'ContractNotFound', but return zero
         assert_eq!(
@@ -66,7 +68,8 @@ mod tests {
                 deployed_kakarot.kakarot_proxy,
             ),
             JsonRpcClient::new(HttpTransport::new(starknet_test_sequencer.url())),
-        );
+        )
+        .unwrap();
 
         let deployed_balance = kakarot_client
             .balance(deployed_kakarot.eoa_eth_address, BlockId::Number(reth_primitives::BlockNumberOrTag::Latest))
@@ -163,7 +166,8 @@ mod tests {
                 deployed_kakarot.kakarot_proxy,
             ),
             JsonRpcClient::new(HttpTransport::new(starknet_test_sequencer.url())),
-        );
+        )
+        .unwrap();
 
         kakarot_client
             .get_code(plain_opcodes_eth_address, BlockId::Number(reth_primitives::BlockNumberOrTag::Latest))

--- a/crates/core/tests/client.rs
+++ b/crates/core/tests/client.rs
@@ -5,7 +5,6 @@ mod tests {
     use kakarot_rpc_core::client::api::KakarotEthApi;
     use kakarot_rpc_core::client::config::{Network, StarknetConfig};
     use kakarot_rpc_core::client::KakarotClient;
-    use kakarot_rpc_core::mock::constants::EXAMPLE_URL;
     use kakarot_rpc_core::models::felt::Felt252Wrapper;
     use kakarot_rpc_core::test_utils::constants::EOA_WALLET;
     use kakarot_rpc_core::test_utils::deploy_helpers::{
@@ -32,8 +31,7 @@ mod tests {
                 deployed_kakarot.kakarot_proxy,
             ),
             JsonRpcClient::new(HttpTransport::new(starknet_test_sequencer.url())),
-        )
-        .unwrap();
+        );
 
         // Zero address shouldn't throw 'ContractNotFound', but return zero
         assert_eq!(
@@ -68,8 +66,7 @@ mod tests {
                 deployed_kakarot.kakarot_proxy,
             ),
             JsonRpcClient::new(HttpTransport::new(starknet_test_sequencer.url())),
-        )
-        .unwrap();
+        );
 
         let deployed_balance = kakarot_client
             .balance(deployed_kakarot.eoa_eth_address, BlockId::Number(reth_primitives::BlockNumberOrTag::Latest))
@@ -166,8 +163,7 @@ mod tests {
                 deployed_kakarot.kakarot_proxy,
             ),
             JsonRpcClient::new(HttpTransport::new(starknet_test_sequencer.url())),
-        )
-        .unwrap();
+        );
 
         kakarot_client
             .get_code(plain_opcodes_eth_address, BlockId::Number(reth_primitives::BlockNumberOrTag::Latest))

--- a/crates/eth-rpc/src/api/eth_api.rs
+++ b/crates/eth-rpc/src/api/eth_api.rs
@@ -133,7 +133,7 @@ pub trait EthApi {
     /// Generates and returns an estimate of how much gas is necessary to allow the transaction to
     /// complete.
     #[method(name = "eth_estimateGas")]
-    async fn estimate_gas(&self, request: CallRequest, block_number: Option<BlockId>) -> Result<U256>;
+    async fn estimate_gas(&self, request: CallRequest, block_id: Option<BlockId>) -> Result<U256>;
 
     /// Returns the current price per gas in wei.
     #[method(name = "eth_gasPrice")]

--- a/crates/eth-rpc/src/main.rs
+++ b/crates/eth-rpc/src/main.rs
@@ -5,7 +5,9 @@ use eyre::Result;
 use kakarot_rpc::config::RPCConfig;
 use kakarot_rpc::rpc::KakarotRpcModuleBuilder;
 use kakarot_rpc::run_server;
-use kakarot_rpc_core::client::config::{JsonRpcClientBuilder, Network, StarknetConfig};
+use kakarot_rpc_core::client::config::{
+    JsonRpcClientBuilder, Network, SequencerGatewayProviderBuilder, StarknetConfig,
+};
 use kakarot_rpc_core::client::KakarotClient;
 use starknet::providers::jsonrpc::HttpTransport;
 use starknet::providers::{JsonRpcClient, SequencerGatewayProvider};
@@ -32,22 +34,12 @@ async fn main() -> Result<()> {
         Network::Madara | Network::Katana => {
             StarknetProvider::JsonRpcClient(JsonRpcClientBuilder::with_http(&starknet_config).unwrap().build())
         }
-
-        Network::Goerli1Gateway => {
-            StarknetProvider::SequencerGatewayProvider(SequencerGatewayProvider::starknet_alpha_goerli())
-        }
-
-        Network::Goerli2Gateway => {
-            StarknetProvider::SequencerGatewayProvider(SequencerGatewayProvider::starknet_alpha_goerli_2())
-        }
-
-        Network::MainnetGateway => {
-            StarknetProvider::SequencerGatewayProvider(SequencerGatewayProvider::starknet_alpha_mainnet())
-        }
-
-        Network::JsonRpcProvider(url) => {
+        Network::ProviderUrl(url) => {
             StarknetProvider::JsonRpcClient(JsonRpcClientBuilder::new(HttpTransport::new(url.clone())).build())
         }
+        _ => StarknetProvider::SequencerGatewayProvider(
+            SequencerGatewayProviderBuilder::new(&starknet_config.network).build(),
+        ),
     };
 
     let kakarot_rpc_module = match starknet_provider {

--- a/crates/eth-rpc/src/main.rs
+++ b/crates/eth-rpc/src/main.rs
@@ -34,7 +34,7 @@ async fn main() -> Result<()> {
         Network::Madara | Network::Katana => {
             StarknetProvider::JsonRpcClient(JsonRpcClientBuilder::with_http(&starknet_config).unwrap().build())
         }
-        Network::ProviderUrl(url) => {
+        Network::JsonRpcProvider(url) => {
             StarknetProvider::JsonRpcClient(JsonRpcClientBuilder::new(HttpTransport::new(url.clone())).build())
         }
         _ => StarknetProvider::SequencerGatewayProvider(

--- a/crates/eth-rpc/src/servers/eth_rpc.rs
+++ b/crates/eth-rpc/src/servers/eth_rpc.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use jsonrpsee::core::{async_trait, RpcResult as Result};
 use jsonrpsee::types::error::{INTERNAL_ERROR_CODE, METHOD_NOT_FOUND_CODE};
 use kakarot_rpc_core::client::api::KakarotEthApi;
-use kakarot_rpc_core::client::constants::{CHAIN_ID, ESTIMATE_GAS};
+use kakarot_rpc_core::client::constants::CHAIN_ID;
 use kakarot_rpc_core::client::errors::{rpc_err, EthApiError};
 use kakarot_rpc_core::models::block::EthBlockId;
 use reth_primitives::rpc::transaction::eip2930::AccessListWithGasUsed;
@@ -178,8 +178,10 @@ impl<P: Provider + Send + Sync + 'static> EthApiServer for KakarotEthRpc<P> {
         todo!()
     }
 
-    async fn estimate_gas(&self, _request: CallRequest, _block_number: Option<BlockId>) -> Result<U256> {
-        Ok(*ESTIMATE_GAS)
+    async fn estimate_gas(&self, request: CallRequest, block_id: Option<BlockId>) -> Result<U256> {
+        let block_id = block_id.unwrap_or(BlockId::Number(BlockNumberOrTag::Latest));
+
+        Ok(self.kakarot_client.estimate_gas(request, block_id).await?)
     }
 
     async fn gas_price(&self) -> Result<U256> {

--- a/crates/eth-rpc/src/servers/eth_rpc.rs
+++ b/crates/eth-rpc/src/servers/eth_rpc.rs
@@ -165,7 +165,7 @@ impl<P: Provider + Send + Sync + 'static> EthApiServer for KakarotEthRpc<P> {
         })?;
 
         let block_id = block_number.unwrap_or(BlockId::Number(BlockNumberOrTag::Latest));
-        let result = self.kakarot_client.call_view(to, Bytes::from(calldata.0), block_id).await?;
+        let result = self.kakarot_client.call(to, Bytes::from(calldata.0), block_id).await?;
 
         Ok(result)
     }


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->
Add a simulate transaction to the API and implements the json rpc method for `eth_estimateGas`.

Time spent on this PR: 2 days

Resolves: #164 

# Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Testing

# What is the new behavior?
Route estimate_gas is implemented using the gateway url. 

<!-- Please describe the behavior or changes that are being added by this PR. -->

# Does this introduce a breaking change?

- [ ] Yes
- [x] No

# Note

Currently, given the layout of the `Network` enum, we can only use estimate fee when using the `SequencerGatewayProvider`. Might need to modify it.
