### PR TITLE
dev: rename `StarknetConfig` to `KakarotConfig`

### DIFF
--- a/crates/core/src/client/config.rs
+++ b/crates/core/src/client/config.rs
@@ -54,7 +54,7 @@ impl Network {
 
 #[derive(Default, Clone)]
 /// Configuration for the Starknet RPC client.
-pub struct StarknetConfig {
+pub struct KakarotRpcConfig {
     /// Starknet network.
     pub network: Network,
     /// Kakarot contract address.
@@ -63,9 +63,9 @@ pub struct StarknetConfig {
     pub proxy_account_class_hash: FieldElement,
 }
 
-impl StarknetConfig {
+impl KakarotRpcConfig {
     pub fn new(network: Network, kakarot_address: FieldElement, proxy_account_class_hash: FieldElement) -> Self {
-        StarknetConfig { network, kakarot_address, proxy_account_class_hash }
+        KakarotRpcConfig { network, kakarot_address, proxy_account_class_hash }
     }
 
     /// Create a new `StarknetConfig` from environment variables.
@@ -99,7 +99,7 @@ impl StarknetConfig {
             ))
         })?;
 
-        Ok(StarknetConfig::new(network, kakarot_address, proxy_account_class_hash))
+        Ok(KakarotRpcConfig::new(network, kakarot_address, proxy_account_class_hash))
     }
 }
 
