### PR TITLE
feat: add timeout to all github workflows

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -13,6 +13,7 @@
     jobs:
       benchmark:
         runs-on: ubuntu-latest
+        timeout-minutes: 120
         steps:
           - uses: actions/checkout@v3
             with:

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -8,6 +8,7 @@ jobs:
   # Enforces the update of a changelog file on every pull request
   changelog:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: dangoslen/changelog-enforcer@v3
         with:

--- a/.github/workflows/kakarot_rpc.yml
+++ b/.github/workflows/kakarot_rpc.yml
@@ -12,6 +12,7 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest-16-cores
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -10,6 +10,7 @@ jobs:
   lock:
     name: 🔒 Lock closed issues and PRs
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: dessant/lock-threads@v2.0.3
         with:

--- a/.github/workflows/spell_check.yml
+++ b/.github/workflows/spell_check.yml
@@ -5,6 +5,7 @@ on: [push, pull_request]
 jobs:
   spell-check:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -10,6 +10,7 @@ jobs:
   stale:
     name: 🧹 Clean up stale issues and PRs
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: 🚀 Run stale
         uses: actions/stale@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,7 @@ jobs:
   check:
     name: check
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
@@ -19,6 +20,7 @@ jobs:
   fmt:
     name: fmt
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
@@ -35,6 +37,7 @@ jobs:
   clippy:
     name: clippy
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
@@ -51,6 +54,7 @@ jobs:
   test:
     name: test
     runs-on: ubuntu-latest-16-cores
+    timeout-minutes: 30
     steps:
       # foundry
       - name: install foundry

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,3 +14,4 @@ and this project adheres to
 - test: update integration tests to use prepopulated Katana dumped state
 - ci: cross-compile binaries to improve build time
 - dev: always pull image for latest tags when doing `docker-compose`
+- ci: add timeout to all workflows


### PR DESCRIPTION
Add timeout to all github workflows.

Resolves: #439 

# Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Testing

# What is the new behavior?

- all workflows have a timeout so that they stop if they are running for very long duration
- no need to manually stop workflows

# Does this introduce a breaking change?

- [ ] Yes
- [x] No

# Added changes to [`CHANGELOG.md`](../CHANGELOG.md)

- [x] Yes
- [ ] No
