### PR TITLE
Simplify `Felt252Wrapper` usage via `Deref` and `DerefMut`

### DIFF
--- a/src/models/felt.rs
+++ b/src/models/felt.rs
@@ -1,5 +1,5 @@
 use reth_primitives::{Address, B256, U256, U64};
-use starknet::core::types::FieldElement;
+use starknet::core::types::{EthAddress, FieldElement};
 use std::ops::{Deref, DerefMut};
 
 #[derive(Debug, thiserror::Error)]
@@ -39,15 +39,9 @@ impl TryFrom<Felt252Wrapper> for Address {
     type Error = ConversionError;
 
     fn try_from(felt: Felt252Wrapper) -> Result<Self, Self::Error> {
-        let bytes = felt.to_bytes_be();
-
-        let (prefix, suffix) = bytes.split_at(12);
-
-        if prefix.iter().all(|&x| x == 0) {
-            Ok(Self::from_slice(suffix))
-        } else {
-            Err(ConversionError)
-        }
+        EthAddress::from_felt(&felt)
+            .map(|eth_address| Self::from_slice(eth_address.as_bytes()))
+            .map_err(|_| ConversionError)
     }
 }
 

--- a/src/models/felt.rs
+++ b/src/models/felt.rs
@@ -1,5 +1,6 @@
 use reth_primitives::{Address, B256, U256, U64};
 use starknet::core::types::FieldElement;
+use std::ops::{Deref, DerefMut};
 
 #[derive(Debug, thiserror::Error)]
 #[error("conversion failed")]
@@ -23,15 +24,14 @@ impl From<Felt252Wrapper> for FieldElement {
 #[allow(clippy::fallible_impl_from)]
 impl From<Address> for Felt252Wrapper {
     fn from(address: Address) -> Self {
-        let felt = FieldElement::from_byte_slice_be(address.as_slice()).unwrap(); // safe unwrap since H160 is 20 bytes
-        Self(felt)
+        // safe unwrap since H160 is 20 bytes
+        Self(FieldElement::from_byte_slice_be(address.as_slice()).unwrap())
     }
 }
 
 impl From<U64> for Felt252Wrapper {
     fn from(value: U64) -> Self {
-        let felt = FieldElement::from(value.to::<u64>());
-        Self(felt)
+        Self(FieldElement::from(value.to::<u64>()))
     }
 }
 
@@ -39,15 +39,15 @@ impl TryFrom<Felt252Wrapper> for Address {
     type Error = ConversionError;
 
     fn try_from(felt: Felt252Wrapper) -> Result<Self, Self::Error> {
-        let felt: FieldElement = felt.into();
         let bytes = felt.to_bytes_be();
 
-        // Check if the first 12 bytes are all zeros.
-        if bytes[0..12].iter().any(|&x| x != 0) {
-            return Err(ConversionError);
-        }
+        let (prefix, suffix) = bytes.split_at(12);
 
-        Ok(Self::from_slice(&bytes[12..]))
+        if prefix.iter().all(|&x| x == 0) {
+            Ok(Self::from_slice(suffix))
+        } else {
+            Err(ConversionError)
+        }
     }
 }
 
@@ -55,8 +55,7 @@ impl TryFrom<B256> for Felt252Wrapper {
     type Error = ConversionError;
 
     fn try_from(value: B256) -> Result<Self, Self::Error> {
-        let felt = FieldElement::from_bytes_be(value.as_ref()).map_err(|_| ConversionError)?;
-        Ok(Self(felt))
+        Ok(Self(FieldElement::from_bytes_be(value.as_ref()).map_err(|_| ConversionError)?))
     }
 }
 
@@ -64,15 +63,27 @@ impl TryFrom<U256> for Felt252Wrapper {
     type Error = ConversionError;
 
     fn try_from(u256: U256) -> Result<Self, Self::Error> {
-        let felt = FieldElement::from_bytes_be(&u256.to_be_bytes()).map_err(|_| ConversionError)?;
-        Ok(Self(felt))
+        Ok(Self(FieldElement::from_bytes_be(&u256.to_be_bytes()).map_err(|_| ConversionError)?))
     }
 }
 
 impl From<Felt252Wrapper> for U256 {
     fn from(felt: Felt252Wrapper) -> Self {
-        let felt: FieldElement = felt.into();
         Self::from_be_bytes(felt.to_bytes_be())
+    }
+}
+
+impl Deref for Felt252Wrapper {
+    type Target = FieldElement;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl DerefMut for Felt252Wrapper {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
     }
 }
 


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

Time spent on this PR: 20 min


# Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [X] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Testing

# What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- The usage of `Felt252Wrapper` is simplified via the implementation of `Deref` and `DerefMut`.
- Conversion from Ethereum `Address` type to `Felt252Wrapper` is simplified.


# Does this introduce a breaking change?

- [ ] Yes
- [X] No
