### PR TITLE
Add fuzzer values to test suite

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,7 +81,7 @@ tracing = { version = "0.1.37", default-features = false }
 tracing-subscriber = { version = "0.3.3", features = ["env-filter"] }
 url = { version = "2.3.1", default-features = false }
 walkdir = { version = "2.3.3", default-features = false }
-rand = { version = "0.8.5", default-features = false }
+rand = { version = "0.8.5", default-features = false, optional = true }
 
 # Prometheus
 governor = { version = "0.6.0", default-features = false, features = ["std"] }
@@ -124,8 +124,10 @@ testing = [
   "ef-testing",
   "tokio-util",
   "tokio-stream",
+  "rand",
 ]
 hive = []
+arbitrary = ["rand"]
 
 [[bin]]
 name = "katana_genesis"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,6 +81,7 @@ tracing = { version = "0.1.37", default-features = false }
 tracing-subscriber = { version = "0.3.3", features = ["env-filter"] }
 url = { version = "2.3.1", default-features = false }
 walkdir = { version = "2.3.3", default-features = false }
+rand = { version = "0.8.5", default-features = false }
 
 # Prometheus
 governor = { version = "0.6.0", default-features = false, features = ["std"] }
@@ -115,7 +116,6 @@ starknet_api = { git = "https://github.com/starkware-libs/starknet-api.git", tag
 [dev-dependencies]
 rstest = { version = "0.18.1", default-features = false }
 toml = { version = "0.7.5", default-features = false }
-rand = { version = "0.8.5", default-features = false }
 
 [features]
 testing = [

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -121,7 +121,7 @@ services:
     command:
       - -c
       # clone the repository in `/code`, removing any old copy.
-      - cd /code && rm -rf kakarot-indexer && git clone -b fix/block-number-padding -v https://github.com/kkrt-labs/kakarot-indexer.git
+      - cd /code && rm -rf kakarot-indexer && git clone -v https://github.com/kkrt-labs/kakarot-indexer.git
     volumes:
       - indexer_code:/code
     restart: on-failure

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -121,7 +121,7 @@ services:
     command:
       - -c
       # clone the repository in `/code`, removing any old copy.
-      - cd /code && rm -rf kakarot-indexer && git clone -v https://github.com/kkrt-labs/kakarot-indexer.git
+      - cd /code && rm -rf kakarot-indexer && git clone -b fix/block-number-padding -v https://github.com/kkrt-labs/kakarot-indexer.git
     volumes:
       - indexer_code:/code
     restart: on-failure

--- a/docker/hive/Dockerfile
+++ b/docker/hive/Dockerfile
@@ -46,7 +46,7 @@ RUN case $BUILDPLATFORM in \
 #### First, clone the indexer repository
 FROM docker.io/alpine/git:latest as indexer-cloner
 WORKDIR /code
-RUN git clone "https://github.com/kkrt-labs/kakarot-indexer.git"
+RUN git clone -b fix/block-number-padding "https://github.com/kkrt-labs/kakarot-indexer.git"
 
 #### MongoDB
 FROM mongo:6.0.8 as mongo
@@ -92,14 +92,14 @@ FROM chef AS planner
 COPY . .
 RUN cargo chef prepare --recipe-path recipe.json
 
-FROM chef AS builder 
+FROM chef AS builder
 COPY --from=planner /app/recipe.json recipe.json
 
 # Build application
 COPY . .
 # Install system dependencies
 RUN apt-get update && \
-    apt-get -y upgrade && \ 
+    apt-get -y upgrade && \
     apt-get install -y gcc-aarch64-linux-gnu libssl-dev clang libclang-dev
 
 # Set working directory
@@ -114,7 +114,7 @@ RUN cargo build \
     --features hive --release --target-dir /usr/src/rpc/target && \
     cargo build \
     --bin hive_genesis --release --features testing --target-dir /usr/src/rpc/target && \
-    cargo build \ 
+    cargo build \
     --bin hive_chain --release --features testing --target-dir /usr/src/rpc/target
 
 FROM debian:bookworm-slim as base

--- a/docker/hive/Dockerfile
+++ b/docker/hive/Dockerfile
@@ -46,7 +46,7 @@ RUN case $BUILDPLATFORM in \
 #### First, clone the indexer repository
 FROM docker.io/alpine/git:latest as indexer-cloner
 WORKDIR /code
-RUN git clone -b fix/block-number-padding "https://github.com/kkrt-labs/kakarot-indexer.git"
+RUN git clone "https://github.com/kkrt-labs/kakarot-indexer.git"
 
 #### MongoDB
 FROM mongo:6.0.8 as mongo

--- a/src/eth_provider/constant.rs
+++ b/src/eth_provider/constant.rs
@@ -5,6 +5,8 @@ lazy_static! {
 }
 
 pub const CALL_REQUEST_GAS_LIMIT: u64 = 5_000_000;
+pub const HASH_PADDING: usize = 64;
+pub const U64_PADDING: usize = 16;
 
 #[cfg(feature = "hive")]
 use {

--- a/src/eth_provider/database/types/header.rs
+++ b/src/eth_provider/database/types/header.rs
@@ -1,5 +1,5 @@
 #[cfg(any(test, feature = "arbitrary", feature = "testing"))]
-use reth_primitives::{SealedHeader, B64, U256, U64};
+use reth_primitives::{constants::EMPTY_ROOT_HASH, SealedHeader, B64, U256, U64};
 use reth_rpc_types::Header;
 use serde::{Deserialize, Serialize};
 
@@ -35,7 +35,7 @@ impl<'a> arbitrary::Arbitrary<'a> for StoredHeader {
                 mix_hash: Some(header.mix_hash),
                 nonce: Some(B64::from(header.nonce)),
                 base_fee_per_gas: header.base_fee_per_gas.map(U256::from),
-                withdrawals_root: header.withdrawals_root,
+                withdrawals_root: Some(EMPTY_ROOT_HASH),
                 blob_gas_used: header.blob_gas_used.map(U64::from),
                 excess_blob_gas: header.excess_blob_gas.map(U64::from),
                 parent_beacon_block_root: header.parent_beacon_block_root,

--- a/src/eth_provider/database/types/header.rs
+++ b/src/eth_provider/database/types/header.rs
@@ -1,10 +1,7 @@
+#[cfg(any(test, feature = "arbitrary", feature = "testing"))]
+use reth_primitives::{SealedHeader, B64, U256, U64};
 use reth_rpc_types::Header;
 use serde::{Deserialize, Serialize};
-#[cfg(any(test, feature = "arbitrary"))]
-use {
-    arbitrary::Arbitrary,
-    reth_primitives::{SealedHeader, B64, U256, U64},
-};
 
 /// A header as stored in the database
 #[derive(Debug, Serialize, Deserialize, Hash, Clone, PartialEq, Eq)]
@@ -13,7 +10,7 @@ pub struct StoredHeader {
     pub header: Header,
 }
 
-#[cfg(any(test, feature = "arbitrary"))]
+#[cfg(any(test, feature = "arbitrary", feature = "testing"))]
 impl<'a> arbitrary::Arbitrary<'a> for StoredHeader {
     fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
         let header = SealedHeader::arbitrary(u)?;
@@ -50,6 +47,7 @@ impl<'a> arbitrary::Arbitrary<'a> for StoredHeader {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use arbitrary::Arbitrary;
     use rand::Rng;
 
     #[test]

--- a/src/eth_provider/database/types/receipt.rs
+++ b/src/eth_provider/database/types/receipt.rs
@@ -55,7 +55,7 @@ impl<'a> arbitrary::Arbitrary<'a> for StoredTransactionReceipt {
                 logs_bloom: Bloom::arbitrary(u)?,
                 state_root: Some(B256::arbitrary(u)?),
                 status_code: Some(U64::from(receipt.success as u8)),
-                transaction_type: U8::from::<u8>(receipt.tx_type.into()),
+                transaction_type: U8::from::<u8>(Into::<u8>::into(receipt.tx_type) % 3),
                 other: Default::default(),
             },
         })

--- a/src/eth_provider/database/types/receipt.rs
+++ b/src/eth_provider/database/types/receipt.rs
@@ -1,10 +1,7 @@
+#[cfg(any(test, feature = "arbitrary", feature = "testing"))]
+use reth_primitives::{Address, Bloom, Receipt, B256, U128, U256, U64, U8};
 use reth_rpc_types::TransactionReceipt;
 use serde::{Deserialize, Serialize};
-#[cfg(any(test, feature = "arbitrary"))]
-use {
-    arbitrary::Arbitrary,
-    reth_primitives::{Address, Bloom, Receipt, B256, U128, U256, U64, U8},
-};
 
 /// A transaction receipt as stored in the database
 #[derive(Debug, Serialize, Deserialize, Eq, PartialEq, Clone)]
@@ -19,7 +16,7 @@ impl From<StoredTransactionReceipt> for TransactionReceipt {
     }
 }
 
-#[cfg(any(test, feature = "arbitrary"))]
+#[cfg(any(test, feature = "arbitrary", feature = "testing"))]
 impl<'a> arbitrary::Arbitrary<'a> for StoredTransactionReceipt {
     fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
         let receipt = Receipt::arbitrary(u)?;
@@ -68,6 +65,7 @@ impl<'a> arbitrary::Arbitrary<'a> for StoredTransactionReceipt {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use arbitrary::Arbitrary;
     use rand::Rng;
 
     #[test]

--- a/src/eth_provider/database/types/transaction.rs
+++ b/src/eth_provider/database/types/transaction.rs
@@ -1,11 +1,8 @@
 use reth_primitives::B256;
+#[cfg(any(test, feature = "arbitrary", feature = "testing"))]
+use reth_primitives::{Address, TransactionSigned, U128, U256, U64};
 use reth_rpc_types::Transaction;
 use serde::{Deserialize, Serialize};
-#[cfg(any(test, feature = "arbitrary"))]
-use {
-    arbitrary::Arbitrary,
-    reth_primitives::{Address, TransactionSigned, U128, U256, U64},
-};
 
 /// A full transaction as stored in the database
 #[derive(Debug, Serialize, Deserialize, Eq, PartialEq, Clone)]
@@ -20,7 +17,7 @@ impl From<StoredTransaction> for Transaction {
     }
 }
 
-#[cfg(any(test, feature = "arbitrary"))]
+#[cfg(any(test, feature = "arbitrary", feature = "testing"))]
 impl<'a> arbitrary::Arbitrary<'a> for StoredTransaction {
     fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
         let transaction = TransactionSigned::arbitrary(u)?;
@@ -30,13 +27,13 @@ impl<'a> arbitrary::Arbitrary<'a> for StoredTransaction {
                 hash: transaction.hash,
                 nonce: U64::from(transaction.nonce()),
                 block_hash: Some(B256::arbitrary(u)?),
-                block_number: Some(U256::arbitrary(u)?),
+                block_number: Some(U256::from(U64::arbitrary(u)?)),
                 transaction_index: Some(U256::from(U64::arbitrary(u)?)),
                 from: Address::arbitrary(u)?,
                 to: transaction.to(),
                 value: transaction.value(),
                 gas_price: Some(U128::arbitrary(u)?),
-                gas: U256::arbitrary(u)?,
+                gas: U256::from(U64::arbitrary(u)?),
                 max_fee_per_gas: Some(U128::from(transaction.max_fee_per_gas())),
                 max_priority_fee_per_gas: transaction.max_priority_fee_per_gas().map(U128::from),
                 max_fee_per_blob_gas: transaction.max_fee_per_blob_gas().map(U128::from),
@@ -91,6 +88,7 @@ impl From<StoredTransactionHash> for B256 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use arbitrary::Arbitrary;
     use rand::Rng;
 
     #[test]

--- a/src/eth_provider/database/types/transaction.rs
+++ b/src/eth_provider/database/types/transaction.rs
@@ -55,7 +55,7 @@ impl<'a> arbitrary::Arbitrary<'a> for StoredTransaction {
                         })
                         .collect()
                 }),
-                transaction_type: Some(U64::from::<u8>(transaction.tx_type().into())),
+                transaction_type: Some(U64::from::<u8>(Into::<u8>::into(transaction.tx_type()) % 3)),
                 other: Default::default(),
             },
         })

