### PR TITLE
dev: Decouple test environment from `.env` file

### DIFF
--- a/src/eth_rpc/config.rs
+++ b/src/eth_rpc/config.rs
@@ -25,11 +25,13 @@ impl RPCConfig {
         Ok(config)
     }
 
+    #[cfg(feature = "testing")]
     pub fn new_test_config() -> Self {
         // Hardcode the socket address for testing environment
         Self::new("127.0.0.1:3030".to_string())
     }
 
+    #[cfg(feature = "testing")]
     pub fn new_test_config_from_port(port: u16) -> Self {
         let mut config = Self::new_test_config();
         // Remove port from socket address and replace it with provided port

--- a/src/eth_rpc/config.rs
+++ b/src/eth_rpc/config.rs
@@ -24,4 +24,19 @@ impl RPCConfig {
         }
         Ok(config)
     }
+
+    pub fn new_test_config() -> Self {
+        // Hardcode the socket address for testing environment
+        Self::new("127.0.0.1:3030".to_string())
+    }
+
+    pub fn new_test_config_from_port(port: u16) -> Self {
+        let mut config = Self::new_test_config();
+        // Remove port from socket address and replace it with provided port
+        let parts: Vec<&str> = config.socket_addr.split(':').collect();
+        if let Some(addr) = parts.first() {
+            config.socket_addr = format!("{}:{}", addr, port);
+        }
+        config
+    }
 }

--- a/src/test_utils/rpc/mod.rs
+++ b/src/test_utils/rpc/mod.rs
@@ -80,7 +80,7 @@ async fn get_next_port() -> u16 {
 pub async fn start_kakarot_rpc_server(katana: &Katana) -> Result<(SocketAddr, ServerHandle), eyre::Report> {
     Ok(run_server(
         KakarotRpcModuleBuilder::new(katana.eth_provider()).rpc_module()?,
-        RPCConfig::from_port(get_next_port().await)?,
+        RPCConfig::new_test_config_from_port(get_next_port().await),
     )
     .await?)
 }

--- a/src/test_utils/rpc/mod.rs
+++ b/src/test_utils/rpc/mod.rs
@@ -80,7 +80,10 @@ async fn get_next_port() -> u16 {
 pub async fn start_kakarot_rpc_server(katana: &Katana) -> Result<(SocketAddr, ServerHandle), eyre::Report> {
     Ok(run_server(
         KakarotRpcModuleBuilder::new(katana.eth_provider()).rpc_module()?,
+        #[cfg(feature = "testing")]
         RPCConfig::new_test_config_from_port(get_next_port().await),
+        #[cfg(not(feature = "testing"))]
+        RPCConfig::from_port(get_next_port().await),
     )
     .await?)
 }


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

Time spent on this PR: 15 min

Resolves: #879 

# Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [X] Testing

# What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

A new method is introduced in `RPCConfig` structure in order not to depend anymore on the `.env` file for testing purposes.


# Does this introduce a breaking change?

- [ ] Yes
- [X] No
