### PR TITLE
Differenciate pending block in `tag_into_block_number`

### DIFF
--- a/docker/hive/Dockerfile
+++ b/docker/hive/Dockerfile
@@ -46,7 +46,7 @@ RUN case $BUILDPLATFORM in \
 #### First, clone the indexer repository
 FROM docker.io/alpine/git:latest as indexer-cloner
 WORKDIR /code
-RUN git clone -b feat/handle-pending-block "https://github.com/kkrt-labs/kakarot-indexer.git"
+RUN git clone "https://github.com/kkrt-labs/kakarot-indexer.git"
 
 #### MongoDB
 FROM mongo:6.0.8 as mongo

--- a/docker/hive/Dockerfile
+++ b/docker/hive/Dockerfile
@@ -46,7 +46,7 @@ RUN case $BUILDPLATFORM in \
 #### First, clone the indexer repository
 FROM docker.io/alpine/git:latest as indexer-cloner
 WORKDIR /code
-RUN git clone "https://github.com/kkrt-labs/kakarot-indexer.git"
+RUN git clone -b feat/handle-pending-block "https://github.com/kkrt-labs/kakarot-indexer.git"
 
 #### MongoDB
 FROM mongo:6.0.8 as mongo

--- a/src/eth_provider/provider.rs
+++ b/src/eth_provider/provider.rs
@@ -765,25 +765,12 @@ where
             BlockNumberOrTag::Earliest => Ok(U64::ZERO),
             // Converts the tag containing a specific block number into a `U64`.
             BlockNumberOrTag::Number(number) => Ok(U64::from(number)),
-            // Deducts 1 from the current block number to represent the latest, finalized, or safe block.
+            // Returns `self.block_number()` which is the block number of the latest finalized block.
             BlockNumberOrTag::Latest | BlockNumberOrTag::Finalized | BlockNumberOrTag::Safe => {
-                let block_number = self.block_number().await?;
-                Ok(match self.block(BlockHashOrNumber::Number(block_number.to::<u64>()), false).await? {
-                    Some(block) => {
-                        // If the block hash is null then we have a pending block
-                        // We must subtract one
-                        if block.header.hash.unwrap_or_default().is_zero() {
-                            block_number.saturating_sub(U64::from(1))
-                        } else {
-                            block_number
-                        }
-                    }
-                    // If block is not recognized, then subtract one
-                    None => block_number.saturating_sub(U64::from(1)),
-                })
+                self.block_number().await
             }
-            // Retrieves the block number representing the latest pending block.
-            BlockNumberOrTag::Pending => self.block_number().await,
+            // Adds 1 to the block number of the latest finalized block.
+            BlockNumberOrTag::Pending => Ok(self.block_number().await?.saturating_add(U64::from(1))),
         }
     }
 }

--- a/src/eth_provider/provider.rs
+++ b/src/eth_provider/provider.rs
@@ -159,7 +159,9 @@ where
                     .try_into()
                     .inspect_err(|err| tracing::error!("internal error: {:?}", err))
                     .map_err(|_| EthApiError::UnknownBlockNumber)?;
-                U64::from(number)
+
+                let is_pending_block = header.header.hash.unwrap_or_default().is_zero();
+                U64::from(if is_pending_block { number - 1 } else { number })
             }
         };
         Ok(block_number)

--- a/src/eth_provider/provider.rs
+++ b/src/eth_provider/provider.rs
@@ -766,7 +766,7 @@ where
             // Deducts 1 from the current block number to represent the latest, finalized, or safe block.
             // There is a pending block after
             BlockNumberOrTag::Latest | BlockNumberOrTag::Finalized | BlockNumberOrTag::Safe => {
-                Ok(self.block_number().await? - U64::from(1))
+                Ok(self.block_number().await?.saturating_sub(U64::from(1)))
             }
             // Retrieves the block number representing the latest pending block.
             BlockNumberOrTag::Pending => self.block_number().await,

--- a/src/eth_provider/provider.rs
+++ b/src/eth_provider/provider.rs
@@ -756,15 +756,20 @@ where
         }
     }
 
-    /// Convert the given BlockNumberOrTag into a block number
+    /// Converts the given `BlockNumberOrTag` into a block number.
     async fn tag_into_block_number(&self, tag: BlockNumberOrTag) -> EthProviderResult<U64> {
         match tag {
+            // Converts the tag representing the earliest block into block number 0.
             BlockNumberOrTag::Earliest => Ok(U64::ZERO),
+            // Converts the tag containing a specific block number into a `U64`.
             BlockNumberOrTag::Number(number) => Ok(U64::from(number)),
-            BlockNumberOrTag::Latest
-            | BlockNumberOrTag::Finalized
-            | BlockNumberOrTag::Safe
-            | BlockNumberOrTag::Pending => self.block_number().await,
+            // Deducts 1 from the current block number to represent the latest, finalized, or safe block.
+            // There is a pending block after
+            BlockNumberOrTag::Latest | BlockNumberOrTag::Finalized | BlockNumberOrTag::Safe => {
+                Ok(self.block_number().await? - U64::from(1))
+            }
+            // Retrieves the block number representing the latest pending block.
+            BlockNumberOrTag::Pending => self.block_number().await,
         }
     }
 }

--- a/src/eth_provider/provider.rs
+++ b/src/eth_provider/provider.rs
@@ -756,7 +756,7 @@ where
         }
     }
 
-    /// Converts the given `BlockNumberOrTag` into a block number.
+    /// Converts the given [`BlockNumberOrTag`] into a block number.
     async fn tag_into_block_number(&self, tag: BlockNumberOrTag) -> EthProviderResult<U64> {
         match tag {
             // Converts the tag representing the earliest block into block number 0.


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

Time spent on this PR: 10 min

# Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Testing

# What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

With the recent update, the behavior of distinguishing the pending block from `Latest`, `Finalized`, or `Safe` has been introduced. In this scenario, when the tag is `Pending`, it represents the last indexed block. To obtain the block numbers for `Latest`, `Finalized`, or `Safe`, the result of the provider's `block_number` is decremented by one.

# Does this introduce a breaking change?

- [ ] Yes
- [X] No
