### PR TITLE
Reorder operations in `EthDataProvider` `block` method

### DIFF
--- a/src/eth_provider/provider.rs
+++ b/src/eth_provider/provider.rs
@@ -9,8 +9,8 @@ use reth_primitives::serde_helper::{JsonStorageKey, U64HexOrNumber};
 use reth_primitives::{constants::EMPTY_ROOT_HASH, revm_primitives::FixedBytes};
 use reth_primitives::{Address, BlockId, BlockNumberOrTag, Bytes, TransactionSigned, B256, U256, U64};
 use reth_rpc_types::{
-    other::OtherFields, Block, BlockHashOrNumber, BlockTransactions, FeeHistory, Filter, FilterChanges, Header, Index,
-    RichBlock, TransactionReceipt, TransactionRequest, ValueOrArray,
+    Block, BlockHashOrNumber, BlockTransactions, FeeHistory, Filter, FilterChanges, Header, Index, RichBlock,
+    TransactionReceipt, TransactionRequest, ValueOrArray,
 };
 use reth_rpc_types::{SyncInfo, SyncStatus};
 use starknet::core::types::SyncStatusType;
@@ -713,31 +713,29 @@ where
     /// Get a block from the database based on a block hash or number.
     /// If full is true, the block will contain the full transactions, otherwise just the hashes
     async fn block(&self, block_id: BlockHashOrNumber, full: bool) -> EthProviderResult<Option<RichBlock>> {
-        let header = self.header(block_id).await?;
-        let header = match header {
-            Some(header) => header,
+        let header = match self.header(block_id).await? {
+            Some(h) => h.header,
             None => return Ok(None),
         };
 
-        let transactions = self.transactions(block_id, full).await?;
-
         // The withdrawals are not supported, hence the withdrawals_root should always be empty.
-        if let Some(withdrawals_root) = header.header.withdrawals_root {
+        if let Some(withdrawals_root) = header.withdrawals_root {
             if withdrawals_root != EMPTY_ROOT_HASH {
                 return Err(EthApiError::Unsupported("withdrawals"));
             }
         }
 
-        let block = Block {
-            header: header.header,
-            transactions,
-            uncles: Vec::new(),
-            size: None,
-            withdrawals: Some(vec![]),
-            other: OtherFields::default(),
-        };
-
-        Ok(Some(block.into()))
+        Ok(Some(
+            Block {
+                header,
+                transactions: self.transactions(block_id, full).await?,
+                uncles: Default::default(),
+                size: Default::default(),
+                withdrawals: Some(Default::default()),
+                other: Default::default(),
+            }
+            .into(),
+        ))
     }
 
     /// Convert the given block id into a Starknet block id


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

Time spent on this PR: 20 min

# Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [X] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Testing

# What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

Currently, in the `block` function of `EthDataProvider`, the block transactions were retrieved before checking if the `withdrawals_root` was correct. This operation, which is quite expensive, is unnecessary to carry out in the case where we know in advance that the `withdrawals_root` is false and that an error will therefore have to be returned.

The transaction query operation for the block is therefore deported to the end of the function, once we are sure that the `withdrawals_root` is valid or `None`.

# Does this introduce a breaking change?

- [ ] Yes
- [X] No
