### PR TITLE
adjust proxy class hash, default to madara

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,7 +16,7 @@ MADARA_PRIVATE_KEY=0x00c1cf1490de1352865301bb8705143f3ef938f97fdf892f1090dcb5ac7
 KAKAROT_HTTP_RPC_ADDRESS=0.0.0.0:3030
 ## check `./deployments/katana/deployments.json` after running `make devnet`
 KAKAROT_ADDRESS=
-PROXY_ACCOUNT_CLASS_HASH=0x3010a53967fa04842bcbcb6de8817101f047ef0d074b3eacbe714a3fc42a2eb
+PROXY_ACCOUNT_CLASS_HASH=0x4b9eef81a3f0a582dfed69be93196cedbff063e0fa206b34b4c2f06ac505f0c
 
 ## configurations for testing
 COMPILED_KAKAROT_PATH=lib/kakarot/build

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 HURL_FILES = $(shell find ./rpc-call-examples/ -name '*.hurl')
 
-STARKNET_NETWORK?=katana
+STARKNET_NETWORK?=madara
 
 pull-kakarot: .gitmodules 
 	git submodule update --init --recursive
@@ -10,7 +10,7 @@ build-kakarot: setup
 	cd lib/kakarot && make build && make build-sol
 
 build-and-deploy-kakarot:
-	source .env && cd lib/kakarot && make deploy
+	source .env && cd lib/kakarot && STARKNET_NETWORK=$(STARKNET_NETWORK) make deploy
 
 deploy-kakarot:
 	source .env && cd lib/kakarot && poetry run python ./scripts/deploy_kakarot.py

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ build-and-deploy-kakarot:
 	source .env && cd lib/kakarot && STARKNET_NETWORK=$(STARKNET_NETWORK) make deploy
 
 deploy-kakarot:
-	source .env && cd lib/kakarot && poetry run python ./scripts/deploy_kakarot.py
+	source .env && cd lib/kakarot && STARKNET_NETWORK=$(STARKNET_NETWORK) poetry run python ./scripts/deploy_kakarot.py
 
 setup: pull-kakarot build-kakarot
 


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

Time spent on this PR: infinite

Resolves: #<Issue number>

# Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Testing

# What is the new behavior?

There was currently a very tragic 'but the forge script works on my computer, you guys' phenomena going on. After witnessing first hand the horror of the same flow not working on other computers (which also unfortunately exist), I made the effort to diff my top level env file from the example.

I was able to reproduce the error cases locally and then narrow it down to adjusting the `PROXY_ACCOUNT_CLASS_HASH`

I then cloned a fresh repo and did the following steps

- have rust and jq installed (need to ensure i have good coverage of this, was just focusing on reproducing/fixing the error cases i saw in two different deploy attempts today)
- in madara
  - run `cargo run --release -- --dev`
- in kkrt rpc
  - run `cp .env.example .env`
  - run `make setup`
  - run `cp lib/kakarot/.env.example .env`
  - run `make deploy-kakarot STARKNET_NETWORK=madara`
  - run `make run-dev STARKNET_NETWORK=madara`
- separate terminal run
  - run `forge script scripts/PlainOpcodes.s.sol --broadcast --legacy --compute-units-per-second 4000 --slow --fork-url http://0.0.0.0:3030` 

# Does this introduce a breaking change?

- [ ] Yes
- [X] No
