### PR TITLE
feat: update benchmark CI to use madara binary

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -12,7 +12,7 @@
     
     jobs:
       benchmark:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-latest-16-cores
         timeout-minutes: 120
         steps:
           - uses: actions/checkout@v3
@@ -24,7 +24,7 @@
             run: |
               git submodule update --init --recursive
               sudo apt update
-              sudo apt install -y protobuf-compiler clang jq
+              sudo apt install -y protobuf-compiler clang jq wget
 
           - uses: actions/cache@v3
             id: cache
@@ -34,8 +34,7 @@
                 ~/.cargo/registry/index/
                 ~/.cargo/registry/cache/
                 ~/.cargo/git/db/
-                ./lib/madara/target/
-              key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.lock') }}-${{hashFiles('./lib/madara/Cargo.lock')}}
+              key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.lock') }}}
           
           # build rpc and madara  
           - name: Setup Rust
@@ -45,12 +44,14 @@
           - name: Build RPC
             run: |
               cargo build --release
-          - name: Build Madara
+          - name: Download Madara
             if: steps.cache.outputs.cache-hit  != 'true'
             run: |
               cd ./lib/madara
-              cargo build --release
-          
+              mkdir -p target/release
+              cd target/release
+              wget https://github.com/keep-starknet-strange/madara/releases/download/v0.1.0.experimental.3/x86_64-unknown-linux-gnu-madara
+              chmod +x x86_64-unknown-linux-gnu-madara && mv x86_64-unknown-linux-gnu-madara madara
           
           # Python Setup and dependencies installation
           - uses: actions/setup-python@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,3 +23,4 @@ and this project adheres to
 - dev: rename crate conformance-test-utils to hive-utils
 - dev: update code and integration tests to return correct datatype for get_logs
 - fix: update jsonrpsee error codes to EIP 1474 codes.
+- ci: use madara binary for benchmark CI


### PR DESCRIPTION
Use Madara Binary on benchmark CI.

Time spent on this PR:

Resolves: #444 

# Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Testing

# What is the new behavior?

On the CI to speed things up we are using the Madara binary.

# Does this introduce a breaking change?

- [ ] Yes
- [x] No

# Added changes to [`CHANGELOG.md`](../CHANGELOG.md)

- [x] Yes
- [ ] No

# Additional Information
- I am still keeping Madara as a submodule for now, so that for people using it they won't have to download binaries from the internet
- We will use the Madara binary on CI, to speed things up, and locally if someone wants to benchmark, they can build Madara, and do the benchmark.
- Bumping up the machine we use for benchmarking, I think it should produce more accurate result and should speed up the job, if it doesn't we can rollback to the old machine and ponder on a self hosted runner.
