### PR TITLE
Use reth `TxType` in `rpc_transaction_to_primitive`

### DIFF
--- a/src/models/transaction.rs
+++ b/src/models/transaction.rs
@@ -1,6 +1,4 @@
-use reth_primitives::{
-    AccessList, AccessListItem, Transaction, TransactionKind, TxEip1559, TxEip2930, TxLegacy, TxType,
-};
+use reth_primitives::{AccessList, AccessListItem, TransactionKind, TxEip1559, TxEip2930, TxLegacy, TxType};
 
 use super::felt::ConversionError;
 use crate::eth_provider::error::KakarotError;
@@ -14,7 +12,7 @@ pub fn rpc_transaction_to_primitive(
     };
 
     match tx_type {
-        TxType::Legacy => Ok(Transaction::Legacy(TxLegacy {
+        TxType::Legacy => Ok(reth_primitives::Transaction::Legacy(TxLegacy {
             nonce: rpc_transaction.nonce.to::<u64>(),
             gas_price: rpc_transaction.gas_price.ok_or(ConversionError)?.to::<u128>(),
             gas_limit: rpc_transaction.gas.try_into().map_err(|_| ConversionError)?,
@@ -23,7 +21,7 @@ pub fn rpc_transaction_to_primitive(
             input: rpc_transaction.input,
             chain_id: rpc_transaction.chain_id.map(|id| id.to::<u64>()),
         })),
-        TxType::Eip2930 => Ok(Transaction::Eip2930(TxEip2930 {
+        TxType::Eip2930 => Ok(reth_primitives::Transaction::Eip2930(TxEip2930 {
             chain_id: rpc_transaction.chain_id.ok_or(ConversionError)?.to::<u64>(),
             nonce: rpc_transaction.nonce.to::<u64>(),
             gas_price: rpc_transaction.gas_price.ok_or(ConversionError)?.to::<u128>(),
@@ -43,7 +41,7 @@ pub fn rpc_transaction_to_primitive(
             ),
             input: rpc_transaction.input,
         })),
-        TxType::Eip1559 => Ok(Transaction::Eip1559(TxEip1559 {
+        TxType::Eip1559 => Ok(reth_primitives::Transaction::Eip1559(TxEip1559 {
             chain_id: rpc_transaction.chain_id.ok_or(ConversionError)?.to::<u64>(),
             nonce: rpc_transaction.nonce.to::<u64>(),
             gas_limit: rpc_transaction.gas.try_into().map_err(|_| ConversionError)?,

--- a/src/models/transaction.rs
+++ b/src/models/transaction.rs
@@ -7,7 +7,11 @@ pub fn rpc_transaction_to_primitive(
     rpc_transaction: reth_rpc_types::Transaction,
 ) -> Result<reth_primitives::Transaction, KakarotError> {
     let tx_type = match rpc_transaction.transaction_type {
-        Some(transaction_type) => transaction_type.to::<u8>().try_into().map_err(|_| ConversionError)?,
+        Some(transaction_type) => {
+            let transaction_type_u8: u8 = transaction_type.try_into().map_err(|_| ConversionError)?;
+
+            transaction_type_u8.try_into().map_err(|_| ConversionError)?
+        }
         _ => return Err(ConversionError.into()),
     };
 

--- a/src/models/transaction.rs
+++ b/src/models/transaction.rs
@@ -8,9 +8,9 @@ pub fn rpc_transaction_to_primitive(
 ) -> Result<reth_primitives::Transaction, KakarotError> {
     let tx_type = match rpc_transaction.transaction_type {
         Some(transaction_type) => {
-            let transaction_type_u8: u8 = transaction_type.try_into().map_err(|_| ConversionError)?;
+            let transaction_type: u8 = transaction_type.try_into().map_err(|_| ConversionError)?;
 
-            transaction_type_u8.try_into().map_err(|_| ConversionError)?
+            transaction_type.try_into().map_err(|_| ConversionError)?
         }
         _ => return Err(ConversionError.into()),
     };

--- a/src/models/transaction.rs
+++ b/src/models/transaction.rs
@@ -1,4 +1,6 @@
-use reth_primitives::{AccessList, AccessListItem, TransactionKind, TxEip1559, TxEip2930, TxLegacy};
+use reth_primitives::{
+    AccessList, AccessListItem, Transaction, TransactionKind, TxEip1559, TxEip2930, TxLegacy, TxType,
+};
 
 use super::felt::ConversionError;
 use crate::eth_provider::error::KakarotError;
@@ -6,63 +8,66 @@ use crate::eth_provider::error::KakarotError;
 pub fn rpc_transaction_to_primitive(
     rpc_transaction: reth_rpc_types::Transaction,
 ) -> Result<reth_primitives::Transaction, KakarotError> {
-    match rpc_transaction.transaction_type {
-        Some(transaction_type) => match transaction_type.to::<u64>() {
-            0 => Ok(reth_primitives::Transaction::Legacy(TxLegacy {
-                nonce: rpc_transaction.nonce.to::<u64>(),
-                gas_price: rpc_transaction.gas_price.ok_or(ConversionError)?.to::<u128>(),
-                gas_limit: rpc_transaction.gas.try_into().map_err(|_| ConversionError)?,
-                to: rpc_transaction.to.map_or_else(|| TransactionKind::Create, TransactionKind::Call),
-                value: rpc_transaction.value,
-                input: rpc_transaction.input,
-                chain_id: rpc_transaction.chain_id.map(|id| id.to::<u64>()),
-            })),
-            1 => Ok(reth_primitives::Transaction::Eip2930(TxEip2930 {
-                chain_id: rpc_transaction.chain_id.ok_or(ConversionError)?.to::<u64>(),
-                nonce: rpc_transaction.nonce.to::<u64>(),
-                gas_price: rpc_transaction.gas_price.ok_or(ConversionError)?.to::<u128>(),
-                gas_limit: rpc_transaction.gas.try_into().map_err(|_| ConversionError)?,
-                to: rpc_transaction.to.map_or_else(|| TransactionKind::Create, TransactionKind::Call),
-                value: rpc_transaction.value,
-                access_list: AccessList(
-                    rpc_transaction
-                        .access_list
-                        .unwrap_or_default()
-                        .into_iter()
-                        .map(|access_list| AccessListItem {
-                            address: access_list.address,
-                            storage_keys: access_list.storage_keys,
-                        })
-                        .collect(),
-                ),
-                input: rpc_transaction.input,
-            })),
-            2 => Ok(reth_primitives::Transaction::Eip1559(TxEip1559 {
-                chain_id: rpc_transaction.chain_id.ok_or(ConversionError)?.to::<u64>(),
-                nonce: rpc_transaction.nonce.to::<u64>(),
-                gas_limit: rpc_transaction.gas.try_into().map_err(|_| ConversionError)?,
-                max_fee_per_gas: rpc_transaction.max_fee_per_gas.ok_or(ConversionError)?.to::<u128>(),
-                max_priority_fee_per_gas: rpc_transaction.max_priority_fee_per_gas.ok_or(ConversionError)?.to::<u128>(),
-                to: rpc_transaction.to.map_or_else(|| TransactionKind::Create, TransactionKind::Call),
-                value: rpc_transaction.value,
-                access_list: AccessList(
-                    rpc_transaction
-                        .access_list
-                        .unwrap_or_default()
-                        .into_iter()
-                        .map(|access_list| AccessListItem {
-                            address: access_list.address,
-                            storage_keys: access_list.storage_keys,
-                        })
-                        .collect(),
-                ),
-                input: rpc_transaction.input,
-            })),
-            _ => Err(ConversionError.into()),
-        },
+    let tx_type = match rpc_transaction.transaction_type {
+        Some(transaction_type) => transaction_type.to::<u8>().try_into().map_err(|_| ConversionError)?,
+        _ => return Err(ConversionError.into()),
+    };
+
+    match tx_type {
+        TxType::Legacy => Ok(Transaction::Legacy(TxLegacy {
+            nonce: rpc_transaction.nonce.to::<u64>(),
+            gas_price: rpc_transaction.gas_price.ok_or(ConversionError)?.to::<u128>(),
+            gas_limit: rpc_transaction.gas.try_into().map_err(|_| ConversionError)?,
+            to: rpc_transaction.to.map_or_else(|| TransactionKind::Create, TransactionKind::Call),
+            value: rpc_transaction.value,
+            input: rpc_transaction.input,
+            chain_id: rpc_transaction.chain_id.map(|id| id.to::<u64>()),
+        })),
+        TxType::Eip2930 => Ok(Transaction::Eip2930(TxEip2930 {
+            chain_id: rpc_transaction.chain_id.ok_or(ConversionError)?.to::<u64>(),
+            nonce: rpc_transaction.nonce.to::<u64>(),
+            gas_price: rpc_transaction.gas_price.ok_or(ConversionError)?.to::<u128>(),
+            gas_limit: rpc_transaction.gas.try_into().map_err(|_| ConversionError)?,
+            to: rpc_transaction.to.map_or_else(|| TransactionKind::Create, TransactionKind::Call),
+            value: rpc_transaction.value,
+            access_list: AccessList(
+                rpc_transaction
+                    .access_list
+                    .unwrap_or_default()
+                    .into_iter()
+                    .map(|access_list| AccessListItem {
+                        address: access_list.address,
+                        storage_keys: access_list.storage_keys,
+                    })
+                    .collect(),
+            ),
+            input: rpc_transaction.input,
+        })),
+        TxType::Eip1559 => Ok(Transaction::Eip1559(TxEip1559 {
+            chain_id: rpc_transaction.chain_id.ok_or(ConversionError)?.to::<u64>(),
+            nonce: rpc_transaction.nonce.to::<u64>(),
+            gas_limit: rpc_transaction.gas.try_into().map_err(|_| ConversionError)?,
+            max_fee_per_gas: rpc_transaction.max_fee_per_gas.ok_or(ConversionError)?.to::<u128>(),
+            max_priority_fee_per_gas: rpc_transaction.max_priority_fee_per_gas.ok_or(ConversionError)?.to::<u128>(),
+            to: rpc_transaction.to.map_or_else(|| TransactionKind::Create, TransactionKind::Call),
+            value: rpc_transaction.value,
+            access_list: AccessList(
+                rpc_transaction
+                    .access_list
+                    .unwrap_or_default()
+                    .into_iter()
+                    .map(|access_list| AccessListItem {
+                        address: access_list.address,
+                        storage_keys: access_list.storage_keys,
+                    })
+                    .collect(),
+            ),
+            input: rpc_transaction.input,
+        })),
         _ => Err(ConversionError.into()),
     }
 }
+
 #[cfg(test)]
 mod tests {
     use std::str::FromStr;


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

Time spent on this PR: 10 min

# Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [X] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Testing

# What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

To accurately convert an RPC transaction type to a primitive transaction type, it's advisable to use the reth `TxType` enum for identification rather than hardcoded numerical values.

Therefore, we begin by attempting to convert the bigint to a u8, raising a conversion error if necessary. Subsequently, we perform a thorough identification based on the `TxType`, addressing all potential scenarios.

# Does this introduce a breaking change?

- [ ] Yes
- [X] No
