### PR TITLE
dev: `docker-compose` always pulls image for latest tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,3 +13,4 @@ and this project adheres to
 - ci: add `CHANGELOG.md` and enforce it is edited for each PR on `main`
 - test: update integration tests to use prepopulated Katana dumped state
 - ci: cross-compile binaries to improve build time
+- dev: always pull image for latest tags when doing `docker-compose`

--- a/Makefile
+++ b/Makefile
@@ -41,14 +41,14 @@ run-release:
 
 # Run Katana, Deploy Kakarot, Run Kakarot RPC
 katana-rpc-up:
-	docker-compose -f docker-compose.yaml -f docker-compose.katana.yaml up -d --force-recreate
+	docker-compose -f docker-compose.yaml -f docker-compose.katana.yaml up -d --force-recreate --pull always
 
 katana-rpc-down:
 	docker-compose -f docker-compose.yaml -f docker-compose.katana.yaml down --remove-orphans
 
 # Run Madara, Deploy Kakarot, Run Kakarot RPC
 madara-rpc-up:
-	docker-compose up -d --force-recreate
+	docker-compose up -d --force-recreate --pull always
 
 madara-rpc-down:
 	docker-compose down --remove-orphans


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

Time spent on this PR: 0

Resolves: #<Issue number>

# Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [x] Build-related changes
- [ ] Documentation content changes
- [ ] Testing

# What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->
Always pulls the image for services with latest tag

# Does this introduce a breaking change?

- [ ] Yes
- [x] No

# Added changes to [`CHANGELOG.md`](../CHANGELOG.md)

- [x] Yes
- [ ] No
