### PR TITLE
dev: slightly decrease the rate at which we send transaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to
 
 ### Added
 
+- ci: decrease the rate which we send transactions in benchmark CI
 - ci: add `CHANGELOG.md` and enforce it is edited for each PR on `main`
 - test: update integration tests to use prepopulated Katana dumped state
 - ci: cross-compile binaries to improve build time

--- a/benchmarking/scripts/processor.js
+++ b/benchmarking/scripts/processor.js
@@ -37,7 +37,7 @@ const nativeTokenTransfer = async (context, ee, next) => {
 
     // break to make sure transactions arrive in order to RPC.
     // NOTE: reduce it if you are skipping validate
-    await sleep(350);
+    await sleep(500);
   }
 
   next();


### PR DESCRIPTION
In the current benchmarking CI, ofthen there occurs a nonce race, and from my experience, the way to solve it is to decrease the rate at which send the transaction, this PR slightly bumps the delay between two transactions by 150ms, which should probably resolve it, otherwise we would have to move to a custom runner.

# Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [x] Build-related changes
- [ ] Documentation content changes
- [ ] Testing

# What is the new behavior?

- Decreases the rate at which we send transactions which should lower the chance of getting a nonce race.


# Does this introduce a breaking change?

- [ ] Yes
- [x] No

# Added changes to [`CHANGELOG.md`](../CHANGELOG.md)

- [x] Yes
- [ ] No
