### PR TITLE
Small fix on withdrawals root `EMPTY_ROOT_HASH` check

### DIFF
--- a/src/eth_provider/provider.rs
+++ b/src/eth_provider/provider.rs
@@ -722,9 +722,10 @@ where
         let transactions = self.transactions(block_id, full).await?;
 
         // The withdrawals are not supported, hence the withdrawals_root should always be empty.
-        let withdrawal_root = header.header.withdrawals_root.unwrap_or_default();
-        if withdrawal_root != EMPTY_ROOT_HASH {
-            return Err(EthApiError::Unsupported("withdrawals"));
+        if let Some(withdrawals_root) = header.header.withdrawals_root {
+            if withdrawals_root != EMPTY_ROOT_HASH {
+                return Err(EthApiError::Unsupported("withdrawals"));
+            }
         }
 
         let block = Block {


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

Time spent on this PR: 5 min

# Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Testing

# What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

Currently withdrawals are not supported by the RPC. When studying a block, we therefore check that `withdrawals_root` is indeed either `null` or equal to `EMPTY_ROOT_HASH`. If this is not the case then we return an error saying that withdrawals are not supported.

However, until now an `unwrap_or_default` was done. Which means that if `withdrawals_root` was set to `None` then it was assigned the default value of `B256` which is 0x....00 and which does not correspond to the `EMPTY_ROOT_HASH` so an error was thrown. On the contrary, two scenarios must be accepted without raising an error and this is what is done in this PR:
   - The `withdrawals_root` is set to `None`: no error
   - The `withdrawals_root` is set to `EMPTY_ROOT_HASH`: no error
   - The `withdrawals_root` is set to something other than `EMPTY_ROOT_HASH`: error

# Does this introduce a breaking change?

- [ ] Yes
- [X] No
