### PR TITLE
refactor: use namespaces to remove using prefixes for annotating methods, refactor Net API api …

### DIFF
--- a/crates/eth-rpc/src/api/alchemy_api.rs
+++ b/crates/eth-rpc/src/api/alchemy_api.rs
@@ -3,9 +3,10 @@ use jsonrpsee::proc_macros::rpc;
 use kakarot_rpc_core::models::balance::TokenBalances;
 use reth_primitives::Address;
 
-#[rpc(server)]
+// TODO: Define and implement of methods of Alchemy API
+#[rpc(server, namespace = "alchemy")]
 #[async_trait]
 pub trait AlchemyApi {
-    #[method(name = "alchemy_getTokenBalances")]
+    #[method(name = "getTokenBalances")]
     async fn token_balances(&self, address: Address, contract_addresses: Vec<Address>) -> Result<TokenBalances>;
 }

--- a/crates/eth-rpc/src/api/eth_api.rs
+++ b/crates/eth-rpc/src/api/eth_api.rs
@@ -7,10 +7,10 @@ use reth_rpc_types::{
     TransactionReceipt, TransactionRequest, Work,
 };
 
-#[rpc(server)]
+#[rpc(server, namespace = "eth")]
 #[async_trait]
 pub trait EthApi {
-    #[method(name = "eth_blockNumber")]
+    #[method(name = "blockNumber")]
     async fn block_number(&self) -> Result<U64>;
 
     /// Returns the protocol version encoded as a string.
@@ -18,51 +18,51 @@ pub trait EthApi {
     fn protocol_version(&self) -> Result<U64>;
 
     /// Returns an object with data about the sync status or false.
-    #[method(name = "eth_syncing")]
+    #[method(name = "syncing")]
     async fn syncing(&self) -> Result<SyncStatus>;
 
     /// Returns the client coinbase address.
-    #[method(name = "eth_coinbase")]
+    #[method(name = "coinbase")]
     async fn author(&self) -> Result<Address>;
 
     /// Returns a list of addresses owned by client.
-    #[method(name = "eth_accounts")]
+    #[method(name = "accounts")]
     async fn accounts(&self) -> Result<Vec<Address>>;
 
     /// Returns the chain ID of the current network.
-    #[method(name = "eth_chainId")]
+    #[method(name = "chainId")]
     async fn chain_id(&self) -> Result<Option<U64>>;
 
     /// Returns information about a block by hash.
-    #[method(name = "eth_getBlockByHash")]
+    #[method(name = "getBlockByHash")]
     async fn block_by_hash(&self, hash: H256, full: bool) -> Result<Option<RichBlock>>;
 
     /// Returns information about a block by number.
-    #[method(name = "eth_getBlockByNumber")]
+    #[method(name = "getBlockByNumber")]
     async fn block_by_number(&self, number: BlockNumberOrTag, full: bool) -> Result<Option<RichBlock>>;
 
     /// Returns the number of transactions in a block from a block matching the given block hash.
-    #[method(name = "eth_getBlockTransactionCountByHash")]
+    #[method(name = "getBlockTransactionCountByHash")]
     async fn block_transaction_count_by_hash(&self, hash: H256) -> Result<U64>;
 
     /// Returns the number of transactions in a block matching the given block number.
-    #[method(name = "eth_getBlockTransactionCountByNumber")]
+    #[method(name = "getBlockTransactionCountByNumber")]
     async fn block_transaction_count_by_number(&self, number: BlockNumberOrTag) -> Result<U64>;
 
     /// Returns the number of uncles in a block from a block matching the given block hash.
-    #[method(name = "eth_getUncleCountByBlockHash")]
+    #[method(name = "getUncleCountByBlockHash")]
     async fn block_uncles_count_by_hash(&self, hash: H256) -> Result<U256>;
 
     /// Returns the number of uncles in a block with given block number.
-    #[method(name = "eth_getUncleCountByBlockNumber")]
+    #[method(name = "getUncleCountByBlockNumber")]
     async fn block_uncles_count_by_number(&self, number: BlockNumberOrTag) -> Result<U256>;
 
     /// Returns an uncle block of the given block and index.
-    #[method(name = "eth_getUncleByBlockHashAndIndex")]
+    #[method(name = "getUncleByBlockHashAndIndex")]
     async fn uncle_by_block_hash_and_index(&self, hash: H256, index: Index) -> Result<Option<RichBlock>>;
 
     /// Returns an uncle block of the given block and index.
-    #[method(name = "eth_getUncleByBlockNumberAndIndex")]
+    #[method(name = "getUncleByBlockNumberAndIndex")]
     async fn uncle_by_block_number_and_index(
         &self,
         number: BlockNumberOrTag,
@@ -70,15 +70,15 @@ pub trait EthApi {
     ) -> Result<Option<RichBlock>>;
 
     /// Returns the information about a transaction requested by transaction hash.
-    #[method(name = "eth_getTransactionByHash")]
+    #[method(name = "getTransactionByHash")]
     async fn transaction_by_hash(&self, hash: H256) -> Result<Option<EthTransaction>>;
 
     /// Returns information about a transaction by block hash and transaction index position.
-    #[method(name = "eth_getTransactionByBlockHashAndIndex")]
+    #[method(name = "getTransactionByBlockHashAndIndex")]
     async fn transaction_by_block_hash_and_index(&self, hash: H256, index: Index) -> Result<Option<EthTransaction>>;
 
     /// Returns information about a transaction by block number and transaction index position.
-    #[method(name = "eth_getTransactionByBlockNumberAndIndex")]
+    #[method(name = "getTransactionByBlockNumberAndIndex")]
     async fn transaction_by_block_number_and_index(
         &self,
         number: BlockNumberOrTag,
@@ -86,27 +86,27 @@ pub trait EthApi {
     ) -> Result<Option<EthTransaction>>;
 
     /// Returns the receipt of a transaction by transaction hash.
-    #[method(name = "eth_getTransactionReceipt")]
+    #[method(name = "getTransactionReceipt")]
     async fn transaction_receipt(&self, hash: H256) -> Result<Option<TransactionReceipt>>;
 
     /// Returns the balance of the account of given address.
-    #[method(name = "eth_getBalance")]
+    #[method(name = "getBalance")]
     async fn balance(&self, address: Address, block_number: Option<BlockId>) -> Result<U256>;
 
     /// Returns the value from a storage position at a given address
-    #[method(name = "eth_getStorageAt")]
+    #[method(name = "getStorageAt")]
     async fn storage_at(&self, address: Address, index: U256, block_id: Option<BlockId>) -> Result<U256>;
 
     /// Returns the number of transactions sent from an address at given block number.
-    #[method(name = "eth_getTransactionCount")]
+    #[method(name = "getTransactionCount")]
     async fn transaction_count(&self, address: Address, block_id: Option<BlockId>) -> Result<U256>;
 
     /// Returns code at a given address at given block number.
-    #[method(name = "eth_getCode")]
+    #[method(name = "getCode")]
     async fn get_code(&self, address: Address, block_id: Option<BlockId>) -> Result<Bytes>;
 
     /// Executes a new message call immediately without creating a transaction on the block chain.
-    #[method(name = "eth_call")]
+    #[method(name = "call")]
     async fn call(&self, request: CallRequest, block_id: Option<BlockId>) -> Result<Bytes>;
 
     /// Generates an access list for a transaction.
@@ -119,11 +119,11 @@ pub trait EthApi {
     /// It returns list of addresses and storage keys used by the transaction, plus the gas
     /// consumed when the access list is added. That is, it gives you the list of addresses and
     /// storage keys that will be used by that transaction, plus the gas consumed if the access
-    /// list is included. Like eth_estimateGas, this is an estimation; the list could change
+    /// list is included. Like estimateGas, this is an estimation; the list could change
     /// when the transaction is actually mined. Adding an accessList to your transaction does
     /// not necessary result in lower gas usage compared to a transaction without an access
     /// list.
-    #[method(name = "eth_createAccessList")]
+    #[method(name = "createAccessList")]
     async fn create_access_list(
         &self,
         request: CallRequest,
@@ -132,11 +132,11 @@ pub trait EthApi {
 
     /// Generates and returns an estimate of how much gas is necessary to allow the transaction to
     /// complete.
-    #[method(name = "eth_estimateGas")]
+    #[method(name = "estimateGas")]
     async fn estimate_gas(&self, request: CallRequest, block_id: Option<BlockId>) -> Result<U256>;
 
     /// Returns the current price per gas in wei.
-    #[method(name = "eth_gasPrice")]
+    #[method(name = "gasPrice")]
     async fn gas_price(&self) -> Result<U256>;
 
     /// Returns the Transaction fee history
@@ -146,7 +146,7 @@ pub trait EthApi {
     /// Returns transaction base fee per gas and effective priority fee per gas for the
     /// requested/supported block range. The returned Fee history for the returned block range
     /// can be a subsection of the requested range if not all blocks are available.
-    #[method(name = "eth_feeHistory")]
+    #[method(name = "feeHistory")]
     async fn fee_history(
         &self,
         block_count: U256,
@@ -155,56 +155,56 @@ pub trait EthApi {
     ) -> Result<FeeHistory>;
 
     /// Returns the current maxPriorityFeePerGas per gas in wei.
-    #[method(name = "eth_maxPriorityFeePerGas")]
+    #[method(name = "maxPriorityFeePerGas")]
     async fn max_priority_fee_per_gas(&self) -> Result<U128>;
 
     /// Returns whether the client is actively mining new blocks.
-    #[method(name = "eth_mining")]
+    #[method(name = "mining")]
     async fn is_mining(&self) -> Result<bool>;
 
     /// Returns the number of hashes per second that the node is mining with.
-    #[method(name = "eth_hashrate")]
+    #[method(name = "hashrate")]
     async fn hashrate(&self) -> Result<U256>;
 
     /// Returns the hash of the current block, the seedHash, and the boundary condition to be met
     /// (“target”)
-    #[method(name = "eth_getWork")]
+    #[method(name = "getWork")]
     async fn get_work(&self) -> Result<Work>;
 
     /// Used for submitting mining hashrate.
-    #[method(name = "eth_submitHashrate")]
+    #[method(name = "submitHashrate")]
     async fn submit_hashrate(&self, hashrate: U256, id: H256) -> Result<bool>;
 
     /// Used for submitting a proof-of-work solution.
-    #[method(name = "eth_submitWork")]
+    #[method(name = "submitWork")]
     async fn submit_work(&self, nonce: H64, pow_hash: H256, mix_digest: H256) -> Result<bool>;
 
     /// Sends transaction; will block waiting for signer to return the
     /// transaction hash.
-    #[method(name = "eth_sendTransaction")]
+    #[method(name = "sendTransaction")]
     async fn send_transaction(&self, request: TransactionRequest) -> Result<H256>;
 
     /// Sends signed transaction, returning its hash.
-    #[method(name = "eth_sendRawTransaction")]
+    #[method(name = "sendRawTransaction")]
     async fn send_raw_transaction(&self, bytes: Bytes) -> Result<H256>;
 
     /// Returns an Ethereum specific signature with: sign(keccak256("\x19Ethereum Signed Message:\n"
     /// + len(message) + message))).
-    #[method(name = "eth_sign")]
+    #[method(name = "sign")]
     async fn sign(&self, address: Address, message: Bytes) -> Result<Bytes>;
 
     /// Signs a transaction that can be submitted to the network at a later time using with
-    /// `eth_sendRawTransaction.`
-    #[method(name = "eth_signTransaction")]
+    /// `sendRawTransaction.`
+    #[method(name = "signTransaction")]
     async fn sign_transaction(&self, transaction: CallRequest) -> Result<Bytes>;
 
     /// Signs data via [EIP-712](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-712.md).
-    #[method(name = "eth_signTypedData")]
+    #[method(name = "signTypedData")]
     async fn sign_typed_data(&self, address: Address, data: serde_json::Value) -> Result<Bytes>;
 
     /// Returns the account and storage values of the specified account including the Merkle-proof.
     /// This call can be used to verify that the data you are pulling from is not tampered with.
-    #[method(name = "eth_getProof")]
+    #[method(name = "getProof")]
     async fn get_proof(
         &self,
         address: Address,

--- a/crates/eth-rpc/src/api/eth_api.rs
+++ b/crates/eth-rpc/src/api/eth_api.rs
@@ -13,10 +13,6 @@ pub trait EthApi {
     #[method(name = "blockNumber")]
     async fn block_number(&self) -> Result<U64>;
 
-    /// Returns the protocol version encoded as a string.
-    #[method(name = "net_version")]
-    fn protocol_version(&self) -> Result<U64>;
-
     /// Returns an object with data about the sync status or false.
     #[method(name = "syncing")]
     async fn syncing(&self) -> Result<SyncStatus>;

--- a/crates/eth-rpc/src/api/mod.rs
+++ b/crates/eth-rpc/src/api/mod.rs
@@ -1,3 +1,4 @@
 pub mod alchemy_api;
 pub mod eth_api;
+pub mod net_api;
 pub mod web3_api;

--- a/crates/eth-rpc/src/api/net_api.rs
+++ b/crates/eth-rpc/src/api/net_api.rs
@@ -1,0 +1,12 @@
+use jsonrpsee::core::RpcResult as Result;
+use jsonrpsee::proc_macros::rpc;
+use reth_primitives::U64;
+
+// TODO: Define and implement of methods of Net API
+#[rpc(server, namespace = "net")]
+#[async_trait]
+pub trait NetApi {
+    /// Returns the protocol version encoded as a string.
+    #[method(name = "version")]
+    fn protocol_version(&self) -> Result<U64>;
+}

--- a/crates/eth-rpc/src/api/net_api.rs
+++ b/crates/eth-rpc/src/api/net_api.rs
@@ -18,5 +18,5 @@ pub trait NetApi {
     /// Returns true if client is actively listening for network connections.
     /// Otherwise false.
     #[method(name = "listening")]
-    fn is_listening(&self) -> Result<bool>;
+    fn listening(&self) -> Result<bool>;
 }

--- a/crates/eth-rpc/src/api/net_api.rs
+++ b/crates/eth-rpc/src/api/net_api.rs
@@ -1,6 +1,7 @@
 use jsonrpsee::core::RpcResult as Result;
 use jsonrpsee::proc_macros::rpc;
 use reth_primitives::U64;
+use reth_rpc_types::PeerCount;
 
 // TODO: Define and implement of methods of Net API
 #[rpc(server, namespace = "net")]
@@ -8,5 +9,14 @@ use reth_primitives::U64;
 pub trait NetApi {
     /// Returns the protocol version encoded as a string.
     #[method(name = "version")]
-    fn protocol_version(&self) -> Result<U64>;
+    fn version(&self) -> Result<U64>;
+
+    /// Returns number of peers connected to node.
+    #[method(name = "peerCount")]
+    fn peer_count(&self) -> Result<PeerCount>;
+
+    /// Returns true if client is actively listening for network connections.
+    /// Otherwise false.
+    #[method(name = "listening")]
+    fn is_listening(&self) -> Result<bool>;
 }

--- a/crates/eth-rpc/src/api/web3_api.rs
+++ b/crates/eth-rpc/src/api/web3_api.rs
@@ -2,14 +2,14 @@ use jsonrpsee::core::RpcResult as Result;
 use jsonrpsee::proc_macros::rpc;
 use reth_primitives::{Bytes, H256};
 
-#[rpc(server)]
+#[rpc(server, namespace = "web3")]
 #[async_trait]
 pub trait Web3Api {
     /// Returns the client version of the running Kakarot RPC
-    #[method(name = "web3_clientVersion")]
+    #[method(name = "clientVersion")]
     fn client_version(&self) -> Result<String>;
 
     /// Returns Keccak256 of some input value
-    #[method(name = "web3_sha3")]
+    #[method(name = "sha3")]
     fn sha3(&self, input: Bytes) -> Result<H256>;
 }

--- a/crates/eth-rpc/src/rpc.rs
+++ b/crates/eth-rpc/src/rpc.rs
@@ -9,9 +9,11 @@ use starknet::providers::Provider;
 
 use crate::api::alchemy_api::AlchemyApiServer;
 use crate::api::eth_api::EthApiServer;
+use crate::api::net_api::NetApiServer;
 use crate::api::web3_api::Web3ApiServer;
 use crate::servers::alchemy_rpc::AlchemyRpc;
 use crate::servers::eth_rpc::KakarotEthRpc;
+use crate::servers::net_rpc::NetRpc;
 use crate::servers::web3_rpc::Web3Rpc;
 
 /// Represents RPC modules that are supported by reth
@@ -20,6 +22,7 @@ pub enum KakarotRpcModule {
     Eth,
     Alchemy,
     Web3,
+    Net,
 }
 
 pub struct KakarotRpcModuleBuilder<P: Provider + Send + Sync + 'static> {
@@ -32,12 +35,14 @@ impl<P: Provider + Send + Sync + 'static> KakarotRpcModuleBuilder<P> {
         let eth_rpc_module = KakarotEthRpc::new(kakarot_client.clone()).into_rpc();
         let alchemy_rpc_module = AlchemyRpc::new(kakarot_client).into_rpc();
         let web3_rpc_module = Web3Rpc::default().into_rpc();
+        let net_rpc_module = NetRpc::default().into_rpc();
 
         let mut modules: HashMap<KakarotRpcModule, Methods> = HashMap::new();
 
         modules.insert(KakarotRpcModule::Eth, eth_rpc_module.into());
         modules.insert(KakarotRpcModule::Alchemy, alchemy_rpc_module.into());
         modules.insert(KakarotRpcModule::Web3, web3_rpc_module.into());
+        modules.insert(KakarotRpcModule::Net, net_rpc_module.into());
 
         Self { modules, _phantom: PhantomData }
     }

--- a/crates/eth-rpc/src/servers/eth_rpc.rs
+++ b/crates/eth-rpc/src/servers/eth_rpc.rs
@@ -37,12 +37,6 @@ impl<P: Provider + Send + Sync + 'static> EthApiServer for KakarotEthRpc<P> {
         Ok(block_number)
     }
 
-    /// Get the protocol version of the Kakarot Starknet RPC.
-    fn protocol_version(&self) -> Result<U64> {
-        let protocol_version = 1_u64;
-        Ok(protocol_version.into())
-    }
-
     async fn syncing(&self) -> Result<SyncStatus> {
         let status = self.kakarot_client.syncing().await?;
         Ok(status)

--- a/crates/eth-rpc/src/servers/mod.rs
+++ b/crates/eth-rpc/src/servers/mod.rs
@@ -1,3 +1,4 @@
 pub mod alchemy_rpc;
 pub mod eth_rpc;
+pub mod net_rpc;
 pub mod web3_rpc;

--- a/crates/eth-rpc/src/servers/net_rpc.rs
+++ b/crates/eth-rpc/src/servers/net_rpc.rs
@@ -26,7 +26,7 @@ impl NetApiServer for NetRpc {
         todo!()
     }
 
-    fn is_listening(&self) -> Result<bool> {
+    fn listening(&self) -> Result<bool> {
         todo!()
     }
 }

--- a/crates/eth-rpc/src/servers/net_rpc.rs
+++ b/crates/eth-rpc/src/servers/net_rpc.rs
@@ -1,0 +1,23 @@
+use jsonrpsee::core::{async_trait, RpcResult as Result};
+use reth_primitives::U64;
+
+use crate::api::net_api::NetApiServer;
+
+/// The RPC module for the implementing Net api
+#[derive(Default)]
+pub struct NetRpc {}
+
+impl NetRpc {
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+#[async_trait]
+impl NetApiServer for NetRpc {
+    /// Get the protocol version of the Kakarot Starknet RPC.
+    fn protocol_version(&self) -> Result<U64> {
+        let protocol_version = 1_u64;
+        Ok(protocol_version.into())
+    }
+}

--- a/crates/eth-rpc/src/servers/net_rpc.rs
+++ b/crates/eth-rpc/src/servers/net_rpc.rs
@@ -1,5 +1,6 @@
 use jsonrpsee::core::{async_trait, RpcResult as Result};
 use reth_primitives::U64;
+use reth_rpc_types::PeerCount;
 
 use crate::api::net_api::NetApiServer;
 
@@ -16,8 +17,16 @@ impl NetRpc {
 #[async_trait]
 impl NetApiServer for NetRpc {
     /// Get the protocol version of the Kakarot Starknet RPC.
-    fn protocol_version(&self) -> Result<U64> {
+    fn version(&self) -> Result<U64> {
         let protocol_version = 1_u64;
         Ok(protocol_version.into())
+    }
+
+    fn peer_count(&self) -> Result<PeerCount> {
+        todo!()
+    }
+
+    fn is_listening(&self) -> Result<bool> {
+        todo!()
     }
 }


### PR DESCRIPTION
Refactor which allows us to use namespaces for all APIs, which removes the need for adding prefixes like { eth_, alchemy_ } while annotating these methods.

Also, this PR refactors the Net Api method from our from Eth Api, and defines and implements it as a seperate API { Net is a seperate API, and reth treats it like it as well, you can check it out [here](https://github.com/paradigmxyz/reth/blob/main/crates/rpc/rpc-api/src/net.rs). }

Resolves: #310 

# Pull Request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Testing

# What is the new behavior?

- use of namespaces in APIs.
- net is refactored and implemented as a separate API.

# Does this introduce a breaking change?

- [ ] Yes
- [x] No
