### PR TITLE
dev: remove `from_dump_state` and use `SerializableState` to initialize `TestSequencer`

### DIFF
--- a/crates/core/src/test_utils/bin/dump-katana.rs
+++ b/crates/core/src/test_utils/bin/dump-katana.rs
@@ -1,28 +1,15 @@
 use std::collections::HashMap;
 
-use ethers::abi::Token;
 use git2::{Repository, SubmoduleIgnore};
 use kakarot_rpc_core::client::api::KakarotStarknetApi;
 use kakarot_rpc_core::test_utils::constants::STARKNET_DEPLOYER_ACCOUNT_PRIVATE_KEY;
-use kakarot_rpc_core::test_utils::deploy_helpers::{
-    ContractDeploymentArgs, DeployerAccount, KakarotTestEnvironmentContext, TestContext,
-};
+use kakarot_rpc_core::test_utils::deploy_helpers::{DeployerAccount, KakarotTestEnvironmentContext};
 use starknet::accounts::Account;
 
 #[tokio::main]
 async fn main() {
     // Deploy all kakarot contracts + EVM contracts
-    let mut test_context = KakarotTestEnvironmentContext::new(TestContext::PlainOpcodes).await;
-    test_context = test_context
-        .deploy_evm_contract(ContractDeploymentArgs {
-            name: "ERC20".into(),
-            constructor_args: (
-                Token::String("Test".into()),               // name
-                Token::String("TT".into()),                 // symbol
-                Token::Uint(ethers::types::U256::from(18)), // decimals
-            ),
-        })
-        .await;
+    let test_context = KakarotTestEnvironmentContext::new(false).await;
 
     tokio::task::spawn_blocking(move || {
         // Get a serializable state for the sequencer

--- a/crates/core/src/test_utils/fixtures.rs
+++ b/crates/core/src/test_utils/fixtures.rs
@@ -5,5 +5,6 @@ use crate::test_utils::deploy_helpers::KakarotTestEnvironmentContext;
 
 #[fixture]
 pub fn kakarot_test_env_ctx() -> KakarotTestEnvironmentContext {
-    block_on(async { KakarotTestEnvironmentContext::from_dump_state().await })
+    // Create a new test environment with dumped state
+    block_on(async { KakarotTestEnvironmentContext::new(true).await })
 }


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

Time spent on this PR: 0.2

Resolves: #532 

# Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [X] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Testing

# What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->
- Use `SerializableState` to initialize the TestSequencer instead of loading it
- Remove `from_dump_state` and refactor `KakarotTestEnvironmentContext`

# Does this introduce a breaking change?

- [ ] Yes
- [X] No
