### PR TITLE
fix: update the dump katana script

### DIFF
--- a/crates/core/src/test_utils/bin/dump-katana.rs
+++ b/crates/core/src/test_utils/bin/dump-katana.rs
@@ -60,7 +60,7 @@ async fn main() {
         contracts.insert("Kakarot", serde_json::to_value(test_context.kakarot()).unwrap());
         contracts.insert("ERC20", serde_json::to_value(test_context.evm_contract("ERC20")).unwrap());
         contracts.insert("Counter", serde_json::to_value(test_context.evm_contract("Counter")).unwrap());
-        contracts.insert(" PlainOpcodes", serde_json::to_value(test_context.evm_contract("PlainOpcodes")).unwrap());
+        contracts.insert("PlainOpcodes", serde_json::to_value(test_context.evm_contract("PlainOpcodes")).unwrap());
         contracts.insert("DeployerAccount", serde_json::to_value(deployer_account).unwrap());
 
         // Dump the contracts information
@@ -82,7 +82,7 @@ async fn main() {
                 .url()
                 .expect("Failed to get Kakarot origin remote url")
                 .to_string(),
-            hash: reference.target().unwrap().to_string(),
+            hash: reference.target().expect("Failed to get commit hash").to_string(),
         })
         .expect("Failed to get Kakarot submodule head");
     let submodules = serde_json::to_string(&submodule).expect("Failed to serialize submodule");

--- a/crates/core/src/test_utils/bin/dump-katana.rs
+++ b/crates/core/src/test_utils/bin/dump-katana.rs
@@ -60,7 +60,7 @@ async fn main() {
         contracts.insert("Kakarot", serde_json::to_value(test_context.kakarot()).unwrap());
         contracts.insert("ERC20", serde_json::to_value(test_context.evm_contract("ERC20")).unwrap());
         contracts.insert("Counter", serde_json::to_value(test_context.evm_contract("Counter")).unwrap());
-        contracts.insert("PlainOpcodes", serde_json::to_value(test_context.evm_contract("PlainOpcodes")).unwrap());
+        contracts.insert(" PlainOpcodes", serde_json::to_value(test_context.evm_contract("PlainOpcodes")).unwrap());
         contracts.insert("DeployerAccount", serde_json::to_value(deployer_account).unwrap());
 
         // Dump the contracts information
@@ -71,19 +71,21 @@ async fn main() {
     .await
     .expect("Failed to dump state");
 
-    let repo = Repository::open(".").unwrap();
-    let submodules: Vec<Submodule> = repo
-        .submodules()
-        .unwrap()
-        .iter()
-        .map(|submodule| Submodule {
-            name: submodule.name().unwrap().to_string(),
-            url: submodule.url().unwrap().to_string(),
-            hash: submodule.head_id().unwrap().to_string(),
+    let repo = Repository::open("lib/kakarot").expect("Failed to open kakarot submodule");
+    let submodule: Submodule = repo
+        .head()
+        .map(|reference| Submodule {
+            name: "kakarot".to_string(),
+            url: repo
+                .find_remote("origin")
+                .expect("Failed to find origin remote for Kakarot")
+                .url()
+                .expect("Failed to get Kakarot origin remote url")
+                .to_string(),
+            hash: reference.target().unwrap().to_string(),
         })
-        .filter(|submodule| submodule.name != "katana")
-        .collect();
-    let submodules = serde_json::to_string(&submodules[0]).expect("Failed to serialize submodules");
+        .expect("Failed to get Kakarot submodule head");
+    let submodules = serde_json::to_string(&submodule).expect("Failed to serialize submodule");
     std::fs::write(".katana/submodules.json", submodules)
         .expect("Failed to write submodules to .katana/submodules.json");
 }


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->
Fixes the dump katana script in order to correctly mark the current commit hash used for Kakarot.

Time spent on this PR: 0.1 day

Resolves: #NA

# Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Testing

# What is the new behavior?
The correct commit hash for Kakarot is added in the .katana folder along with the dump.

<!-- Please describe the behavior or changes that are being added by this PR. -->

# Does this introduce a breaking change?

- [ ] Yes
- [x] No
