### PR TITLE
dev: refactor KakarotTestEnvironmentContext.seqeuncer() method to return the Arc<KatanaSeqeuncer>

### DIFF
--- a/crates/test-utils/src/bin/dump-katana.rs
+++ b/crates/test-utils/src/bin/dump-katana.rs
@@ -27,13 +27,8 @@ async fn main() {
     tokio::task::spawn_blocking(move || {
         // Get a serializable state for the sequencer
         let sequencer = test_context.sequencer();
-        let dump_state = sequencer
-            .sequencer
-            .backend
-            .state
-            .blocking_write()
-            .dump_state()
-            .expect("Failed to call dump_state on Katana state");
+        let dump_state =
+            sequencer.backend.state.blocking_write().dump_state().expect("Failed to call dump_state on Katana state");
 
         let state = serde_json::to_string(&dump_state).expect("Failed to serialize state");
 

--- a/crates/test-utils/src/deploy_helpers.rs
+++ b/crates/test-utils/src/deploy_helpers.rs
@@ -19,6 +19,7 @@ use kakarot_rpc_core::client::KakarotClient;
 use kakarot_rpc_core::contracts::kakarot::KakarotContract;
 use kakarot_rpc_core::models::felt::Felt252Wrapper;
 use katana_core::db::serde::state::SerializableState;
+use katana_core::sequencer::KatanaSequencer;
 use reth_primitives::{sign_message, Address, Bytes, Transaction, TransactionKind, TransactionSigned, TxEip1559, H256};
 use serde::{Deserialize, Serialize};
 use starknet::accounts::{Account, Call, ConnectedAccount, ExecutionEncoding, SingleOwnerAccount};
@@ -843,8 +844,12 @@ impl KakarotTestEnvironmentContext {
         self
     }
 
-    pub fn sequencer(&self) -> &TestSequencer {
-        &self.sequencer
+    pub fn sequencer(&self) -> Arc<KatanaSequencer> {
+        self.sequencer.sequencer.clone()
+    }
+
+    pub fn url(&self) -> Url {
+        self.sequencer.url()
     }
 
     pub fn client(&self) -> &KakarotClient<JsonRpcClient<HttpTransport>> {

--- a/crates/test-utils/src/hive_utils/madara/utils.rs
+++ b/crates/test-utils/src/hive_utils/madara/utils.rs
@@ -259,8 +259,10 @@ mod tests {
         let env = Arc::clone(&test_environment);
         // It is not possible to block the async test task, so we need to spawn a blocking task
         tokio::task::spawn_blocking(move || {
+            let sequencer = env.sequencer();
+
             // Get lock on the Starknet sequencer
-            let mut starknet = env.sequencer().sequencer.backend.state.blocking_write();
+            let mut starknet = sequencer.backend.state.blocking_write();
             let mut counter_storage = HashMap::new();
 
             // Set the counter bytecode length into the contract
@@ -403,8 +405,10 @@ mod tests {
         let env = Arc::clone(&test_environment);
         // It is not possible to block the async test task, so we need to spawn a blocking task
         tokio::task::spawn_blocking(move || {
+            let sequencer = env.sequencer();
+
             // Get lock on the Starknet sequencer
-            let mut starknet = env.sequencer().sequencer.backend.state.blocking_write();
+            let mut starknet = sequencer.backend.state.blocking_write();
             let mut storage = HashMap::new();
 
             // Prepare the record to be inserted into the storage

--- a/crates/test-utils/src/rpc_helpers.rs
+++ b/crates/test-utils/src/rpc_helpers.rs
@@ -62,12 +62,11 @@ use crate::deploy_helpers::KakarotTestEnvironmentContext;
 pub async fn start_kakarot_rpc_server(
     kakarot_test_env: &KakarotTestEnvironmentContext,
 ) -> Result<(SocketAddr, ServerHandle), eyre::Report> {
-    let sequencer = kakarot_test_env.sequencer();
     let kakarot = kakarot_test_env.kakarot();
 
-    let provider = Arc::new(JsonRpcClient::new(HttpTransport::new(sequencer.url())));
+    let provider = Arc::new(JsonRpcClient::new(HttpTransport::new(kakarot_test_env.url())));
     let starknet_config = KakarotRpcConfig::new(
-        Network::JsonRpcProvider(sequencer.url()),
+        Network::JsonRpcProvider(kakarot_test_env.url()),
         kakarot.kakarot_address,
         kakarot.proxy_class_hash,
         kakarot.externally_owned_account_class_hash,


### PR DESCRIPTION
Resolves: #531 

# Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Testing

# What is the new behavior?

The `KakarotTestEnvironmentContext.seqeuncer()` method returns `Arc<KatanaSeqeuncer>` which helps solve the current code smell of `KakarotTestEnvironmentContext.seqeuncer().seqeuncer`, we can now just use `KakarotTestEnvironmentContext.seqeuncer()`.

A getter for seqeuncer `url` has also been added to the`KakarotTestEnironmentContext` + also fixes some doc issues.

# Does this introduce a breaking change?

- [ ] Yes
- [x] No
