### PR TITLE
Add cargo fmt nightly for import granularity

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          components: llvm-tools-preview, clippy
+          components: llvm-tools-preview, rustfmt, clippy
           override: true
           toolchain: 1.76.0
       - name: Retrieve cached dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,17 @@ on:
   workflow_call:
 
 jobs:
+  fmt:
+    name: fmt
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@nightly
+        with:
+          components: rustfmt
+      - run: cargo fmt --all --check
+
   test:
     runs-on: ubuntu-latest-16-cores
     timeout-minutes: 30
@@ -13,7 +24,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          components: llvm-tools-preview, rustfmt, clippy
+          components: llvm-tools-preview, clippy
           override: true
           toolchain: 1.76.0
       - name: Retrieve cached dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@nightly
         with:
           components: rustfmt
+          toolchain: nightly
       - run: cargo fmt --all --check
 
   test:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "kakarot-rpc"
 version = "0.1.0"
 edition = "2021"
+rust-version = "1.76"
 authors = [
   "Abdelhamid Bakhta <@abdelhamidbakhta>",
   "Elias Tazartes <@eikix>",

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -20,7 +20,17 @@ To set up a development environment, please follow these steps:
    cargo test
    ```
 
-2. TODO
+2. If you are working in VSCode, we recommend you install the [rust-analyzer](https://rust-analyzer.github.io/) extension, and use the following VSCode user settings:
+
+   ```json
+   "editor.formatOnSave": true,
+   "rust-analyzer.rustfmt.extraArgs": ["+nightly"],
+   "[rust]": {
+   "editor.defaultFormatter": "rust-lang.rust-analyzer"
+   }
+   ```
+
+3. TODO
 
 ## Issues and feature requests
 

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,2 +1,0 @@
-[toolchain]
-channel = "1.76.0"

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "stable"

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -4,3 +4,4 @@ use_field_init_shorthand = true
 use_small_heuristics = "Max"
 use_try_shorthand = true
 max_width = 120
+imports_granularity = "Crate"

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,7 +1,11 @@
 use eyre::eyre;
-use starknet::core::types::FieldElement;
-use starknet::providers::jsonrpc::{HttpTransport, JsonRpcTransport};
-use starknet::providers::{JsonRpcClient, SequencerGatewayProvider};
+use starknet::{
+    core::types::FieldElement,
+    providers::{
+        jsonrpc::{HttpTransport, JsonRpcTransport},
+        JsonRpcClient, SequencerGatewayProvider,
+    },
+};
 use std::env::var;
 use url::Url;
 

--- a/src/eth_provider/constant.rs
+++ b/src/eth_provider/constant.rs
@@ -1,11 +1,4 @@
 use lazy_static::lazy_static;
-
-lazy_static! {
-    pub static ref MAX_PRIORITY_FEE_PER_GAS: u64 = 0;
-}
-
-pub const CALL_REQUEST_GAS_LIMIT: u64 = 5_000_000;
-
 #[cfg(feature = "hive")]
 use {
     crate::config::KakarotRpcConfig,
@@ -19,6 +12,12 @@ use {
     std::{env::var, str::FromStr, sync::OnceLock},
     tokio::sync::Mutex,
 };
+
+lazy_static! {
+    pub static ref MAX_PRIORITY_FEE_PER_GAS: u64 = 0;
+}
+
+pub const CALL_REQUEST_GAS_LIMIT: u64 = 5_000_000;
 
 #[cfg(feature = "hive")]
 pub static CHAIN_ID: OnceLock<FieldElement> = OnceLock::new();

--- a/src/eth_provider/contracts/erc20.rs
+++ b/src/eth_provider/contracts/erc20.rs
@@ -1,15 +1,10 @@
-use ethers::abi::AbiEncode;
-use ethers::core::types::Address as EthersAddress;
-use ethers::prelude::abigen;
-use reth_primitives::Address;
-
-use reth_primitives::{BlockId, U256};
-use reth_rpc_types::request::TransactionInput;
-use reth_rpc_types::TransactionRequest;
-
-use crate::eth_provider::error::KakarotError;
-use crate::eth_provider::provider::EthProviderResult;
-use crate::eth_provider::provider::EthereumProvider;
+use crate::eth_provider::{
+    error::KakarotError,
+    provider::{EthProviderResult, EthereumProvider},
+};
+use ethers::{abi::AbiEncode, core::types::Address as EthersAddress, prelude::abigen};
+use reth_primitives::{Address, BlockId, U256};
+use reth_rpc_types::{request::TransactionInput, TransactionRequest};
 
 // abigen generates a lot of unused code, needs to be benchmarked if performances ever become a
 // concern

--- a/src/eth_provider/database/mod.rs
+++ b/src/eth_provider/database/mod.rs
@@ -1,5 +1,4 @@
-pub mod types;
-
+use super::error::KakarotError;
 use futures::TryStreamExt;
 use mongodb::{
     bson::Document,
@@ -8,7 +7,7 @@ use mongodb::{
 };
 use serde::de::DeserializeOwned;
 
-use super::error::KakarotError;
+pub mod types;
 
 type DatabaseResult<T> = eyre::Result<T, KakarotError>;
 

--- a/src/eth_provider/database/types/serde/mod.rs
+++ b/src/eth_provider/database/types/serde/mod.rs
@@ -1,7 +1,6 @@
-use std::collections::HashMap;
-
 use serde::{de::value::MapDeserializer, Deserialize, Deserializer};
 use serde_json::Value;
+use std::collections::HashMap;
 
 /// Used in order to perform a custom deserialization of the stored
 /// Ethereum data from the database. All the primitive types are stored

--- a/src/eth_provider/error.rs
+++ b/src/eth_provider/error.rs
@@ -1,7 +1,6 @@
+use crate::models::ConversionError;
 use jsonrpsee::types::ErrorObject;
 use thiserror::Error;
-
-use crate::models::ConversionError;
 
 /// List of JSON-RPC error codes from ETH rpc spec.
 /// https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1474.md

--- a/src/eth_provider/starknet/kakarot_core.rs
+++ b/src/eth_provider/starknet/kakarot_core.rs
@@ -1,6 +1,8 @@
-use std::str::FromStr;
-
-use crate::models::felt::Felt252Wrapper;
+use crate::{
+    eth_provider::{provider::EthProviderResult, utils::split_u256},
+    into_via_wrapper,
+    models::felt::Felt252Wrapper,
+};
 use alloy_rlp::Encodable;
 use cainome::rs::abigen_legacy;
 use dotenv::dotenv;
@@ -11,11 +13,7 @@ use starknet::{
     macros::selector,
 };
 use starknet_crypto::FieldElement;
-
-use crate::{
-    eth_provider::{provider::EthProviderResult, utils::split_u256},
-    into_via_wrapper,
-};
+use std::str::FromStr;
 
 // Contract ABIs
 

--- a/src/eth_provider/starknet/mod.rs
+++ b/src/eth_provider/starknet/mod.rs
@@ -1,9 +1,9 @@
 #![allow(non_snake_case)]
-pub mod kakarot_core;
-
 use cainome::rs::abigen_legacy;
 use lazy_static::lazy_static;
 use starknet_crypto::FieldElement;
+
+pub mod kakarot_core;
 
 abigen_legacy!(ERC20, "./.kakarot/artifacts/fixtures/ERC20.json");
 

--- a/src/eth_provider/utils.rs
+++ b/src/eth_provider/utils.rs
@@ -1,5 +1,3 @@
-use std::fmt::LowerHex;
-
 use cainome::cairo_serde::Error;
 use itertools::Itertools;
 use mongodb::bson::{doc, Document};
@@ -8,6 +6,7 @@ use starknet::{
     core::types::{ContractErrorData, StarknetError},
     providers::ProviderError,
 };
+use std::fmt::LowerHex;
 
 /// Converts an iterator of `Into<D>` into a `Vec<D>`.
 #[inline]

--- a/src/eth_rpc/api/alchemy_api.rs
+++ b/src/eth_rpc/api/alchemy_api.rs
@@ -1,6 +1,5 @@
 use crate::models::balance::TokenBalances;
-use jsonrpsee::core::RpcResult as Result;
-use jsonrpsee::proc_macros::rpc;
+use jsonrpsee::{core::RpcResult as Result, proc_macros::rpc};
 use reth_primitives::Address;
 
 // TODO: Define and implement of methods of Alchemy API

--- a/src/eth_rpc/api/debug_api.rs
+++ b/src/eth_rpc/api/debug_api.rs
@@ -1,5 +1,4 @@
-use jsonrpsee::core::RpcResult as Result;
-use jsonrpsee::proc_macros::rpc;
+use jsonrpsee::{core::RpcResult as Result, proc_macros::rpc};
 use reth_primitives::{Bytes, B256};
 use reth_rpc_types::BlockId;
 

--- a/src/eth_rpc/api/eth_api.rs
+++ b/src/eth_rpc/api/eth_api.rs
@@ -1,7 +1,8 @@
-use jsonrpsee::core::RpcResult as Result;
-use jsonrpsee::proc_macros::rpc;
-use reth_primitives::serde_helper::{JsonStorageKey, U64HexOrNumber};
-use reth_primitives::{Address, BlockId, BlockNumberOrTag, Bytes, B256, B64, U256, U64};
+use jsonrpsee::{core::RpcResult as Result, proc_macros::rpc};
+use reth_primitives::{
+    serde_helper::{JsonStorageKey, U64HexOrNumber},
+    Address, BlockId, BlockNumberOrTag, Bytes, B256, B64, U256, U64,
+};
 use reth_rpc_types::{
     AccessListWithGasUsed, EIP1186AccountProofResponse, FeeHistory, Filter, FilterChanges, Index, RichBlock,
     SyncStatus, Transaction as EthTransaction, TransactionReceipt, TransactionRequest, Work,

--- a/src/eth_rpc/api/net_api.rs
+++ b/src/eth_rpc/api/net_api.rs
@@ -1,5 +1,4 @@
-use jsonrpsee::core::RpcResult as Result;
-use jsonrpsee::proc_macros::rpc;
+use jsonrpsee::{core::RpcResult as Result, proc_macros::rpc};
 use reth_primitives::U64;
 use reth_rpc_types::PeerCount;
 

--- a/src/eth_rpc/api/web3_api.rs
+++ b/src/eth_rpc/api/web3_api.rs
@@ -1,5 +1,4 @@
-use jsonrpsee::core::RpcResult as Result;
-use jsonrpsee::proc_macros::rpc;
+use jsonrpsee::{core::RpcResult as Result, proc_macros::rpc};
 use reth_primitives::{Bytes, B256};
 
 #[rpc(server, namespace = "web3")]

--- a/src/eth_rpc/mod.rs
+++ b/src/eth_rpc/mod.rs
@@ -1,19 +1,22 @@
 // //! Kakarot RPC module for Ethereum.
 // //! It is an adapter layer to interact with Kakarot ZK-EVM.
-use std::net::{AddrParseError, SocketAddr};
-
 use config::RPCConfig;
+use eyre::Result;
+use jsonrpsee::{
+    server::{
+        middleware::http::{InvalidPath, ProxyGetRequestLayer},
+        ServerBuilder, ServerHandle,
+    },
+    RpcModule,
+};
+use std::net::{AddrParseError, SocketAddr};
+use thiserror::Error;
+use tower_http::cors::{Any, CorsLayer};
+
 pub mod api;
 pub mod config;
 pub mod rpc;
 pub mod servers;
-
-use eyre::Result;
-use jsonrpsee::server::middleware::http::{InvalidPath, ProxyGetRequestLayer};
-use jsonrpsee::server::{ServerBuilder, ServerHandle};
-use jsonrpsee::RpcModule;
-use thiserror::Error;
-use tower_http::cors::{Any, CorsLayer};
 
 #[derive(Error, Debug)]
 pub enum RpcError {

--- a/src/eth_rpc/rpc.rs
+++ b/src/eth_rpc/rpc.rs
@@ -1,21 +1,17 @@
-use std::collections::HashMap;
-use std::marker::PhantomData;
-use std::sync::Arc;
-
-use jsonrpsee::server::RegisterMethodError;
-use jsonrpsee::{Methods, RpcModule};
-
-use crate::eth_provider::provider::EthereumProvider;
-use crate::eth_rpc::api::alchemy_api::AlchemyApiServer;
-use crate::eth_rpc::api::debug_api::DebugApiServer;
-use crate::eth_rpc::api::eth_api::EthApiServer;
-use crate::eth_rpc::api::net_api::NetApiServer;
-use crate::eth_rpc::api::web3_api::Web3ApiServer;
-use crate::eth_rpc::servers::alchemy_rpc::AlchemyRpc;
-use crate::eth_rpc::servers::debug_rpc::DebugRpc;
-use crate::eth_rpc::servers::eth_rpc::KakarotEthRpc;
-use crate::eth_rpc::servers::net_rpc::NetRpc;
-use crate::eth_rpc::servers::web3_rpc::Web3Rpc;
+use crate::{
+    eth_provider::provider::EthereumProvider,
+    eth_rpc::{
+        api::{
+            alchemy_api::AlchemyApiServer, debug_api::DebugApiServer, eth_api::EthApiServer, net_api::NetApiServer,
+            web3_api::Web3ApiServer,
+        },
+        servers::{
+            alchemy_rpc::AlchemyRpc, debug_rpc::DebugRpc, eth_rpc::KakarotEthRpc, net_rpc::NetRpc, web3_rpc::Web3Rpc,
+        },
+    },
+};
+use jsonrpsee::{server::RegisterMethodError, Methods, RpcModule};
+use std::{collections::HashMap, marker::PhantomData, sync::Arc};
 
 /// Represents RPC modules that are supported by reth
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]

--- a/src/eth_rpc/servers/alchemy_rpc.rs
+++ b/src/eth_rpc/servers/alchemy_rpc.rs
@@ -1,11 +1,11 @@
+use crate::{
+    eth_provider::{contracts::erc20::EthereumErc20, provider::EthereumProvider},
+    eth_rpc::api::alchemy_api::AlchemyApiServer,
+    models::balance::{FutureTokenBalance, TokenBalances},
+};
 use futures::future::join_all;
 use jsonrpsee::core::{async_trait, RpcResult as Result};
 use reth_primitives::{Address, BlockId, BlockNumberOrTag};
-
-use crate::eth_provider::contracts::erc20::EthereumErc20;
-use crate::eth_rpc::api::alchemy_api::AlchemyApiServer;
-use crate::models::balance::FutureTokenBalance;
-use crate::{eth_provider::provider::EthereumProvider, models::balance::TokenBalances};
 
 /// The RPC module for the Ethereum protocol required by Kakarot.
 pub struct AlchemyRpc<P: EthereumProvider> {

--- a/src/eth_rpc/servers/debug_rpc.rs
+++ b/src/eth_rpc/servers/debug_rpc.rs
@@ -1,7 +1,11 @@
-use crate::eth_provider::error::{EthApiError, ReceiptError, SignatureError};
-use crate::eth_rpc::api::debug_api::DebugApiServer;
-use crate::models::block::rpc_to_primitive_block;
-use crate::{eth_provider::provider::EthereumProvider, models::transaction::rpc_transaction_to_primitive};
+use crate::{
+    eth_provider::{
+        error::{EthApiError, ReceiptError, SignatureError},
+        provider::EthereumProvider,
+    },
+    eth_rpc::api::debug_api::DebugApiServer,
+    models::{block::rpc_to_primitive_block, transaction::rpc_transaction_to_primitive},
+};
 use alloy_rlp::Encodable;
 use jsonrpsee::core::{async_trait, RpcResult as Result};
 use reth_primitives::{Bytes, Log, Receipt, ReceiptWithBloom, TransactionSigned, B256};

--- a/src/eth_rpc/servers/eth_rpc.rs
+++ b/src/eth_rpc/servers/eth_rpc.rs
@@ -1,18 +1,18 @@
 #![allow(clippy::blocks_in_conditions)]
-
+use crate::{
+    eth_provider::{constant::MAX_PRIORITY_FEE_PER_GAS, error::EthApiError, provider::EthereumProvider},
+    eth_rpc::api::eth_api::EthApiServer,
+};
 use jsonrpsee::core::{async_trait, RpcResult as Result};
-use reth_primitives::serde_helper::{JsonStorageKey, U64HexOrNumber};
-use reth_primitives::{Address, BlockId, BlockNumberOrTag, Bytes, B256, B64, U256, U64};
+use reth_primitives::{
+    serde_helper::{JsonStorageKey, U64HexOrNumber},
+    Address, BlockId, BlockNumberOrTag, Bytes, B256, B64, U256, U64,
+};
 use reth_rpc_types::{
     AccessListWithGasUsed, EIP1186AccountProofResponse, FeeHistory, Filter, FilterChanges, Index, RichBlock,
     SyncStatus, Transaction, TransactionReceipt, TransactionRequest, Work,
 };
 use serde_json::Value;
-
-use crate::eth_provider::constant::MAX_PRIORITY_FEE_PER_GAS;
-use crate::eth_provider::error::EthApiError;
-use crate::eth_provider::provider::EthereumProvider;
-use crate::eth_rpc::api::eth_api::EthApiServer;
 
 /// The RPC module for the Ethereum protocol required by Kakarot.
 pub struct KakarotEthRpc<P>

--- a/src/eth_rpc/servers/net_rpc.rs
+++ b/src/eth_rpc/servers/net_rpc.rs
@@ -1,9 +1,7 @@
-use crate::eth_provider::provider::EthereumProvider;
+use crate::{eth_provider::provider::EthereumProvider, eth_rpc::api::net_api::NetApiServer};
 use jsonrpsee::core::{async_trait, RpcResult as Result};
 use reth_primitives::U64;
 use reth_rpc_types::PeerCount;
-
-use crate::eth_rpc::api::net_api::NetApiServer;
 
 /// The RPC module for the implementing Net api
 pub struct NetRpc<P: EthereumProvider> {

--- a/src/eth_rpc/servers/web3_rpc.rs
+++ b/src/eth_rpc/servers/web3_rpc.rs
@@ -1,7 +1,6 @@
+use crate::eth_rpc::api::web3_api::Web3ApiServer;
 use jsonrpsee::core::{async_trait, RpcResult as Result};
 use reth_primitives::{keccak256, Bytes, B256};
-
-use crate::eth_rpc::api::web3_api::Web3ApiServer;
 
 /// The RPC module for the implementing Web3 Api { i.e rpc endpoints prefixed with web3_ }
 #[derive(Default)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,17 +1,14 @@
-use std::env::var;
-use std::sync::Arc;
+use std::{env::var, sync::Arc};
 
 use dotenv::dotenv;
 use eyre::Result;
-use kakarot_rpc::config::{JsonRpcClientBuilder, KakarotRpcConfig, Network, SequencerGatewayProviderBuilder};
-use kakarot_rpc::eth_provider::database::Database;
-use kakarot_rpc::eth_provider::provider::EthDataProvider;
-use kakarot_rpc::eth_rpc::config::RPCConfig;
-use kakarot_rpc::eth_rpc::rpc::KakarotRpcModuleBuilder;
-use kakarot_rpc::eth_rpc::run_server;
+use kakarot_rpc::{
+    config::{JsonRpcClientBuilder, KakarotRpcConfig, Network, SequencerGatewayProviderBuilder},
+    eth_provider::{database::Database, provider::EthDataProvider},
+    eth_rpc::{config::RPCConfig, rpc::KakarotRpcModuleBuilder, run_server},
+};
 use mongodb::options::{DatabaseOptions, ReadConcern, WriteConcern};
-use starknet::providers::jsonrpc::HttpTransport;
-use starknet::providers::{JsonRpcClient, SequencerGatewayProvider};
+use starknet::providers::{jsonrpc::HttpTransport, JsonRpcClient, SequencerGatewayProvider};
 use tracing_subscriber::util::SubscriberInitExt;
 
 enum StarknetProvider {
@@ -54,8 +51,7 @@ async fn main() -> Result<()> {
     #[cfg(feature = "hive")]
     {
         use kakarot_rpc::eth_provider::constant::{CHAIN_ID, DEPLOY_WALLET, DEPLOY_WALLET_NONCE};
-        use starknet::accounts::ConnectedAccount;
-        use starknet::providers::Provider;
+        use starknet::{accounts::ConnectedAccount, providers::Provider};
         let provider = JsonRpcClient::new(HttpTransport::new(
             starknet_config.network.provider_url().expect("Incorrect provider URL"),
         ));

--- a/src/models/balance.rs
+++ b/src/models/balance.rs
@@ -1,11 +1,8 @@
-use std::pin::Pin;
-use std::task::Poll;
-
+use crate::eth_provider::error::EthApiError;
 use futures::{Future, FutureExt};
 use reth_primitives::{Address, U256};
 use serde::{Deserialize, Serialize};
-
-use crate::eth_provider::error::EthApiError;
+use std::{pin::Pin, task::Poll};
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct TokenBalance {

--- a/src/models/block.rs
+++ b/src/models/block.rs
@@ -1,8 +1,7 @@
-use reth_primitives::{BlockId as EthereumBlockId, BlockNumberOrTag, TransactionSigned, Withdrawals};
-use starknet::core::types::{BlockId as StarknetBlockId, BlockTag};
-
 use super::{transaction::rpc_transaction_to_primitive, ConversionError};
 use crate::{eth_provider::error::KakarotError, into_via_try_wrapper};
+use reth_primitives::{BlockId as EthereumBlockId, BlockNumberOrTag, TransactionSigned, Withdrawals};
+use starknet::core::types::{BlockId as StarknetBlockId, BlockTag};
 
 pub struct EthBlockId(EthereumBlockId);
 

--- a/src/models/felt.rs
+++ b/src/models/felt.rs
@@ -1,8 +1,7 @@
+use super::ConversionError;
 use reth_primitives::{Address, B256, U256, U64};
 use starknet::core::types::{EthAddress, FieldElement};
 use std::ops::{Deref, DerefMut};
-
-use super::ConversionError;
 
 #[derive(Clone, Debug)]
 pub struct Felt252Wrapper(FieldElement);

--- a/src/models/transaction.rs
+++ b/src/models/transaction.rs
@@ -1,7 +1,6 @@
-use reth_primitives::{AccessList, AccessListItem, TransactionKind, TxEip1559, TxEip2930, TxLegacy, TxType};
-
 use super::ConversionError;
 use crate::eth_provider::error::KakarotError;
+use reth_primitives::{AccessList, AccessListItem, TransactionKind, TxEip1559, TxEip2930, TxLegacy, TxType};
 
 pub fn rpc_transaction_to_primitive(
     rpc_transaction: reth_rpc_types::Transaction,

--- a/src/test_utils/eoa.rs
+++ b/src/test_utils/eoa.rs
@@ -1,22 +1,33 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use ethers::abi::Tokenize;
-use ethers::signers::{LocalWallet, Signer};
+use ethers::{
+    abi::Tokenize,
+    signers::{LocalWallet, Signer},
+};
 use reth_primitives::{
     sign_message, Address, Bytes, Transaction, TransactionKind, TransactionSigned, TxEip1559, B256, U256,
 };
-use starknet::core::types::{MaybePendingTransactionReceipt, TransactionReceipt};
-use starknet::core::utils::get_selector_from_name;
-use starknet::providers::Provider;
+use starknet::{
+    core::{
+        types::{MaybePendingTransactionReceipt, TransactionReceipt},
+        utils::get_selector_from_name,
+    },
+    providers::Provider,
+};
 use starknet_crypto::FieldElement;
 
-use crate::eth_provider::provider::{EthDataProvider, EthereumProvider};
-use crate::eth_provider::starknet::kakarot_core::starknet_address;
-use crate::models::felt::Felt252Wrapper;
-use crate::test_utils::evm_contract::EvmContract;
-use crate::test_utils::evm_contract::KakarotEvmContract;
-use crate::test_utils::tx_waiter::watch_tx;
+use crate::{
+    eth_provider::{
+        provider::{EthDataProvider, EthereumProvider},
+        starknet::kakarot_core::starknet_address,
+    },
+    models::felt::Felt252Wrapper,
+    test_utils::{
+        evm_contract::{EvmContract, KakarotEvmContract},
+        tx_waiter::watch_tx,
+    },
+};
 
 pub const TX_GAS_LIMIT: u64 = 5_000_000;
 

--- a/src/test_utils/evm_contract.rs
+++ b/src/test_utils/evm_contract.rs
@@ -1,5 +1,4 @@
-use std::fs;
-use std::path::Path;
+use std::{fs, path::Path};
 
 use ethers::abi::Tokenize;
 use ethers_solc::artifacts::CompactContractBytecode;
@@ -7,8 +6,7 @@ use foundry_config::{find_project_root_path, load_config};
 use reth_primitives::{Transaction, TransactionKind, TxEip1559, U256};
 use starknet_crypto::FieldElement;
 
-use crate::models::felt::Felt252Wrapper;
-use crate::root_project_path;
+use crate::{models::felt::Felt252Wrapper, root_project_path};
 
 use super::eoa::TX_GAS_LIMIT;
 

--- a/src/test_utils/katana/genesis.rs
+++ b/src/test_utils/katana/genesis.rs
@@ -1,24 +1,22 @@
-use std::collections::HashMap;
-use std::fs;
-use std::marker::PhantomData;
-use std::path::PathBuf;
+use std::{collections::HashMap, fs, marker::PhantomData, path::PathBuf};
 
-use cairo_lang_starknet::casm_contract_class::CasmContractClass;
-use cairo_lang_starknet::contract_class::ContractClass;
-use ethers::signers::LocalWallet;
-use ethers::signers::Signer;
-use ethers::types::U256;
+use cairo_lang_starknet::{casm_contract_class::CasmContractClass, contract_class::ContractClass};
+use ethers::{
+    signers::{LocalWallet, Signer},
+    types::U256,
+};
 use eyre::{eyre, Result};
-use katana_primitives::block::GasPrices;
-use katana_primitives::contract::{StorageKey, StorageValue};
-use katana_primitives::genesis::allocation::DevAllocationsGenerator;
-use katana_primitives::genesis::constant::DEFAULT_FEE_TOKEN_ADDRESS;
-use katana_primitives::genesis::constant::DEFAULT_PREFUNDED_ACCOUNT_BALANCE;
-use katana_primitives::genesis::json::GenesisAccountJson;
-use katana_primitives::genesis::json::{FeeTokenConfigJson, GenesisJson};
 use katana_primitives::{
-    contract::ContractAddress,
-    genesis::json::{GenesisClassJson, GenesisContractJson, PathOrFullArtifact},
+    block::GasPrices,
+    contract::{ContractAddress, StorageKey, StorageValue},
+    genesis::{
+        allocation::DevAllocationsGenerator,
+        constant::{DEFAULT_FEE_TOKEN_ADDRESS, DEFAULT_PREFUNDED_ACCOUNT_BALANCE},
+        json::{
+            FeeTokenConfigJson, GenesisAccountJson, GenesisClassJson, GenesisContractJson, GenesisJson,
+            PathOrFullArtifact,
+        },
+    },
 };
 use lazy_static::lazy_static;
 use rayon::prelude::*;
@@ -26,10 +24,11 @@ use reth_primitives::B256;
 use serde::Serialize;
 use serde_json::Value;
 use serde_with::serde_as;
-use starknet::core::serde::unsigned_field_element::UfeHex;
-use starknet::core::types::contract::legacy::LegacyContractClass;
-use starknet::core::types::FieldElement;
-use starknet::core::utils::{get_contract_address, get_storage_var_address, get_udc_deployed_address, UdcUniqueness};
+use starknet::core::{
+    serde::unsigned_field_element::UfeHex,
+    types::{contract::legacy::LegacyContractClass, FieldElement},
+    utils::{get_contract_address, get_storage_var_address, get_udc_deployed_address, UdcUniqueness},
+};
 use walkdir::WalkDir;
 
 lazy_static! {

--- a/src/test_utils/katana/mod.rs
+++ b/src/test_utils/katana/mod.rs
@@ -1,20 +1,17 @@
 pub mod genesis;
 
-use std::path::Path;
-use std::str::FromStr as _;
-use std::sync::Arc;
+use std::{path::Path, str::FromStr as _, sync::Arc};
 
 use dojo_test_utils::sequencer::{Environment, SequencerConfig, StarknetConfig, TestSequencer};
-use katana_primitives::block::GasPrices;
-use katana_primitives::chain::ChainId;
-use katana_primitives::genesis::json::GenesisJson;
-use katana_primitives::genesis::Genesis;
+use katana_primitives::{
+    block::GasPrices,
+    chain::ChainId,
+    genesis::{json::GenesisJson, Genesis},
+};
 use reth_primitives::B256;
-use starknet::providers::jsonrpc::HttpTransport;
-use starknet::providers::JsonRpcClient;
+use starknet::providers::{jsonrpc::HttpTransport, JsonRpcClient};
 
-use crate::eth_provider::provider::EthDataProvider;
-use crate::test_utils::eoa::KakarotEOA;
+use crate::{eth_provider::provider::EthDataProvider, test_utils::eoa::KakarotEOA};
 
 use super::mongo::mock_database;
 

--- a/src/test_utils/rpc/mod.rs
+++ b/src/test_utils/rpc/mod.rs
@@ -3,9 +3,7 @@ use std::net::SocketAddr;
 use jsonrpsee::server::ServerHandle;
 
 use super::katana::Katana;
-use crate::eth_rpc::config::RPCConfig;
-use crate::eth_rpc::rpc::KakarotRpcModuleBuilder;
-use crate::eth_rpc::run_server;
+use crate::eth_rpc::{config::RPCConfig, rpc::KakarotRpcModuleBuilder, run_server};
 use lazy_static::lazy_static;
 use tokio::sync::Mutex;
 

--- a/tests/alchemy.rs
+++ b/tests/alchemy.rs
@@ -1,12 +1,18 @@
 #![cfg(feature = "testing")]
-use ethers::abi::Token;
-use ethers::core::types::{Address as EthersAddress, U256 as EthersU256};
-use kakarot_rpc::models::{balance::TokenBalances, felt::Felt252Wrapper};
-use kakarot_rpc::test_utils::eoa::Eoa as _;
-use kakarot_rpc::test_utils::evm_contract::KakarotEvmContract;
-use kakarot_rpc::test_utils::fixtures::{erc20, setup};
-use kakarot_rpc::test_utils::katana::Katana;
-use kakarot_rpc::test_utils::rpc::start_kakarot_rpc_server;
+use ethers::{
+    abi::Token,
+    core::types::{Address as EthersAddress, U256 as EthersU256},
+};
+use kakarot_rpc::{
+    models::{balance::TokenBalances, felt::Felt252Wrapper},
+    test_utils::{
+        eoa::Eoa as _,
+        evm_contract::KakarotEvmContract,
+        fixtures::{erc20, setup},
+        katana::Katana,
+        rpc::start_kakarot_rpc_server,
+    },
+};
 use reth_primitives::{Address, U256};
 use rstest::*;
 use serde_json::{json, Value};

--- a/tests/debug_api.rs
+++ b/tests/debug_api.rs
@@ -1,11 +1,15 @@
 #![cfg(feature = "testing")]
 use alloy_rlp::{Decodable, Encodable};
-use kakarot_rpc::eth_provider::provider::EthereumProvider;
-use kakarot_rpc::models::block::rpc_to_primitive_block;
-use kakarot_rpc::test_utils::fixtures::{katana, setup};
-use kakarot_rpc::test_utils::katana::Katana;
-use kakarot_rpc::test_utils::mongo::{BLOCK_HASH, BLOCK_NUMBER, EIP1599_TX_HASH, EIP2930_TX_HASH, LEGACY_TX_HASH};
-use kakarot_rpc::test_utils::rpc::start_kakarot_rpc_server;
+use kakarot_rpc::{
+    eth_provider::provider::EthereumProvider,
+    models::block::rpc_to_primitive_block,
+    test_utils::{
+        fixtures::{katana, setup},
+        katana::Katana,
+        mongo::{BLOCK_HASH, BLOCK_NUMBER, EIP1599_TX_HASH, EIP2930_TX_HASH, LEGACY_TX_HASH},
+        rpc::start_kakarot_rpc_server,
+    },
+};
 use reth_primitives::{
     BlockNumberOrTag, Bytes, Log, Receipt, ReceiptWithBloom, TransactionSigned, TransactionSignedEcRecovered, U256,
 };

--- a/tests/eth_provider.rs
+++ b/tests/eth_provider.rs
@@ -1,21 +1,24 @@
 #![cfg(feature = "testing")]
-use std::cmp::min;
-use std::str::FromStr;
-
-use kakarot_rpc::eth_provider::provider::EthereumProvider;
-use kakarot_rpc::models::felt::Felt252Wrapper;
-use kakarot_rpc::test_utils::eoa::Eoa as _;
-use kakarot_rpc::test_utils::evm_contract::EvmContract;
-use kakarot_rpc::test_utils::fixtures::{counter, katana, setup};
-use kakarot_rpc::test_utils::mongo::{BLOCK_HASH, BLOCK_NUMBER};
-use kakarot_rpc::test_utils::{evm_contract::KakarotEvmContract, katana::Katana};
-use reth_primitives::serde_helper::{JsonStorageKey, U64HexOrNumber};
-use reth_primitives::{Address, BlockNumberOrTag, Bytes, B256, U256, U64};
-use reth_rpc_types::request::TransactionInput;
-use reth_rpc_types::{RpcBlockHash, TransactionRequest};
+use kakarot_rpc::{
+    eth_provider::provider::EthereumProvider,
+    models::felt::Felt252Wrapper,
+    test_utils::{
+        eoa::Eoa as _,
+        evm_contract::{EvmContract, KakarotEvmContract},
+        fixtures::{counter, katana, setup},
+        katana::Katana,
+        mongo::{BLOCK_HASH, BLOCK_NUMBER},
+    },
+};
+use reth_primitives::{
+    serde_helper::{JsonStorageKey, U64HexOrNumber},
+    Address, BlockNumberOrTag, Bytes, B256, U256, U64,
+};
+use reth_rpc_types::{request::TransactionInput, RpcBlockHash, TransactionRequest};
 use rstest::*;
 use starknet::core::types::BlockTag;
 use starknet_crypto::FieldElement;
+use std::{cmp::min, str::FromStr};
 
 #[rstest]
 #[awt]
@@ -284,8 +287,7 @@ async fn test_fee_history(#[future] katana: Katana, _setup: ()) {
 #[cfg(feature = "hive")]
 async fn test_predeploy_eoa(#[future] katana: Katana, _setup: ()) {
     use futures::future::join_all;
-    use kakarot_rpc::eth_provider::constant::CHAIN_ID;
-    use kakarot_rpc::test_utils::eoa::KakarotEOA;
+    use kakarot_rpc::{eth_provider::constant::CHAIN_ID, test_utils::eoa::KakarotEOA};
     use reth_primitives::B256;
     use starknet::providers::Provider;
 


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

Time spent on this PR: 30 min

# Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [X] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Testing

# What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

Rust nightly is activated for  fmt in order to have access to import granularity at a crate level. The check is also added to the CI. 

`CONTRIBUTING.md` file is updated to give instructions to users in order to activate nightly fmt in their VSCode environment.

# Does this introduce a breaking change?

- [ ] Yes
- [X] No