--- a/src/eth_provider/database/types/transaction.rs
+++ b/src/eth_provider/database/types/transaction.rs
@@ -35,7 +35,7 @@ impl<'a> arbitrary::Arbitrary<'a> for StoredTransaction {
                 gas_price: Some(U128::arbitrary(u)?),
                 gas: U256::from(U64::arbitrary(u)?),
                 max_fee_per_gas: Some(U128::from(transaction.max_fee_per_gas())),
-                max_priority_fee_per_gas: transaction.max_priority_fee_per_gas().map(U128::from),
+                max_priority_fee_per_gas: Some(U128::from(transaction.max_priority_fee_per_gas().unwrap_or_default())),
                 max_fee_per_blob_gas: transaction.max_fee_per_blob_gas().map(U128::from),
                 input: transaction.input().clone(),
                 signature: Some(reth_rpc_types::Signature {

--- a/src/eth_provider/provider.rs
+++ b/src/eth_provider/provider.rs
@@ -560,7 +560,12 @@ where
             BlockId::Hash(hash) => BlockHashOrNumber::Hash(hash.block_hash),
         };
 
+        println!("block_id après étape 2 {:?}", block_id);
+
         let block_exists = self.block_exists(block_id).await?;
+
+        println!("est ce que block existe {:?}", block_exists);
+
         if !block_exists {
             return Ok(None);
         }
@@ -675,6 +680,20 @@ where
             BlockHashOrNumber::Hash(hash) => into_filter("header.hash", hash, 64),
             BlockHashOrNumber::Number(number) => into_filter("header.number", number, 64),
         };
+
+        // ################################
+        // ################################
+        // ################################
+
+        println!("filter: {:?}", filter);
+
+        let toto = self.database.get_one::<StoredHeader>("headers", None, None).await?.unwrap();
+
+        println!("toto: {:?}", toto);
+        // ################################
+        // ################################
+        // ################################
+
         self.database
             .get_one("headers", filter, None)
             .await

--- a/src/eth_provider/provider.rs
+++ b/src/eth_provider/provider.rs
@@ -127,7 +127,7 @@ pub trait EthereumProvider {
 /// Uses an access to a database to certain data, while
 /// the rest is fetched from the Starknet Provider.
 pub struct EthDataProvider<SP: starknet::providers::Provider> {
-    pub database: Database,
+    database: Database,
     starknet_provider: SP,
     chain_id: u64,
 }
@@ -196,7 +196,9 @@ where
 
     async fn block_transaction_count_by_hash(&self, hash: B256) -> EthProviderResult<Option<U256>> {
         Ok(if self.block_exists(BlockHashOrNumber::Hash(hash)).await? {
-            Some(U256::from(self.database.count("transactions", into_filter("tx.blockHash", hash, HASH_PADDING)).await?))
+            Some(U256::from(
+                self.database.count("transactions", into_filter("tx.blockHash", hash, HASH_PADDING)).await?,
+            ))
         } else {
             None
         })
@@ -253,7 +255,11 @@ where
     async fn transaction_receipt(&self, hash: B256) -> EthProviderResult<Option<TransactionReceipt>> {
         Ok(self
             .database
-            .get_one::<StoredTransactionReceipt>("receipts", into_filter("receipt.transactionHash", hash, HASH_PADDING), None)
+            .get_one::<StoredTransactionReceipt>(
+                "receipts",
+                into_filter("receipt.transactionHash", hash, HASH_PADDING),
+                None,
+            )
             .await?
             .map(Into::into))
     }

--- a/src/eth_provider/provider.rs
+++ b/src/eth_provider/provider.rs
@@ -233,7 +233,7 @@ where
             return Ok(None);
         }
 
-        let filter = into_filter("tx.blockNumber", block_number, 64);
+        let filter = into_filter("tx.blockNumber", block_number, 16);
         let count = self.database.count("transactions", filter).await?;
         Ok(Some(U256::from(count)))
     }
@@ -263,7 +263,7 @@ where
         index: Index,
     ) -> EthProviderResult<Option<reth_rpc_types::Transaction>> {
         let block_number = self.tag_into_block_number(number_or_tag).await?;
-        let mut filter = into_filter("tx.blockNumber", block_number, 64);
+        let mut filter = into_filter("tx.blockNumber", block_number, 16);
         let index: usize = index.into();
 
         filter.insert("tx.transactionIndex", format_hex(index, 64));
@@ -531,7 +531,7 @@ where
                     return Ok(None);
                 }
 
