### PR TITLE
feat: allow test utils to use builds from outside the RPC repo root

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,7 +12,7 @@ KATANA_PRIVATE_KEY=0x03000018000000003000001800000000000300000000000030060018000
 MADARA_ACCOUNT_ADDRESS=0x3
 MADARA_PRIVATE_KEY=0x00c1cf1490de1352865301bb8705143f3ef938f97fdf892f1090dcb5ac7bcd1d
 
-# configuration for the eoa deployer account 
+# configuration for the eoa deployer account
 DEPLOYER_ACCOUNT_ADDRESS=
 DEPLOYER_ACCOUNT_PRIVATE_KEY=0x0288a51c164874bb6a1ca7bd1cb71823c234a86d0f7b150d70fa8f06de645396
 
@@ -24,6 +24,7 @@ PROXY_ACCOUNT_CLASS_HASH=0xba8f3f34eb92f56498fdf14ecac1f19d507dcc6859fa6d85eb854
 
 ## configurations for testing
 COMPILED_KAKAROT_PATH=lib/kakarot/build
+FOUNDRY_OUTPUT_PATH=./lib/kakarot/tests/integration/solidity_contracts/build
 
 ## An EVM private to define a default EOA for EVM related scripts
 ## This default value is Anvil first account private key

--- a/crates/core/src/test_utils/deploy_helpers.rs
+++ b/crates/core/src/test_utils/deploy_helpers.rs
@@ -104,12 +104,15 @@ pub fn get_contract(filename: &str) -> CompactContractBytecode {
              `./scripts/make_with_env.sh test`",
         );
 
-        // We search firstly for existence for absolute path
+        // We search firstly for existence for absolute path, i.e a path that is not relative to the project
+        // root, ex: /Users/Vitalik/kakarot/tests/integration/solidity_contracts/build
+        // checkout out -> https://www.linuxfoundation.org/blog/blog/classic-sysadmin-absolute-path-vs-relative-path-in-linux-unix
         let foundry_output_path_absolute = PathBuf::from(&foundry_output_path);
         if foundry_output_path_absolute.try_exists().unwrap() {
             foundry_output_path_absolute
         } else {
             // If the absolute path is not found, then we search for a path relative to the project root
+            // ex: ./lib/kakarot/tests/integration/solidity_contracts/build { relative to project root }
             root_project_path!(foundry_output_path)
         }
     };
@@ -446,12 +449,15 @@ fn compiled_kakarot_path() -> PathBuf {
          `./scripts/make_with_env.sh test`",
     );
 
-    // We search firstly for existence for absolute path
+    // We search firstly for existence for absolute path, i.e a path that is not relative to the project
+    // root, ex: /Users/Vitalik/kakarot/build
+    // checkout out -> https://www.linuxfoundation.org/blog/blog/classic-sysadmin-absolute-path-vs-relative-path-in-linux-unix
     let compiled_kakarot_path_absolute = PathBuf::from(&compiled_kakarot_path);
     if compiled_kakarot_path_absolute.try_exists().unwrap() {
         compiled_kakarot_path_absolute
     } else {
         // If the absolute path is not found, then we search for a path relative to the project root
+        // ex: ./lib/kakarot/tests/integration/solidity_contracts/build { relative to project root }
         root_project_path!(compiled_kakarot_path)
     }
 }


### PR DESCRIPTION
Time spent on this PR:

Resolves: #542 

# Pull Request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Testing

# What is the new behavior?

The current change will allow the RPC to consume builds outside from the project root of Kakarot RPC { as of now we need this to simplify CI flow for running ef-tests on kakarot main }, we still get all good DX features we used to have, the flow now is:
- search for the path as absolute path.
- if the above fails, then search for it relative to the project root.

A new environment variable `FOUNDRY_OUTPUT_PATH` has been added so that we can point to solidity builds outside from this repo, this will add no extra complexity as of now, the default value here will work out of the box with the current flow until a change is needed.

# Does this introduce a breaking change?

- [ ] Yes
- [x] No
