### PR TITLE
fix: dump katana script

### DIFF
--- a/crates/core/src/test_utils/bin/dump-katana.rs
+++ b/crates/core/src/test_utils/bin/dump-katana.rs
@@ -79,9 +79,9 @@ async fn main() {
         .map(|submodule| Submodule {
             name: submodule.name().unwrap().to_string(),
             url: submodule.url().unwrap().to_string(),
-            hash: submodule.head_id().unwrap().to_string(),
+            hash: submodule.workdir_id().unwrap().to_string(),
         })
-        .filter(|submodule| submodule.name != "katana")
+        .filter(|submodule| submodule.name == "kakarot")
         .collect();
     let submodules = serde_json::to_string(&submodules[0]).expect("Failed to serialize submodules");
     std::fs::write(".katana/submodules.json", submodules)

--- a/crates/core/src/test_utils/bin/dump-katana.rs
+++ b/crates/core/src/test_utils/bin/dump-katana.rs
@@ -79,7 +79,7 @@ async fn main() {
         .map(|submodule| Submodule {
             name: submodule.name().unwrap().to_string(),
             url: submodule.url().unwrap().to_string(),
-            hash: submodule.workdir_id().unwrap().to_string(),
+            hash: submodule.workdir_id().unwrap_or_else(|| submodule.head_id().unwrap()).to_string(),
         })
         .filter(|submodule| submodule.name == "kakarot")
         .collect();


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->
Fix the way submodule information is fetched when building the katana dump.

Time spent on this PR: 0.1 day

Resolves: #NA

# Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Testing

# What is the new behavior?
Submodule information is now the one present in the working directory.

<!-- Please describe the behavior or changes that are being added by this PR. -->

# Does this introduce a breaking change?

- [ ] Yes
- [x] No
