### PR TITLE
Do not raise when starknet.getTransaction raises

### DIFF
--- a/crates/core/src/client/api.rs
+++ b/crates/core/src/client/api.rs
@@ -16,7 +16,7 @@ use crate::models::transaction::StarknetTransactions;
 pub trait KakarotEthApi<P: Provider + Send + Sync>: KakarotStarknetApi<P> + Send + Sync {
     async fn block_number(&self) -> Result<U64, EthApiError<P::Error>>;
 
-    async fn transaction_by_hash(&self, hash: H256) -> Result<EtherTransaction, EthApiError<P::Error>>;
+    async fn transaction_by_hash(&self, hash: H256) -> Result<Option<EtherTransaction>, EthApiError<P::Error>>;
 
     async fn get_code(
         &self,

--- a/crates/core/src/client/tests/mod.rs
+++ b/crates/core/src/client/tests/mod.rs
@@ -113,12 +113,16 @@ async fn test_transaction_by_hash() {
     let client = init_client(Some(fixtures));
 
     // When
-    let tx = client
+    let tx = match client
         .transaction_by_hash(
             H256::from_str("0x03204b4c0e379c3a5ccb80d08661d5a538e95e2960581c9faf7ebcf8ff5a7d3c").unwrap(),
         )
         .await
-        .unwrap();
+        .unwrap()
+    {
+        Some(tx) => tx,
+        None => panic!("Tx should not be none"),
+    };
 
     // Then
     assert_eq!(*ABDEL_ETHEREUM_ADDRESS, tx.from);

--- a/crates/eth-rpc/src/servers/eth_rpc.rs
+++ b/crates/eth-rpc/src/servers/eth_rpc.rs
@@ -106,7 +106,7 @@ impl<P: Provider + Send + Sync + 'static> EthApiServer for KakarotEthRpc<P> {
 
     async fn transaction_by_hash(&self, _hash: H256) -> Result<Option<EtherTransaction>> {
         let ether_tx = self.kakarot_client.transaction_by_hash(_hash).await?;
-        Ok(Some(ether_tx))
+        Ok(ether_tx)
     }
 
     async fn transaction_by_block_hash_and_index(&self, hash: H256, index: Index) -> Result<Option<EtherTransaction>> {


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

Time spent on this PR: 0.25

# Pull Request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Testing

# What is the new behavior?

Currently, when `starknet_provider` doesn't manage to find a transaction, we raise.
However, the eth_rpc doesn't raise on transaction not found.

The proposed modification is too large as it converts any starknet error into a `None` while
we should probably only convert `tx not found`. However, because some RPC don't use consistent error, I've done this as it was easier.

wdyt?

# Does this introduce a breaking change?

- [ ] Yes
- [x] No
