### PR TITLE
Use new env var for defining kakarot's rpc url

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ run-dev:
 
 # Run Katana, Deploy Kakarot, Run Kakarot RPC
 katana-rpc-up:
-	docker compose -f docker-compose.katana.yaml up  --force-recreate
+	docker compose -f docker-compose.katana.yaml up -d --force-recreate
 
 # Run Madara, Deploy Kakarot, Run Kakarot RPC
 madara-rpc-up:

--- a/docker-compose.katana.yaml
+++ b/docker-compose.katana.yaml
@@ -6,6 +6,8 @@ services:
     image: greged93/katana:v0.4.4
     command:
       - "katana"
+      - "--block-time"
+      - "6000"
       - "--disable-fee"
       - "--validate-max-steps"
       - "16777216"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -58,7 +58,7 @@ services:
     ports:
       - 3030:3030
     environment:
-      - KAKAROT_HTTP_RPC_ADDRESS=0.0.0.0:3030
+      - KAKAROT_RPC_URL=0.0.0.0:3030
       - STARKNET_NETWORK=http://starknet:9944
       - RUST_LOG=kakarot_rpc=info
       - DEPLOYER_ACCOUNT_PRIVATE_KEY=0x0288a51c164874bb6a1ca7bd1cb71823c234a86d0f7b150d70fa8f06de645396


### PR DESCRIPTION
@Eikix knows
- Use new env var for defining kakarot's rpc url
- Run katana as daemon
- Force block sealing in katana

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kkrt-labs/kakarot-rpc/724)
<!-- Reviewable:end -->
