### PR TITLE
dev: use `from_reader` and `to_writer_pretty` from serde_json, remove reading from memory to string

### DIFF
--- a/crates/test-utils/src/bin/dump-katana.rs
+++ b/crates/test-utils/src/bin/dump-katana.rs
@@ -1,6 +1,5 @@
 use std::collections::HashMap;
 use std::fs::File;
-use std::path::PathBuf;
 
 use git2::{Repository, SubmoduleIgnore};
 use kakarot_rpc_core::client::api::KakarotStarknetApi;
@@ -25,19 +24,19 @@ async fn main() {
         .dump_state()
         .expect("Failed to call dump_state on Katana state");
 
-        // Dump the state
-        std::fs::create_dir_all(".katana/").expect("Failed to create Kakata dump dir");
+    // Dump the state
+    std::fs::create_dir_all(".katana/").expect("Failed to create Kakata dump dir");
 
-        let katana_dump_path = String::from(".katana/dump.json");
-        let katana_dump_file = File::options()
-            .create_new(true)
-            .read(true)
-            .write(true)
-            .append(false)
-            .open(katana_dump_path)
-            .expect(format!("Failed to open file {}", katana_dump_path));
-        serde_json::to_writer_pretty(katana_dump_file, &dump_state)
-            .expect(format!("Failed to write to the file {}", katana_dump_path));
+    let katana_dump_path = String::from(".katana/dump.json");
+    let katana_dump_file = File::options()
+        .create_new(true)
+        .read(true)
+        .write(true)
+        .append(false)
+        .open(&katana_dump_path)
+        .unwrap_or_else(|_| panic!("Failed to open file {}", &katana_dump_path));
+    serde_json::to_writer_pretty(katana_dump_file, &dump_state)
+        .unwrap_or_else(|_| panic!("Failed to write to the file {}", katana_dump_path));
 
     let deployer_account = DeployerAccount {
         address: test_context.client().deployer_account().address(),

--- a/crates/test-utils/src/bin/dump-katana.rs
+++ b/crates/test-utils/src/bin/dump-katana.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 use std::fs::File;
+use std::path::PathBuf;
 
 use git2::{Repository, SubmoduleIgnore};
 use kakarot_rpc_core::client::api::KakarotStarknetApi;
@@ -26,9 +27,17 @@ async fn main() {
 
         // Dump the state
         std::fs::create_dir_all(".katana/").expect("Failed to create Kakata dump dir");
-        let katana_dump_file =
-            File::options().create_new(true).read(true).write(true).append(true).open(".katana/dump.json").unwrap();
-        serde_json::to_writer(katana_dump_file, &dump_state);
+
+        let katana_dump_path = String::from(".katana/dump.json");
+        let katana_dump_file = File::options()
+            .create_new(true)
+            .read(true)
+            .write(true)
+            .append(false)
+            .open(katana_dump_path)
+            .expect(format!("Failed to open file {}", katana_dump_path));
+        serde_json::to_writer_pretty(katana_dump_file, &dump_state)
+            .expect(format!("Failed to write to the file {}", katana_dump_path));
 
     let deployer_account = DeployerAccount {
         address: test_context.client().deployer_account().address(),

--- a/crates/test-utils/src/bin/dump-katana.rs
+++ b/crates/test-utils/src/bin/dump-katana.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::fs::File;
 
 use git2::{Repository, SubmoduleIgnore};
 use kakarot_rpc_core::client::api::KakarotStarknetApi;
@@ -23,11 +24,11 @@ async fn main() {
         .dump_state()
         .expect("Failed to call dump_state on Katana state");
 
-    let state = serde_json::to_string(&dump_state).expect("Failed to serialize state");
-
-    // Dump the state
-    std::fs::create_dir_all(".katana/").expect("Failed to create Kakata dump dir");
-    std::fs::write(".katana/dump.json", state).expect("Failed to write dump to .katana/dump.json");
+        // Dump the state
+        std::fs::create_dir_all(".katana/").expect("Failed to create Kakata dump dir");
+        let katana_dump_file =
+            File::options().create_new(true).read(true).write(true).append(true).open(".katana/dump.json").unwrap();
+        serde_json::to_writer(katana_dump_file, &dump_state);
 
     let deployer_account = DeployerAccount {
         address: test_context.client().deployer_account().address(),

--- a/crates/test-utils/src/bin/dump-katana.rs
+++ b/crates/test-utils/src/bin/dump-katana.rs
@@ -29,7 +29,7 @@ async fn main() {
 
     let katana_dump_path = String::from(".katana/dump.json");
     let katana_dump_file = File::options()
-        .create_new(true)
+        .create(true)
         .read(true)
         .write(true)
         .append(false)

--- a/crates/test-utils/src/deploy_helpers.rs
+++ b/crates/test-utils/src/deploy_helpers.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-use std::fs::{self};
+use std::fs::{self, File};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
@@ -101,12 +101,10 @@ pub fn get_contract(filename: &str) -> CompactContractBytecode {
     let compiled_solidity_path = std::path::Path::new(&foundry_default_out).join(dot_sol).join(dot_json);
     let compiled_solidity_path_from_root = root_project_path!(&compiled_solidity_path);
 
-    // Read the content of the file
-    let contents = fs::read_to_string(compiled_solidity_path_from_root).unwrap_or_else(|_| {
+    let compiled_solidity_file = File::open(compiled_solidity_path_from_root).unwrap_or_else(|_| {
         panic!("Could not read file: {}. please run `make setup` to ensure solidity files are compiled", filename)
     });
-
-    serde_json::from_str(&contents).unwrap()
+    serde_json::from_reader(compiled_solidity_file).unwrap()
 }
 
 /// Encodes a contract's bytecode and constructor arguments into deployable bytecode.

--- a/crates/test-utils/src/deploy_helpers.rs
+++ b/crates/test-utils/src/deploy_helpers.rs
@@ -104,7 +104,8 @@ pub fn get_contract(filename: &str) -> CompactContractBytecode {
     let compiled_solidity_file = File::open(compiled_solidity_path_from_root).unwrap_or_else(|_| {
         panic!("Could not read file: {}. please run `make setup` to ensure solidity files are compiled", filename)
     });
-    serde_json::from_reader(compiled_solidity_file).unwrap()
+    serde_json::from_reader(&compiled_solidity_file)
+        .unwrap_or_else(|_| panic!("Failed at reading from file path {:?}", compiled_solidity_file))
 }
 
 /// Encodes a contract's bytecode and constructor arguments into deployable bytecode.

--- a/crates/test-utils/src/hive_utils/hive/genesis.rs
+++ b/crates/test-utils/src/hive_utils/hive/genesis.rs
@@ -226,7 +226,7 @@ pub async fn serialize_hive_to_madara_genesis_config(
     });
 
     let combined_genesis_file = File::options()
-        .create_new(true)
+        .create(true)
         .write(true)
         .append(false)
         .open(combined_genesis_path)

--- a/crates/test-utils/src/hive_utils/hive/genesis.rs
+++ b/crates/test-utils/src/hive_utils/hive/genesis.rs
@@ -51,8 +51,8 @@ pub struct HiveGenesisConfig {
 
 impl HiveGenesisConfig {
     pub fn from_file(path: &str) -> Result<Self> {
-        let hive_genesis_file = File::open(path).unwrap();
-        Ok(serde_json::from_reader(hive_genesis_file).unwrap())
+        let hive_genesis_file = File::open(path)?;
+        Ok(serde_json::from_reader(hive_genesis_file)?)
     }
 }
 
@@ -226,8 +226,8 @@ pub async fn serialize_hive_to_madara_genesis_config(
     });
 
     let combined_genesis_file =
-        File::options().create_new(true).write(true).append(true).open(combined_genesis_path).unwrap();
-    // Serialize the loader to a string and then write to a file
+        File::options().create_new(true).write(true).append(false).open(combined_genesis_path).unwrap();
+    // Serialize the loader to a file
     serde_json::to_writer_pretty(combined_genesis_file, &madara_loader)?;
 
     Ok(())

--- a/crates/test-utils/src/hive_utils/hive/genesis.rs
+++ b/crates/test-utils/src/hive_utils/hive/genesis.rs
@@ -309,7 +309,7 @@ mod tests {
         let hive_genesis = HiveGenesisConfig::from_file("./src/hive_utils/test_data/hive_genesis.json").unwrap();
         let madara_loader =
             serde_json::from_str::<GenesisLoader>(std::include_str!("../test_data/madara_genesis.json")).unwrap();
-        let combined_genesis_path = Path::new("./src/test_data/combined_genesis.json");
+        let combined_genesis_path = Path::new("./src/hive_utils/test_data/combined_genesis.json");
         let compiled_path = Path::new("./cairo-contracts/build");
 
         // When

--- a/crates/test-utils/src/hive_utils/hive/genesis.rs
+++ b/crates/test-utils/src/hive_utils/hive/genesis.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-use std::fs;
+use std::fs::File;
 use std::io::Error as IoError;
 use std::path::Path;
 
@@ -51,7 +51,8 @@ pub struct HiveGenesisConfig {
 
 impl HiveGenesisConfig {
     pub fn from_file(path: &str) -> Result<Self> {
-        Ok(serde_json::from_str(&fs::read_to_string(path)?)?)
+        let hive_genesis_file = File::open(path).unwrap();
+        Ok(serde_json::from_reader(hive_genesis_file).unwrap())
     }
 }
 
@@ -73,7 +74,7 @@ lazy_static! {
 pub async fn serialize_hive_to_madara_genesis_config(
     hive_genesis: HiveGenesisConfig,
     mut madara_loader: GenesisLoader,
-    combined_genesis: &Path,
+    combined_genesis_path: &Path,
     compiled_path: &Path,
 ) -> Result<(), IoError> {
     // Compute the class hash of Kakarot contracts
@@ -224,10 +225,10 @@ pub async fn serialize_hive_to_madara_genesis_config(
         madara_loader.storage.push(is_initialized);
     });
 
-    // Serialize the loader to a string
-    let madara_genesis_str = serde_json::to_string_pretty(&madara_loader)?;
-    // Write the string to a file
-    fs::write(combined_genesis, madara_genesis_str)?;
+    let combined_genesis_file =
+        File::options().create_new(true).write(true).append(true).open(combined_genesis_path).unwrap();
+    // Serialize the loader to a string and then write to a file
+    serde_json::to_writer_pretty(combined_genesis_file, &madara_loader)?;
 
     Ok(())
 }
@@ -252,6 +253,7 @@ pub struct AccountInfo {
 
 #[cfg(test)]
 mod tests {
+    use std::fs::File;
     use std::str::FromStr;
 
     use reth_primitives::U256;
@@ -303,21 +305,21 @@ mod tests {
         let hive_genesis = HiveGenesisConfig::from_file("./src/hive_utils/test_data/hive_genesis.json").unwrap();
         let madara_loader =
             serde_json::from_str::<GenesisLoader>(std::include_str!("../test_data/madara_genesis.json")).unwrap();
-        let combined_genesis = Path::new("./src/hive_utils/test_data/combined_genesis.json");
+        let combined_genesis_path = Path::new("./src/test_data/combined_genesis.json");
         let compiled_path = Path::new("./cairo-contracts/build");
 
         // When
-        serialize_hive_to_madara_genesis_config(hive_genesis, madara_loader, combined_genesis, compiled_path)
+        serialize_hive_to_madara_genesis_config(hive_genesis, madara_loader, combined_genesis_path, compiled_path)
             .await
             .unwrap();
 
+        let combined_genesis_file = File::open(combined_genesis_path).unwrap();
+
         // Then
-        let combined_genesis = fs::read_to_string("./src/hive_utils/test_data/combined_genesis.json").unwrap();
-        let loader: GenesisLoader =
-            serde_json::from_str(&combined_genesis).expect("Failed to read combined_genesis.json");
+        let loader: GenesisLoader = serde_json::from_reader(combined_genesis_file).unwrap();
         assert_eq!(9 + 3 + 7, loader.contracts.len()); // 9 original + 3 Kakarot contracts + 7 hive
 
         // After
-        fs::remove_file("./src/hive_utils/test_data/combined_genesis.json").unwrap();
+        std::fs::remove_file(combined_genesis_path).unwrap();
     }
 }

--- a/crates/test-utils/src/hive_utils/hive/genesis.rs
+++ b/crates/test-utils/src/hive_utils/hive/genesis.rs
@@ -225,8 +225,12 @@ pub async fn serialize_hive_to_madara_genesis_config(
         madara_loader.storage.push(is_initialized);
     });
 
-    let combined_genesis_file =
-        File::options().create_new(true).write(true).append(false).open(combined_genesis_path).unwrap();
+    let combined_genesis_file = File::options()
+        .create_new(true)
+        .write(true)
+        .append(false)
+        .open(combined_genesis_path)
+        .unwrap_or_else(|_| panic!("Failed to open file at path {:?}", combined_genesis_path));
     // Serialize the loader to a file
     serde_json::to_writer_pretty(combined_genesis_file, &madara_loader)?;
 
@@ -313,13 +317,16 @@ mod tests {
             .await
             .unwrap();
 
-        let combined_genesis_file = File::open(combined_genesis_path).unwrap();
+        let combined_genesis_file = File::open(combined_genesis_path)
+            .unwrap_or_else(|_| panic!("Failed to open file at path {:?}", &combined_genesis_path));
 
         // Then
-        let loader: GenesisLoader = serde_json::from_reader(combined_genesis_file).unwrap();
+        let loader: GenesisLoader = serde_json::from_reader(&combined_genesis_file)
+            .unwrap_or_else(|_| panic!("Failed to read from file at path {:?}", &combined_genesis_path));
         assert_eq!(9 + 3 + 7, loader.contracts.len()); // 9 original + 3 Kakarot contracts + 7 hive
 
         // After
-        std::fs::remove_file(combined_genesis_path).unwrap();
+        std::fs::remove_file(combined_genesis_path)
+            .unwrap_or_else(|_| panic!("Failed to remove file at path {:?}", combined_genesis_path));
     }
 }


### PR DESCRIPTION
Resolves: #561 

# Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Testing

# What is the new behavior?

As mentioned in #561 , we were often reading first from a file to string, and then passing it to serde_json.

serde_json has the following methods:
- [from_reader](https://docs.rs/serde_json/latest/serde_json/fn.from_reader.html)
- [to_writer_pretty](https://docs.rs/serde_json/latest/serde_json/fn.to_writer_pretty.html)

Which can allow reading and writing directly from and to a Reader and a Writer respectively.

This PR also fixes some variables names, where it seems fit.

# Does this introduce a breaking change?

- [ ] Yes
- [x] No