@@ -139,7 +139,7 @@ impl JsonRpcClientBuilder<HttpTransport> {
     /// let starknet_provider: JsonRpcClient<HttpTransport> =
     ///     JsonRpcClientBuilder::with_http(&config).unwrap().build();
     /// ```
-    pub fn with_http(config: &StarknetConfig) -> Result<Self> {
+    pub fn with_http(config: &KakarotRpcConfig) -> Result<Self> {
         let url = config.network.provider_url()?;
         let transport = HttpTransport::new(url);
         Ok(Self::new(transport))

--- a/crates/core/src/client/mod.rs
+++ b/crates/core/src/client/mod.rs
@@ -34,7 +34,7 @@ use starknet::providers::{MaybeUnknownErrorCode, Provider, ProviderError, Starkn
 use starknet::signers::LocalWallet;
 
 use self::api::{KakarotEthApi, KakarotStarknetApi};
-use self::config::{Network, StarknetConfig};
+use self::config::{KakarotRpcConfig, Network};
 use self::constants::gas::{BASE_FEE_PER_GAS, MAX_PRIORITY_FEE_PER_GAS, MINIMUM_GAS_FEE};
 use self::constants::{
     CHAIN_ID, CHUNK_SIZE_LIMIT, COUNTER_CALL_MAINNET, COUNTER_CALL_TESTNET1, COUNTER_CALL_TESTNET2,
@@ -71,11 +71,11 @@ pub struct KakarotClient<P: Provider + Send + Sync> {
 impl<P: Provider + Send + Sync + 'static> KakarotClient<P> {
     /// Create a new `KakarotClient`.
     pub fn new(
-        starknet_config: StarknetConfig,
+        starknet_config: KakarotRpcConfig,
         starknet_provider: Arc<P>,
         starknet_account: SingleOwnerAccount<Arc<P>, LocalWallet>,
     ) -> Self {
-        let StarknetConfig { kakarot_address, proxy_account_class_hash, network } = starknet_config;
+        let KakarotRpcConfig { kakarot_address, proxy_account_class_hash, network } = starknet_config;
 
         let kakarot_contract =
             KakarotContract::new(Arc::clone(&starknet_provider), kakarot_address, proxy_account_class_hash);

--- a/crates/core/src/mock/mock_starknet.rs
+++ b/crates/core/src/mock/mock_starknet.rs
@@ -13,7 +13,7 @@ use starknet_crypto::FieldElement;
 use walkdir::WalkDir;
 
 use super::constants::{KAKAROT_ADDRESS, KAKAROT_TESTNET_ADDRESS, PROXY_ACCOUNT_CLASS_HASH};
-use crate::client::config::{Network, SequencerGatewayProviderBuilder, StarknetConfig};
+use crate::client::config::{KakarotRpcConfig, Network, SequencerGatewayProviderBuilder};
 use crate::client::KakarotClient;
 
 /// A fixture for a Starknet RPC call.
@@ -202,7 +202,7 @@ pub fn mock_starknet_provider(fixtures: Option<Vec<StarknetRpcFixture>>) -> Json
 
 pub fn init_testnet_client() -> KakarotClient<SequencerGatewayProvider> {
     let kakarot_address = FieldElement::from_hex_be(KAKAROT_TESTNET_ADDRESS).unwrap();
-    let config = StarknetConfig::new(Network::Goerli1Gateway, kakarot_address, Default::default());
+    let config = KakarotRpcConfig::new(Network::Goerli1Gateway, kakarot_address, Default::default());
 
     let provider = Arc::new(SequencerGatewayProviderBuilder::new(&Network::Goerli1Gateway).build());
     let starknet_account = mock_account(provider.clone());
@@ -216,7 +216,7 @@ pub fn init_mock_client(
     let starknet_provider = Arc::new(mock_starknet_provider(fixtures));
     let starknet_account = mock_account(starknet_provider.clone());
 
-    let config = StarknetConfig::new(Network::Katana, *KAKAROT_ADDRESS, *PROXY_ACCOUNT_CLASS_HASH);
+    let config = KakarotRpcConfig::new(Network::Katana, *KAKAROT_ADDRESS, *PROXY_ACCOUNT_CLASS_HASH);
 
     KakarotClient::new(config, starknet_provider, starknet_account)
 }

--- a/crates/eth-rpc/src/main.rs
+++ b/crates/eth-rpc/src/main.rs
@@ -6,7 +6,7 @@ use kakarot_rpc::config::RPCConfig;
 use kakarot_rpc::rpc::KakarotRpcModuleBuilder;
 use kakarot_rpc::run_server;
 use kakarot_rpc_core::client::config::{
-    get_starknet_account_from_env, JsonRpcClientBuilder, Network, SequencerGatewayProviderBuilder, StarknetConfig,
+    get_starknet_account_from_env, JsonRpcClientBuilder, KakarotRpcConfig, Network, SequencerGatewayProviderBuilder,
 };
 use kakarot_rpc_core::client::KakarotClient;
 use starknet::providers::jsonrpc::HttpTransport;
@@ -26,7 +26,7 @@ async fn main() -> Result<()> {
     let filter = tracing_subscriber::EnvFilter::try_from_default_env()?;
     tracing_subscriber::FmtSubscriber::builder().with_env_filter(filter).finish().try_init()?;
 
-    let starknet_config = StarknetConfig::from_env()?;
+    let starknet_config = KakarotRpcConfig::from_env()?;
 
     let rpc_config = RPCConfig::from_env()?;
 

--- a/crates/test-utils/src/deploy_helpers.rs
+++ b/crates/test-utils/src/deploy_helpers.rs
@@ -12,7 +12,7 @@ use ethers::types::Address as EthersAddress;
 use ethers_solc::artifacts::CompactContractBytecode;
 use foundry_config::utils::{find_project_root_path, load_config};
 use kakarot_rpc_core::client::api::KakarotStarknetApi;
-use kakarot_rpc_core::client::config::{Network, StarknetConfig as StarknetClientConfig};
+use kakarot_rpc_core::client::config::{KakarotRpcConfig, Network};
 use kakarot_rpc_core::client::constants::{CHAIN_ID, DEPLOY_FEE, STARKNET_NATIVE_TOKEN};
 use kakarot_rpc_core::client::waiter::TransactionWaiter;
 use kakarot_rpc_core::client::KakarotClient;
@@ -699,7 +699,7 @@ impl KakarotTestEnvironmentContext {
 
         // Create a Kakarot client
         let kakarot_client = KakarotClient::new(
-            StarknetClientConfig::new(
+            KakarotRpcConfig::new(
                 Network::JsonRpcProvider(sequencer.url()),
                 kakarot.kakarot_address,
                 kakarot.proxy_class_hash,
@@ -816,7 +816,7 @@ impl KakarotTestEnvironmentContext {
 
         // Create a Kakarot client
         let kakarot_client = KakarotClient::new(
-            StarknetClientConfig::new(
+            KakarotRpcConfig::new(
                 Network::JsonRpcProvider(sequencer.url()),
                 kakarot.kakarot_address,
                 kakarot.proxy_class_hash,

--- a/crates/test-utils/src/rpc_helpers.rs
+++ b/crates/test-utils/src/rpc_helpers.rs
@@ -6,7 +6,7 @@ use kakarot_rpc::config::RPCConfig;
 use kakarot_rpc::rpc::KakarotRpcModuleBuilder;
 use kakarot_rpc::run_server;
 use kakarot_rpc_core::client::api::KakarotStarknetApi;
-use kakarot_rpc_core::client::config::{Network, StarknetConfig};
+use kakarot_rpc_core::client::config::{KakarotRpcConfig, Network};
 use kakarot_rpc_core::client::KakarotClient;
 use starknet::providers::jsonrpc::HttpTransport;
 use starknet::providers::JsonRpcClient;
@@ -66,7 +66,7 @@ pub async fn start_kakarot_rpc_server(
     let kakarot = kakarot_test_env.kakarot();
 
     let provider = Arc::new(JsonRpcClient::new(HttpTransport::new(sequencer.url())));
-    let starknet_config = StarknetConfig::new(
+    let starknet_config = KakarotRpcConfig::new(
         Network::JsonRpcProvider(sequencer.url()),
         kakarot.kakarot_address,
         kakarot.proxy_class_hash,


### PR DESCRIPTION
Resolves: #566 

# Pull Request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Testing

# What is the new behavior?

The PR renames `StarknetConfig` to `KakarotRpcConfig` as the name is more accurate to what the structure represents.

# Does this introduce a breaking change?

- [ ] Yes
- [x] No
