### PR TITLE
feat: update benchmarking workflow to only run `push`

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -4,8 +4,6 @@
     on:
       push:
         branches: [main]
-      pull_request:
-        branches: [main]
 
     permissions:
       deployments: write


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

Resolves: #420 

# Pull Request type

This pr makes benchmark only run on `push`.

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Testing

# What is the new behavior?

Benchmark job will only run on push.

# Does this introduce a breaking change?

- [ ] Yes
- [x] No