-                let filter = into_filter("receipt.blockNumber", block_number, 64);
+                let filter = into_filter("receipt.blockNumber", block_number, 16);
                 let tx: Vec<StoredTransactionReceipt> = self.database.get("receipts", filter, None).await?;
                 Ok(Some(tx.into_iter().map(Into::into).collect()))
             }
@@ -678,21 +678,42 @@ where
     async fn header(&self, id: BlockHashOrNumber) -> EthProviderResult<Option<StoredHeader>> {
         let filter = match id {
             BlockHashOrNumber::Hash(hash) => into_filter("header.hash", hash, 64),
-            BlockHashOrNumber::Number(number) => into_filter("header.number", number, 64),
+            BlockHashOrNumber::Number(number) => into_filter("header.number", number, 16),
         };
 
-        // ################################
-        // ################################
-        // ################################
+        // // ################################
+        // // ################################
+        // // ################################
 
-        println!("filter: {:?}", filter);
+        // println!("filter: {:?}", filter.clone());
 
-        let toto = self.database.get_one::<StoredHeader>("headers", None, None).await?.unwrap();
+        // let toto = self.database.get_one::<StoredHeader>("headers", None, None).await?.unwrap();
 
-        println!("toto: {:?}", toto);
-        // ################################
-        // ################################
-        // ################################
+        // println!("toto: {:?}", toto);
+
+        // use futures::StreamExt;
+
+        // // Obtenez une poignée sur la collection
+        // let collection = self.database.inner().collection::<mongodb::bson::Document>("headers");
+
+        // // Récupérer tous les documents de la collection
+        // let mut cursor = collection.find(None, None).await.expect("toto");
+
+        // // Parcourir les résultats et les imprimer
+        // while let Some(result) = cursor.next().await {
+        //     match result {
+        //         Ok(document) => {
+        //             // Imprimer le document brut
+        //             println!("Document: {:?}", document);
+        //         }
+        //         Err(e) => {
+        //             eprintln!("Erreur lors de la récupération du document : {}", e);
+        //         }
+        //     }
+        // }
+        // // ################################
+        // // ################################
+        // // ################################
 
         self.database
             .get_one("headers", filter, None)
@@ -711,7 +732,7 @@ where
     ) -> EthProviderResult<BlockTransactions> {
         let transactions_filter = match block_id {
             BlockHashOrNumber::Hash(hash) => into_filter("tx.blockHash", hash, 64),
-            BlockHashOrNumber::Number(number) => into_filter("tx.blockNumber", number, 64),
+            BlockHashOrNumber::Number(number) => into_filter("tx.blockNumber", number, 16),
         };
 
         let block_transactions = if full {

--- a/src/eth_provider/provider.rs
+++ b/src/eth_provider/provider.rs
@@ -559,13 +559,7 @@ where
             }
             BlockId::Hash(hash) => BlockHashOrNumber::Hash(hash.block_hash),
         };
-
-        println!("block_id après étape 2 {:?}", block_id);
-
         let block_exists = self.block_exists(block_id).await?;
-
-        println!("est ce que block existe {:?}", block_exists);
-
         if !block_exists {
             return Ok(None);
         }
