### PR TITLE
demonstrate kkrt handling the `get_caller_address` zero case w/ error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,13 +12,16 @@ pull-kakarot: .gitmodules
 build-kakarot: setup 
 	cd lib/kakarot && make build && make build-sol
 
+build-testing-solidity-contracts:
+	FOUNDRY_PROFILE=testing forge build
+
 build-and-deploy-kakarot:
 	cd lib/kakarot && STARKNET_NETWORK=$(STARKNET_NETWORK) make deploy
 
 deploy-kakarot:
 	cd lib/kakarot && STARKNET_NETWORK=$(STARKNET_NETWORK) poetry run python ./scripts/deploy_kakarot.py
 
-setup: pull-kakarot build-kakarot
+setup: pull-kakarot build-kakarot build-testing-solidity-contracts
 
 # run devnet
 devnet: 

--- a/crates/core/tests/client.rs
+++ b/crates/core/tests/client.rs
@@ -164,7 +164,7 @@ mod tests {
             JsonRpcClient::new(HttpTransport::new(starknet_test_sequencer.url())),
         );
 
-        let _opcode_staticcall = kakarot_client
+        kakarot_client
             .call(
                 get_caller_eth_address,
                 get_caller_address_selector.into(),
@@ -225,18 +225,6 @@ mod tests {
             .get_code(plain_opcodes_eth_address, BlockId::Number(reth_primitives::BlockNumberOrTag::Latest))
             .await
             .expect("contract not deployed");
-
-        let opcode_staticcall_selector = plain_opcodes_abi.function("opcodeStaticCall").unwrap().short_signature();
-
-        let opcode_staticcall = kakarot_client
-            .call(
-                plain_opcodes_eth_address,
-                opcode_staticcall_selector.into(),
-                BlockId::Number(reth_primitives::BlockNumberOrTag::Latest),
-            )
-            .await;
-
-        dbg!(opcode_staticcall);
     }
 
     #[tokio::test]

--- a/crates/core/tests/client.rs
+++ b/crates/core/tests/client.rs
@@ -198,7 +198,7 @@ mod tests {
             address.try_into().unwrap()
         };
 
-        let (plain_opcodes_abi, deployed_addresses) = deployed_kakarot
+        let (_plain_opcodes_abi, deployed_addresses) = deployed_kakarot
             .deploy_evm_contract(
                 starknet_test_sequencer.url(),
                 "PlainOpcodes",

--- a/foundry.toml
+++ b/foundry.toml
@@ -5,6 +5,9 @@ src = "lib/kakarot/tests/integration/solidity_contracts"
 eth_rpc_url = "localhost"
 legacy = true
 
+[profile.testing]
+src = "solidity_contracts"
+
 [rpc_endpoints]
 localhost = "http://127.0.0.1:3030"
 anvil = "http://127.0.0.1:8545"

--- a/solidity_contracts/GetCallerAddress.sol
+++ b/solidity_contracts/GetCallerAddress.sol
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+contract GetCallerAddress {
+    // This function will return the address of the caller
+    function getCallerAddress() public view returns (address) {
+        return msg.sender;
+    }
+}


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

Time spent on this PR: 2 hrs

Resolves: #

addresses: #216 


# Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [X] Testing

# What is the new behavior?

This small pr introduces a potential pattern where pre-alpha testers can do PR's w/ solidity contracts. Currently using testsequencer, which is a little involved, the idea is to have a `solidity_contracts` directory that pre-alpha tests can add solidity code that isnt working and have those contracts ran against the CI
# Does this introduce a breaking change?

- [ ] Yes
- [X] No