@@ -680,41 +674,6 @@ where
             BlockHashOrNumber::Hash(hash) => into_filter("header.hash", hash, 64),
             BlockHashOrNumber::Number(number) => into_filter("header.number", number, 16),
         };
-
-        // // ################################
-        // // ################################
-        // // ################################
-
-        // println!("filter: {:?}", filter.clone());
-
-        // let toto = self.database.get_one::<StoredHeader>("headers", None, None).await?.unwrap();
-
-        // println!("toto: {:?}", toto);
-
-        // use futures::StreamExt;
-
-        // // Obtenez une poignée sur la collection
-        // let collection = self.database.inner().collection::<mongodb::bson::Document>("headers");
-
-        // // Récupérer tous les documents de la collection
-        // let mut cursor = collection.find(None, None).await.expect("toto");
-
-        // // Parcourir les résultats et les imprimer
-        // while let Some(result) = cursor.next().await {
-        //     match result {
-        //         Ok(document) => {
-        //             // Imprimer le document brut
-        //             println!("Document: {:?}", document);
-        //         }
-        //         Err(e) => {
-        //             eprintln!("Erreur lors de la récupération du document : {}", e);
-        //         }
-        //     }
-        // }
-        // // ################################
-        // // ################################
-        // // ################################
-
         self.database
             .get_one("headers", filter, None)
             .await

--- a/src/eth_provider/utils.rs
+++ b/src/eth_provider/utils.rs
@@ -40,23 +40,6 @@ where
     doc! {key: format_hex(value, width)}
 }
 
-pub(crate) fn format_hex_without_pad(value: impl LowerHex) -> String {
-    let s = format!("{:x}", value);
-    if format!("{:x}", value).starts_with("0x") {
-        format!("0x{}", &s[2..].trim_start_matches('0'))
-    } else {
-        format!("0x{}", s.trim_start_matches('0'))
-    }
-}
-
-/// Converts a key and value into a MongoDB filter without padding.
-pub(crate) fn into_filter_without_pad<T>(key: &str, value: T) -> Document
-where
-    T: LowerHex,
-{
-    doc! {key: format_hex_without_pad(value)}
-}
-
 /// Splits a U256 value into two generic values implementing the From<u128> trait
 #[inline]
 pub fn split_u256<T: From<u128>>(value: impl Into<U256>) -> [T; 2] {
@@ -110,26 +93,6 @@ mod tests {
         assert_eq!(
             into_filter::<B256>("test_key", B256::default(), 64),
             doc! {"test_key": format!("0x{}", "0".repeat(64))}
-        );
-    }
-
-    #[test]
-    fn test_into_filter_without_padding() {
-        assert_eq!(into_filter_without_pad::<u64>("test_key", 0x1234), doc! {"test_key": "0x1234"});
-        assert_eq!(
-            into_filter_without_pad::<B256>(
-                "test_key",
-                B256::from_str("0xd4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3").unwrap(),
-            ),
-            doc! {"test_key": "0xd4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3"}
-        );
-        assert_eq!(into_filter_without_pad::<B256>("test_key", B256::default()), doc! {"test_key": "0x"});
-        assert_eq!(
-            into_filter_without_pad::<B256>(
-                "test_key",
-                B256::from_str("0x0000000000000000000000000000000000000000000000000000000000000002").unwrap()
-            ),
-            doc! {"test_key": "0x2"}
         );
     }
 }

--- a/src/eth_rpc/servers/debug_rpc.rs
+++ b/src/eth_rpc/servers/debug_rpc.rs
@@ -80,6 +80,8 @@ impl<P: EthereumProvider + Send + Sync + 'static> DebugApiServer for DebugRpc<P>
     async fn raw_transactions(&self, block_id: BlockId) -> Result<Vec<Bytes>> {
         let transactions = self.eth_provider.block_transactions(Some(block_id)).await?.unwrap_or_default();
 
+        // println!("transactions: {:?}", transactions);
+
         let mut raw_transactions = Vec::with_capacity(transactions.len());
 
         for t in transactions {
@@ -96,6 +98,8 @@ impl<P: EthereumProvider + Send + Sync + 'static> DebugApiServer for DebugRpc<P>
             .envelope_encoded();
             raw_transactions.push(bytes);
         }
+
+        // println!("transactions fin: {:?}", raw_transactions.clone());
 
         Ok(raw_transactions)
     }

--- a/src/eth_rpc/servers/debug_rpc.rs
+++ b/src/eth_rpc/servers/debug_rpc.rs
@@ -78,6 +78,8 @@ impl<P: EthereumProvider + Send + Sync + 'static> DebugApiServer for DebugRpc<P>
 
     /// Returns an array of EIP-2718 binary-encoded transactions for the given [BlockId].
     async fn raw_transactions(&self, block_id: BlockId) -> Result<Vec<Bytes>> {
+        println!("block_id debuuuuut {:?}", block_id);
+
         let transactions = self.eth_provider.block_transactions(Some(block_id)).await?.unwrap_or_default();
 
         // println!("transactions: {:?}", transactions);

--- a/src/eth_rpc/servers/debug_rpc.rs
+++ b/src/eth_rpc/servers/debug_rpc.rs
@@ -60,7 +60,9 @@ impl<P: EthereumProvider + Send + Sync + 'static> DebugApiServer for DebugRpc<P>
 
         if let Some(tx) = transaction {
             let signature = tx.signature.ok_or_else(|| EthApiError::from(SignatureError::MissingSignature))?;
+            println!("avaaaaaaant: {:?}", tx);
             let tx = rpc_transaction_to_primitive(tx).map_err(EthApiError::from)?;
+            println!("apreeeeees: {:?}", tx);
             let bytes = TransactionSigned::from_transaction_and_signature(
                 tx,
                 reth_primitives::Signature {
@@ -78,12 +80,7 @@ impl<P: EthereumProvider + Send + Sync + 'static> DebugApiServer for DebugRpc<P>
 
     /// Returns an array of EIP-2718 binary-encoded transactions for the given [BlockId].
     async fn raw_transactions(&self, block_id: BlockId) -> Result<Vec<Bytes>> {
-        println!("block_id debuuuuut {:?}", block_id);
-
         let transactions = self.eth_provider.block_transactions(Some(block_id)).await?.unwrap_or_default();
-
-        // println!("transactions: {:?}", transactions);
-
         let mut raw_transactions = Vec::with_capacity(transactions.len());
 
         for t in transactions {
@@ -100,8 +97,6 @@ impl<P: EthereumProvider + Send + Sync + 'static> DebugApiServer for DebugRpc<P>
             .envelope_encoded();
             raw_transactions.push(bytes);
         }
-
-        // println!("transactions fin: {:?}", raw_transactions.clone());
 
         Ok(raw_transactions)
     }

--- a/src/eth_rpc/servers/debug_rpc.rs
+++ b/src/eth_rpc/servers/debug_rpc.rs
@@ -60,9 +60,7 @@ impl<P: EthereumProvider + Send + Sync + 'static> DebugApiServer for DebugRpc<P>
 
         if let Some(tx) = transaction {
             let signature = tx.signature.ok_or_else(|| EthApiError::from(SignatureError::MissingSignature))?;
-            println!("avaaaaaaant: {:?}", tx);
             let tx = rpc_transaction_to_primitive(tx).map_err(EthApiError::from)?;
-            println!("apreeeeees: {:?}", tx);
             let bytes = TransactionSigned::from_transaction_and_signature(
                 tx,
                 reth_primitives::Signature {

--- a/src/models/block.rs
+++ b/src/models/block.rs
@@ -91,7 +91,8 @@ pub fn rpc_to_primitive_header(
         state_root: header.state_root,
         timestamp: header.timestamp.try_into().map_err(|_| EthereumDataFormatError::PrimitiveError)?,
         transactions_root: header.transactions_root,
-        withdrawals_root: header.withdrawals_root,
+        // Withdrawals are not allowed so we push a None value
+        withdrawals_root: Default::default(),
     })
 }
 

--- a/src/models/block.rs
+++ b/src/models/block.rs
@@ -223,10 +223,7 @@ mod tests {
         assert_eq!(primitive_block.header.state_root, B256::from_str(&format!("0x{:0>64}", "04")).unwrap());
         assert_eq!(primitive_block.header.transactions_root, B256::from_str(&format!("0x{:0>64}", "05")).unwrap());
         assert_eq!(primitive_block.header.receipts_root, B256::from_str(&format!("0x{:0>64}", "06")).unwrap());
-        assert_eq!(
-            primitive_block.header.withdrawals_root.unwrap(),
-            B256::from_str(&format!("0x{:0>64}", "07")).unwrap()
-        );
+        assert!(primitive_block.header.withdrawals_root.is_none());
         assert_eq!(primitive_block.header.logs_bloom, Bloom::ZERO);
         assert_eq!(primitive_block.header.difficulty, U256::ZERO);
         assert_eq!(primitive_block.header.base_fee_per_gas, Some(8));

--- a/src/test_utils/fixtures.rs
+++ b/src/test_utils/fixtures.rs
@@ -1,10 +1,9 @@
-use ethers::abi::Token;
 use rstest::*;
 use tracing_subscriber::{filter, FmtSubscriber};
+#[cfg(any(test, feature = "arbitrary", feature = "testing"))]
+use {super::katana::Katana, crate::test_utils::evm_contract::KakarotEvmContract, ethers::abi::Token, rand::Rng};
 
-use super::katana::Katana;
-use crate::test_utils::evm_contract::KakarotEvmContract;
-
+#[cfg(any(test, feature = "arbitrary", feature = "testing"))]
 #[fixture]
 #[awt]
 pub async fn counter(#[future] katana: Katana) -> (Katana, KakarotEvmContract) {
@@ -13,6 +12,7 @@ pub async fn counter(#[future] katana: Katana) -> (Katana, KakarotEvmContract) {
     (katana, contract)
 }
 
+#[cfg(any(test, feature = "arbitrary", feature = "testing"))]
 #[fixture]
 #[awt]
 pub async fn erc20(#[future] katana: Katana) -> (Katana, KakarotEvmContract) {
@@ -32,10 +32,14 @@ pub async fn erc20(#[future] katana: Katana) -> (Katana, KakarotEvmContract) {
 }
 
 /// This fixture creates a new test environment on Katana.
+#[cfg(any(test, feature = "arbitrary", feature = "testing"))]
 #[fixture]
 pub async fn katana() -> Katana {
+    let mut bytes = [0u8; 100024];
+    rand::thread_rng().fill(bytes.as_mut_slice());
+
     // Create a new test environment on Katana
-    Katana::new().await
+    Katana::new(&mut arbitrary::Unstructured::new(&bytes)).await
 }
 
 /// This fixture configures the tests. The following setup

--- a/src/test_utils/fixtures.rs
+++ b/src/test_utils/fixtures.rs
@@ -1,7 +1,10 @@
 use rstest::*;
 use tracing_subscriber::{filter, FmtSubscriber};
 #[cfg(any(test, feature = "arbitrary", feature = "testing"))]
-use {super::katana::Katana, crate::test_utils::evm_contract::KakarotEvmContract, ethers::abi::Token};
+use {
+    super::katana::Katana, super::mongo::RANDOM_BYTES_SIZE, crate::test_utils::evm_contract::KakarotEvmContract,
+    ethers::abi::Token,
+};
 
 #[cfg(any(test, feature = "arbitrary", feature = "testing"))]
 #[fixture]
@@ -36,7 +39,7 @@ pub async fn erc20(#[future] katana: Katana) -> (Katana, KakarotEvmContract) {
 #[fixture]
 pub async fn katana() -> Katana {
     // Create a new test environment on Katana
-    Katana::new(100024).await
+    Katana::new(RANDOM_BYTES_SIZE).await
 }
 
 /// This fixture configures the tests. The following setup

--- a/src/test_utils/fixtures.rs
+++ b/src/test_utils/fixtures.rs
@@ -1,7 +1,7 @@
 use rstest::*;
 use tracing_subscriber::{filter, FmtSubscriber};
 #[cfg(any(test, feature = "arbitrary", feature = "testing"))]
-use {super::katana::Katana, crate::test_utils::evm_contract::KakarotEvmContract, ethers::abi::Token, rand::Rng};
+use {super::katana::Katana, crate::test_utils::evm_contract::KakarotEvmContract, ethers::abi::Token};
 
 #[cfg(any(test, feature = "arbitrary", feature = "testing"))]
 #[fixture]
@@ -35,11 +35,8 @@ pub async fn erc20(#[future] katana: Katana) -> (Katana, KakarotEvmContract) {
 #[cfg(any(test, feature = "arbitrary", feature = "testing"))]
 #[fixture]
 pub async fn katana() -> Katana {
-    let mut bytes = [0u8; 100024];
-    rand::thread_rng().fill(bytes.as_mut_slice());
-
     // Create a new test environment on Katana
-    Katana::new(&mut arbitrary::Unstructured::new(&bytes)).await
+    Katana::new(100024).await
 }
 
 /// This fixture configures the tests. The following setup

--- a/src/test_utils/katana/mod.rs
+++ b/src/test_utils/katana/mod.rs
@@ -17,11 +17,12 @@ use std::collections::HashMap;
 
 #[cfg(any(test, feature = "arbitrary", feature = "testing"))]
 use {
-    super::mongo::{CollectionDB, MongoFuzzer, StoredData},
+    super::mongo::{CollectionDB, MongoFuzzer, StoredData, DOCKER_CLI},
     dojo_test_utils::sequencer::SequencerConfig,
     reth_primitives::{TxType, B256},
     reth_rpc_types::Transaction,
     std::str::FromStr as _,
+    testcontainers::{Container, GenericImage},
 };
 
 fn load_genesis() -> Genesis {
@@ -53,10 +54,19 @@ async fn katana_sequencer() -> TestSequencer {
     TestSequencer::start(SequencerConfig { no_mining: false, block_time: None, messaging: None }, katana_config()).await
 }
 
+/// Represents the Katana test environment.
 pub struct Katana {
+    /// The test sequencer instance for managing test execution.
     pub sequencer: TestSequencer,
+    /// The Kakarot EOA (Externally Owned Account) instance.
     pub eoa: KakarotEOA<Arc<JsonRpcClient<HttpTransport>>>,
+    /// Mock data stored in a HashMap, representing the database.
     pub mock_data: HashMap<CollectionDB, Vec<StoredData>>,
+    /// The port number used for communication.
+    pub port: u16,
+    /// Option to store the Docker container instance.
+    /// It holds `Some` when the container is running, and `None` otherwise.
+    pub container: Option<Container<'static, GenericImage>>,
 }
 
 impl<'a> Katana {
@@ -75,34 +85,50 @@ impl<'a> Katana {
         starknet_provider: Arc<JsonRpcClient<HttpTransport>>,
         rnd_bytes_size: usize,
     ) -> Self {
-        // Load PK
+        // Load the private key from the environment variables.
         dotenvy::dotenv().expect("Failed to load .env file");
         let pk = std::env::var("EVM_PRIVATE_KEY").expect("Failed to get EVM private key");
         let pk = B256::from_str(&pk).expect("Failed to parse EVM private key");
 
-        // Create a Kakarot client
+        // Initialize a MongoFuzzer instance with the specified random bytes size.
         let mut mongo_fuzzer = MongoFuzzer::new(rnd_bytes_size).await;
+        // Get the port number for communication.
+        let port = mongo_fuzzer.port();
+
+        // Run a Docker container with the MongoDB image.
+        let container = DOCKER_CLI.run(mongo_fuzzer.get_mongo_image());
+
+        // Add random transactions to the MongoDB database.
         mongo_fuzzer.add_random_transactions(10).expect("Failed to add documents in the database");
+        // Add a hardcoded block header range to the MongoDB database.
         mongo_fuzzer.add_hardcoded_block_header_range(0..4).expect("Failed to add block range in the database");
+        // Add a hardcoded Eip1559 transaction to the MongoDB database.
         mongo_fuzzer
             .add_hardcoded_transaction(Some(TxType::Eip1559))
             .expect("Failed to add Eip1559 transaction in the database");
+        // Add a hardcoded Eip2930 transaction to the MongoDB database.
         mongo_fuzzer
             .add_hardcoded_transaction(Some(TxType::Eip2930))
             .expect("Failed to add Eip2930 transaction in the database");
+        // Add a hardcoded Legacy transaction to the MongoDB database.
         mongo_fuzzer
             .add_hardcoded_transaction(Some(TxType::Legacy))
             .expect("Failed to add Legacy transaction in the database");
+        // Finalize the MongoDB database initialization and get the database instance.
         let database = mongo_fuzzer.finalize().await;
+        // Clone the mock data stored in the MongoFuzzer instance.
         let mock_data = (*mongo_fuzzer.documents()).clone();
 
+        // Create a new EthDataProvider instance with the initialized database and Starknet provider.
         let eth_provider = Arc::new(
             EthDataProvider::new(database, starknet_provider).await.expect("Failed to create EthDataProvider"),
         );
 
+        // Create a new Kakarot EOA instance with the private key and EthDataProvider instance.
         let eoa = KakarotEOA::new(pk, eth_provider);
 
-        Self { sequencer, eoa, mock_data }
+        // Return a new instance of Katana with initialized fields.
+        Self { sequencer, eoa, mock_data, port, container: Some(container) }
     }
 
     pub fn eth_provider(&self) -> Arc<EthDataProvider<Arc<JsonRpcClient<HttpTransport>>>> {

--- a/src/test_utils/katana/mod.rs
+++ b/src/test_utils/katana/mod.rs
@@ -81,8 +81,6 @@ impl<'a> Katana {
         let pk = B256::from_str(&pk).expect("Failed to parse EVM private key");
 
         // Create a Kakarot client
-        // let database = MongoFuzzer::mock_database(u, 10, 10).await;
-
         let mut mongo_fuzzer = MongoFuzzer::new(rnd_bytes_size).await;
         mongo_fuzzer.add_random_transactions(10).expect("Failed to add documents in the database");
         mongo_fuzzer

--- a/src/test_utils/katana/mod.rs
+++ b/src/test_utils/katana/mod.rs
@@ -96,7 +96,7 @@ impl<'a> Katana {
         let port = mongo_fuzzer.port();
 
         // Run a Docker container with the MongoDB image.
-        let container = DOCKER_CLI.run(mongo_fuzzer.get_mongo_image());
+        let container = DOCKER_CLI.run(mongo_fuzzer.mongo_image());
 
         // Add random transactions to the MongoDB database.
         mongo_fuzzer.add_random_transactions(10).expect("Failed to add documents in the database");
@@ -147,7 +147,7 @@ impl<'a> Katana {
     }
 
     /// Retrieves the first stored transaction
-    pub fn get_first_transaction(&self) -> Option<Transaction> {
+    pub fn first_transaction(&self) -> Option<Transaction> {
         self.mock_data
             .get(&CollectionDB::Transactions)
             .and_then(|transactions| transactions.first())
@@ -156,7 +156,7 @@ impl<'a> Katana {
     }
 
     /// Retrieves the most recent stored transaction based on block number
-    pub fn get_most_recent_transaction(&self) -> Option<Transaction> {
+    pub fn most_recent_transaction(&self) -> Option<Transaction> {
         self.mock_data
             .get(&CollectionDB::Transactions)
             .and_then(|transactions| {

--- a/src/test_utils/katana/mod.rs
+++ b/src/test_utils/katana/mod.rs
@@ -128,4 +128,22 @@ impl<'a> Katana {
             .and_then(|data| data.extract_stored_transaction())
             .map(|stored_tx| stored_tx.tx.clone())
     }
+
+    /// Retrieves the most recent stored transaction based on block number
+    pub fn get_most_recent_transaction(&self) -> Option<Transaction> {
+        self.mock_data
+            .get(&CollectionDB::Transactions)
+            .and_then(|transactions| {
+                transactions.iter().max_by_key(|data| {
+                    data.extract_stored_transaction().map(|stored_tx| stored_tx.tx.block_number).unwrap_or_default()
+                })
+            })
+            .and_then(|data| data.extract_stored_transaction())
+            .map(|stored_tx| stored_tx.tx.clone())
+    }
+
+    /// Retrieves the number of blocks in the database
+    pub fn count_block(&self) -> usize {
+        self.mock_data.get(&CollectionDB::Headers).map_or(0, |headers| headers.len())
+    }
 }

--- a/src/test_utils/katana/mod.rs
+++ b/src/test_utils/katana/mod.rs
@@ -83,6 +83,7 @@ impl<'a> Katana {
         // Create a Kakarot client
         let mut mongo_fuzzer = MongoFuzzer::new(rnd_bytes_size).await;
         mongo_fuzzer.add_random_transactions(10).expect("Failed to add documents in the database");
+        mongo_fuzzer.add_hardcoded_block_header_range(0..4).expect("Failed to add block range in the database");
         mongo_fuzzer
             .add_hardcoded_transaction(Some(TxType::Eip1559))
             .expect("Failed to add Eip1559 transaction in the database");

--- a/src/test_utils/mongo/mod.rs
+++ b/src/test_utils/mongo/mod.rs
@@ -55,6 +55,7 @@ lazy_static! {
 }
 
 pub const BLOCK_NUMBER: u64 = 0x1234;
+pub const RANDOM_BYTES_SIZE: usize = 100024;
 
 /// Enumeration of collections in the database.
 #[derive(Eq, Hash, PartialEq, Clone)]
@@ -181,7 +182,7 @@ impl MongoFuzzer {
 
     /// Adds a hardcoded transaction to the collection of transactions.
     pub fn add_hardcoded_transaction(&mut self, tx_type: Option<TxType>) -> Result<(), Box<dyn std::error::Error>> {
-        let builder = TransactionBuilder::default().tx_type(tx_type.unwrap_or_default());
+        let builder = TransactionBuilder::default().with_tx_type(tx_type.unwrap_or_default());
         self.add_custom_transaction(builder)
     }
 
@@ -283,7 +284,7 @@ pub struct TransactionBuilder {
 
 impl TransactionBuilder {
     /// Specifies the type of transaction to build.
-    pub fn tx_type(mut self, tx_type: TxType) -> Self {
+    pub fn with_tx_type(mut self, tx_type: TxType) -> Self {
         self.tx_type = Some(tx_type);
         self
     }
@@ -380,8 +381,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_mongo_fuzzer() {
-        // Mocks a database with 100 headers and 100 transactions.
-        let database = MongoFuzzer::mock_database(100024, 100).await;
+        // Mocks a database with 100 transactions, receipts and headers.
+        let database = MongoFuzzer::mock_database(RANDOM_BYTES_SIZE, 100).await;
 
         // Retrieves stored headers from the database.
         let _ = database.get::<StoredHeader>("headers", None, None).await.unwrap();

--- a/src/test_utils/mongo/mod.rs
+++ b/src/test_utils/mongo/mod.rs
@@ -162,7 +162,7 @@ impl MongoFuzzer {
     }
 
     /// Get MongoDB image
-    pub fn get_mongo_image(&self) -> RunnableImage<GenericImage> {
+    pub fn mongo_image(&self) -> RunnableImage<GenericImage> {
         let image = GenericImage::new("mongo".to_string(), "6.0.13".to_string());
         RunnableImage::from(image).with_mapped_port((self.port, 27017))
     }
@@ -427,7 +427,7 @@ mod tests {
         let mut mongo_fuzzer = MongoFuzzer::new(RANDOM_BYTES_SIZE).await;
 
         // Run docker
-        let _c = DOCKER_CLI.run(mongo_fuzzer.get_mongo_image());
+        let _c = DOCKER_CLI.run(mongo_fuzzer.mongo_image());
 
         // Mocks a database with 100 transactions, receipts and headers.
         let database = mongo_fuzzer.mock_database(100).await;

--- a/src/test_utils/mongo/mod.rs
+++ b/src/test_utils/mongo/mod.rs
@@ -181,13 +181,13 @@ impl MongoFuzzer {
 
     /// Adds a hardcoded transaction to the collection of transactions.
     pub fn add_hardcoded_transaction(&mut self, tx_type: Option<TxType>) -> Result<(), Box<dyn std::error::Error>> {
-        let builder = TransactionBuilder::new().tx_type(tx_type.unwrap_or_default());
+        let builder = TransactionBuilder::default().tx_type(tx_type.unwrap_or_default());
         self.add_custom_transaction(builder)
     }
 
     /// Adds a hardcoded transaction to the collection of transactions.
     pub fn add_random_transaction(&mut self) -> Result<(), Box<dyn std::error::Error>> {
-        let builder = TransactionBuilder::new();
+        let builder = TransactionBuilder::default();
         self.add_custom_transaction(builder)
     }
 
@@ -275,17 +275,13 @@ impl MongoFuzzer {
 }
 
 /// Builder for constructing transactions with custom values.
+#[derive(Default, Clone, Debug)]
 pub struct TransactionBuilder {
     /// The type of transaction to construct.
     tx_type: Option<TxType>,
 }
 
 impl TransactionBuilder {
-    /// Creates a new instance of `TransactionBuilder` with default values.
-    pub fn new() -> Self {
-        Self { tx_type: Default::default() }
-    }
-
     /// Specifies the type of transaction to build.
     pub fn tx_type(mut self, tx_type: TxType) -> Self {
         self.tx_type = Some(tx_type);

--- a/tests/debug_api.rs
+++ b/tests/debug_api.rs
@@ -5,9 +5,7 @@ use kakarot_rpc::models::block::rpc_to_primitive_block;
 use kakarot_rpc::models::transaction::rpc_transaction_to_primitive;
 use kakarot_rpc::test_utils::fixtures::{katana, setup};
 use kakarot_rpc::test_utils::katana::Katana;
-use kakarot_rpc::test_utils::mongo::{
-    CollectionDB, BLOCK_HASH, BLOCK_NUMBER, EIP1599_TX_HASH, EIP2930_TX_HASH, LEGACY_TX_HASH,
-};
+use kakarot_rpc::test_utils::mongo::{BLOCK_HASH, BLOCK_NUMBER, EIP1599_TX_HASH, EIP2930_TX_HASH, LEGACY_TX_HASH};
 use kakarot_rpc::test_utils::rpc::start_kakarot_rpc_server;
 use reth_primitives::{
     BlockNumberOrTag, Bytes, Log, Receipt, ReceiptWithBloom, TransactionSigned, TransactionSignedEcRecovered, U256,
@@ -204,15 +202,7 @@ async fn test_raw_transactions(#[future] katana: Katana, _setup: ()) {
         start_kakarot_rpc_server(&katana).await.expect("Error setting up Kakarot RPC server");
 
     // Get the first transaction from the mock data.
-    let tx = &katana
-        .mock_data
-        .get(&CollectionDB::Transactions)
-        .unwrap()
-        .first()
-        .unwrap()
-        .extract_stored_transaction()
-        .unwrap()
-        .tx;
+    let tx = &katana.get_first_transaction().unwrap();
 
     // Get the block hash from the transaction.
     let block_hash = tx.block_hash.unwrap();
@@ -322,15 +312,7 @@ async fn test_raw_receipts(#[future] katana: Katana, _setup: ()) {
         start_kakarot_rpc_server(&katana).await.expect("Error setting up Kakarot RPC server");
 
     // Get the first transaction from the mock data.
-    let tx = &katana
-        .mock_data
-        .get(&CollectionDB::Transactions)
-        .unwrap()
-        .first()
-        .unwrap()
-        .extract_stored_transaction()
-        .unwrap()
-        .tx;
+    let tx = &katana.get_first_transaction().unwrap();
 
     // Get the block hash from the transaction.
     let block_hash = tx.block_hash.unwrap();
@@ -442,15 +424,7 @@ async fn test_raw_block(#[future] katana: Katana, _setup: ()) {
         start_kakarot_rpc_server(&katana).await.expect("Error setting up Kakarot RPC server");
 
     // Get the first transaction from the mock data.
-    let tx = &katana
-        .mock_data
-        .get(&CollectionDB::Transactions)
-        .unwrap()
-        .first()
-        .unwrap()
-        .extract_stored_transaction()
-        .unwrap()
-        .tx;
+    let tx = &katana.get_first_transaction().unwrap();
 
     // Get the block number from the transaction and convert it to a u64.
     let block_number = tx.block_number.unwrap().to::<u64>();
@@ -525,15 +499,7 @@ async fn test_raw_header(#[future] katana: Katana, _setup: ()) {
         start_kakarot_rpc_server(&katana).await.expect("Error setting up Kakarot RPC server");
 
     // Get the first transaction from the mock data.
-    let tx = &katana
-        .mock_data
-        .get(&CollectionDB::Transactions)
-        .unwrap()
-        .first()
-        .unwrap()
-        .extract_stored_transaction()
-        .unwrap()
-        .tx;
+    let tx = &katana.get_first_transaction().unwrap();
 
     // Get the block hash from the transaction.
     let block_hash = tx.block_hash.unwrap();

--- a/tests/debug_api.rs
+++ b/tests/debug_api.rs
@@ -202,7 +202,7 @@ async fn test_raw_transactions(#[future] katana: Katana, _setup: ()) {
         start_kakarot_rpc_server(&katana).await.expect("Error setting up Kakarot RPC server");
 
     // Get the first transaction from the mock data.
-    let tx = &katana.get_first_transaction().unwrap();
+    let tx = &katana.first_transaction().unwrap();
 
     // Get the block hash from the transaction.
     let block_hash = tx.block_hash.unwrap();
@@ -312,7 +312,7 @@ async fn test_raw_receipts(#[future] katana: Katana, _setup: ()) {
         start_kakarot_rpc_server(&katana).await.expect("Error setting up Kakarot RPC server");
 
     // Get the first transaction from the mock data.
-    let tx = &katana.get_first_transaction().unwrap();
+    let tx = &katana.first_transaction().unwrap();
 
     // Get the block hash from the transaction.
     let block_hash = tx.block_hash.unwrap();
@@ -424,7 +424,7 @@ async fn test_raw_block(#[future] katana: Katana, _setup: ()) {
         start_kakarot_rpc_server(&katana).await.expect("Error setting up Kakarot RPC server");
 
     // Get the first transaction from the mock data.
-    let tx = &katana.get_first_transaction().unwrap();
+    let tx = &katana.first_transaction().unwrap();
 
     // Get the block number from the transaction and convert it to a u64.
     let block_number = tx.block_number.unwrap().to::<u64>();
@@ -499,7 +499,7 @@ async fn test_raw_header(#[future] katana: Katana, _setup: ()) {
         start_kakarot_rpc_server(&katana).await.expect("Error setting up Kakarot RPC server");
 
     // Get the first transaction from the mock data.
-    let tx = &katana.get_first_transaction().unwrap();
+    let tx = &katana.first_transaction().unwrap();
 
     // Get the block hash from the transaction.
     let block_hash = tx.block_hash.unwrap();

--- a/tests/eth_provider.rs
+++ b/tests/eth_provider.rs
@@ -28,7 +28,7 @@ async fn test_block_number(#[future] katana: Katana, _setup: ()) {
 
     // Then
     // Catch the most recent block number of the mocked Mongo Database
-    let expected = U64::from(katana.get_most_recent_transaction().unwrap().block_number.unwrap());
+    let expected = U64::from(katana.most_recent_transaction().unwrap().block_number.unwrap());
     assert_eq!(block_number, expected);
 }
 
@@ -263,7 +263,7 @@ async fn test_fee_history(#[future] katana: Katana, _setup: ()) {
     let eth_provider = katana.eth_provider();
 
     // Retrieve the most recent block number.
-    let newest_block = katana.get_most_recent_transaction().unwrap().block_number.unwrap().to::<u64>();
+    let newest_block = katana.most_recent_transaction().unwrap().block_number.unwrap().to::<u64>();
 
     // To ensure that the range includes all mocked blocks.
     let block_count = u64::MAX;


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

Time spent on this PR: 0.5 day

Part of #917.

# Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [X] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Testing

# What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- This PR introduces fuzzing values to our test suite for debug API. As this PR already introduces quite a few changes, I think it is better to proceed step by step and integrate the fuzzing values on the other tests in a follow up PR.
- There seemed to be a problem recognizing block IDs in our tests due to the formatting (the block ID was always considered a hash because it was represented by the same format `0x{:064x}`. This is corrected in the tests where the parameters are:
    - Hash: `0x{:064x}`
    - Number: `0x{:016x}`
- The same problem appeared in the RPC itself, in my opinion, when generating filters via `into_filter` with a width of 64 which was revised to 16 for the block numbers which are u64. The width of 64 is left for block hashes which are represented in this way.

# Does this introduce a breaking change?

- [ ] Yes
- [X] No
