### PR TITLE
dev: improved handling of pending transactions in database

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -75,9 +75,6 @@ impl KakarotRpcConfig {
     /// starknet provider, e.g. https://starknet-goerli.g.alchemy.com/v2/some_key.
     pub fn from_env() -> Result<Self, eyre::Error> {
         let network = var("STARKNET_NETWORK")?;
-
-        println!("tototototototto: {:?}", network);
-
         let network = match network.to_lowercase().as_str() {
             "katana" => Network::Katana,
             "madara" => Network::Madara,

--- a/src/config.rs
+++ b/src/config.rs
@@ -75,6 +75,9 @@ impl KakarotRpcConfig {
     /// starknet provider, e.g. https://starknet-goerli.g.alchemy.com/v2/some_key.
     pub fn from_env() -> Result<Self, eyre::Error> {
         let network = var("STARKNET_NETWORK")?;
+
+        println!("tototototototto: {:?}", network);
+
         let network = match network.to_lowercase().as_str() {
             "katana" => Network::Katana,
             "madara" => Network::Madara,

--- a/src/eth_provider/provider.rs
+++ b/src/eth_provider/provider.rs
@@ -132,7 +132,7 @@ pub trait EthereumProvider {
 /// Uses an access to a database to certain data, while
 /// the rest is fetched from the Starknet Provider.
 pub struct EthDataProvider<SP: starknet::providers::Provider> {
-    database: Database,
+    pub database: Database,
     starknet_provider: SP,
     chain_id: u64,
 }
@@ -478,9 +478,12 @@ where
     }
 
     async fn send_raw_transaction(&self, transaction: Bytes) -> EthProviderResult<B256> {
+        println!("totototototototototo");
         let mut data = transaction.0.as_ref();
         let transaction_signed = TransactionSigned::decode(&mut data)
             .map_err(|_| EthApiError::EthereumDataFormatError(EthereumDataFormatError::TransactionConversionError))?;
+
+        println!("decoded: {:?}", transaction_signed);
 
         let chain_id =
             self.chain_id().await?.unwrap_or_default().try_into().map_err(|_| TransactionError::InvalidChainId)?;

--- a/src/eth_provider/provider.rs
+++ b/src/eth_provider/provider.rs
@@ -5,6 +5,7 @@ use cainome::cairo_serde::CairoArrayLegacy;
 use eyre::Result;
 use itertools::Itertools;
 use mongodb::bson::doc;
+use mongodb::options::{UpdateModifications, UpdateOptions};
 use reth_primitives::constants::EMPTY_ROOT_HASH;
 use reth_primitives::serde_helper::{JsonStorageKey, U64HexOrNumber};
 use reth_primitives::{

--- a/src/eth_provider/provider.rs
+++ b/src/eth_provider/provider.rs
@@ -132,9 +132,16 @@ pub trait EthereumProvider {
 /// Uses an access to a database to certain data, while
 /// the rest is fetched from the Starknet Provider.
 pub struct EthDataProvider<SP: starknet::providers::Provider> {
-    pub database: Database,
+    database: Database,
     starknet_provider: SP,
     chain_id: u64,
+}
+
+impl<SP: starknet::providers::Provider> EthDataProvider<SP> {
+    /// Returns a reference to the database.
+    pub fn database(&self) -> &Database {
+        &self.database
+    }
 }
 
 #[async_trait]

--- a/tests/eth_provider.rs
+++ b/tests/eth_provider.rs
@@ -2,6 +2,7 @@
 use std::cmp::min;
 use std::str::FromStr;
 
+use kakarot_rpc::eth_provider::database::types::transaction::StoredTransaction;
 use kakarot_rpc::eth_provider::provider::EthereumProvider;
 use kakarot_rpc::models::felt::Felt252Wrapper;
 use kakarot_rpc::test_utils::eoa::Eoa as _;
@@ -10,7 +11,7 @@ use kakarot_rpc::test_utils::fixtures::{counter, katana, setup};
 use kakarot_rpc::test_utils::mongo::{BLOCK_HASH, BLOCK_NUMBER};
 use kakarot_rpc::test_utils::{evm_contract::KakarotEvmContract, katana::Katana};
 use reth_primitives::serde_helper::{JsonStorageKey, U64HexOrNumber};
-use reth_primitives::{hex, Address, BlockNumberOrTag, Bytes, B256, U256, U64};
+use reth_primitives::{hex, Address, BlockNumberOrTag, Bytes, TransactionSigned, B256, U256, U64};
 use reth_rpc_types::request::TransactionInput;
 use reth_rpc_types::{RpcBlockHash, TransactionRequest};
 use rstest::*;
@@ -398,7 +399,49 @@ async fn test_send_raw_transaction(#[future] katana: Katana, _setup: ()) {
     // Given
     let eth_provider = katana.eth_provider();
 
-    let data = hex!("b901f202f901ee05228459682f008459682f11830209bf8080b90195608060405234801561001057600080fd5b50610175806100206000396000f3fe608060405234801561001057600080fd5b506004361061002b5760003560e01c80630c49c36c14610030575b600080fd5b61003861004e565b604051610045919061011d565b60405180910390f35b60606020600052600f6020527f68656c6c6f2073746174656d696e64000000000000000000000000000000000060405260406000f35b600081519050919050565b600082825260208201905092915050565b60005b838110156100be5780820151818401526020810190506100a3565b838111156100cd576000848401525b50505050565b6000601f19601f8301169050919050565b60006100ef82610084565b6100f9818561008f565b93506101098185602086016100a0565b610112816100d3565b840191505092915050565b6000602082019050818103600083015261013781846100e4565b90509291505056fea264697066735822122051449585839a4ea5ac23cae4552ef8a96b64ff59d0668f76bfac3796b2bdbb3664736f6c63430008090033c080a0136ebffaa8fc8b9fda9124de9ccb0b1f64e90fbd44251b4c4ac2501e60b104f9a07eb2999eec6d185ef57e91ed099afb0a926c5b536f0155dd67e537c7476e1471");
+    // let tx_bytes = hex!("b901f202f901ee05228459682f008459682f11830209bf8080b90195608060405234801561001057600080fd5b50610175806100206000396000f3fe608060405234801561001057600080fd5b506004361061002b5760003560e01c80630c49c36c14610030575b600080fd5b61003861004e565b604051610045919061011d565b60405180910390f35b60606020600052600f6020527f68656c6c6f2073746174656d696e64000000000000000000000000000000000060405260406000f35b600081519050919050565b600082825260208201905092915050565b60005b838110156100be5780820151818401526020810190506100a3565b838111156100cd576000848401525b50505050565b6000601f19601f8301169050919050565b60006100ef82610084565b6100f9818561008f565b93506101098185602086016100a0565b610112816100d3565b840191505092915050565b6000602082019050818103600083015261013781846100e4565b90509291505056fea264697066735822122051449585839a4ea5ac23cae4552ef8a96b64ff59d0668f76bfac3796b2bdbb3664736f6c63430008090033c080a0136ebffaa8fc8b9fda9124de9ccb0b1f64e90fbd44251b4c4ac2501e60b104f9a07eb2999eec6d185ef57e91ed099afb0a926c5b536f0155dd67e537c7476e1471");
 
-    let res = eth_provider.send_raw_transaction(data.into()).await.expect("failed to send transaction");
+    use reth_primitives::{sign_message, Transaction, TransactionKind, TxEip1559};
+
+    let transaction = Transaction::Eip1559(TxEip1559 {
+        chain_id: 1,
+        nonce: 0,
+        gas_limit: 21000,
+        to: TransactionKind::Call(Address::random()),
+        value: U256::from(1000),
+        input: Bytes::default(),
+        max_fee_per_gas: 875000000,
+        max_priority_fee_per_gas: 0,
+        access_list: Default::default(),
+    });
+
+    // let signature = sign_message(
+    //     B256::from_str("02bbf4f9fd0bbb2e60b0316c1fe0b76cf7a4d0198bd493ced9b8df2a3a24d68a")
+    //         .expect("failed to generate private key"),
+    //     transaction.signature_hash(),
+    // )
+    // .unwrap();
+
+    let signature = sign_message(
+        B256::from_str("0x02a8846878b6ad1f54f6ba46f5f40e11cee755c677f130b2c4b60566c9003f1f")
+            .expect("failed to generate private key"),
+        transaction.signature_hash(),
+    )
+    .unwrap();
+
+    let transaction_signed = TransactionSigned::from_transaction_and_signature(transaction, signature);
+
+    println!("tx: {:?}", transaction_signed);
+
+    let res = eth_provider
+        .send_raw_transaction(transaction_signed.envelope_encoded())
+        .await
+        .expect("failed to send transaction");
+
+    println!("res: {:?}", res);
+
+    let tx: Option<StoredTransaction> =
+        eth_provider.database.get_one("transactions_pending", None, None).await.expect("Failed to get transaction");
+
+    println!("tx: {:?}", tx);
 }

--- a/tests/eth_provider.rs
+++ b/tests/eth_provider.rs
@@ -431,7 +431,7 @@ async fn test_send_raw_transaction(#[future] katana: Katana, _setup: ()) {
 
     // Retrieve the transaction from the database
     let tx: Option<StoredTransaction> =
-        eth_provider.database.get_one("transactions_pending", None, None).await.expect("Failed to get transaction");
+        eth_provider.database().get_one("transactions_pending", None, None).await.expect("Failed to get transaction");
     let tx = tx.unwrap().tx;
 
     // Assert the transaction hash and block number
@@ -476,7 +476,7 @@ async fn test_send_raw_transaction_wrong_signature(#[future] katana: Katana, _se
 
     // Retrieve the transaction from the database
     let tx: Option<StoredTransaction> =
-        eth_provider.database.get_one("transactions_pending", None, None).await.expect("Failed to get transaction");
+        eth_provider.database().get_one("transactions_pending", None, None).await.expect("Failed to get transaction");
 
     // Assert that no transaction is found
     assert!(tx.is_none());

--- a/tests/eth_provider.rs
+++ b/tests/eth_provider.rs
@@ -427,12 +427,7 @@ async fn test_send_raw_transaction(#[future] katana: Katana, _setup: ()) {
     });
 
     // Sign the transaction
-    let signature = sign_message(
-        B256::from_str("0x02bbf4f9fd0bbb2e60b0316c1fe0b76cf7a4d0198bd493ced9b8df2a3a24d68a")
-            .expect("failed to generate private key"),
-        transaction.signature_hash(),
-    )
-    .unwrap();
+    let signature = sign_message(katana.eoa().private_key(), transaction.signature_hash()).unwrap();
     let transaction_signed = TransactionSigned::from_transaction_and_signature(transaction, signature);
 
     // Send the transaction
@@ -472,12 +467,7 @@ async fn test_send_raw_transaction_wrong_signature(#[future] katana: Katana, _se
     });
 
     // Sign the transaction
-    let signature = sign_message(
-        B256::from_str("0x02bbf4f9fd0bbb2e60b0316c1fe0b76cf7a4d0198bd493ced9b8df2a3a24d68a")
-            .expect("failed to generate private key"),
-        transaction.signature_hash(),
-    )
-    .unwrap();
+    let signature = sign_message(katana.eoa().private_key(), transaction.signature_hash()).unwrap();
     let mut transaction_signed = TransactionSigned::from_transaction_and_signature(transaction, signature);
 
     // Set an incorrect signature

--- a/tests/eth_provider.rs
+++ b/tests/eth_provider.rs
@@ -10,7 +10,7 @@ use kakarot_rpc::test_utils::fixtures::{counter, katana, setup};
 use kakarot_rpc::test_utils::mongo::{BLOCK_HASH, BLOCK_NUMBER};
 use kakarot_rpc::test_utils::{evm_contract::KakarotEvmContract, katana::Katana};
 use reth_primitives::serde_helper::{JsonStorageKey, U64HexOrNumber};
-use reth_primitives::{Address, BlockNumberOrTag, Bytes, B256, U256, U64};
+use reth_primitives::{hex, Address, BlockNumberOrTag, Bytes, B256, U256, U64};
 use reth_rpc_types::request::TransactionInput;
 use reth_rpc_types::{RpcBlockHash, TransactionRequest};
 use rstest::*;
@@ -389,4 +389,16 @@ async fn test_to_starknet_block_id(#[future] katana: Katana, _setup: ()) {
     assert_eq!(some_starknet_block_hash, starknet::core::types::BlockId::Hash(FieldElement::from(0x1234_u64)));
     assert_eq!(some_starknet_block_number, starknet::core::types::BlockId::Tag(BlockTag::Pending));
     assert!(unknown_starknet_block_number.is_err());
+}
+
+#[rstest]
+#[awt]
+#[tokio::test(flavor = "multi_thread")]
+async fn test_send_raw_transaction(#[future] katana: Katana, _setup: ()) {
+    // Given
+    let eth_provider = katana.eth_provider();
+
+    let data = hex!("b901f202f901ee05228459682f008459682f11830209bf8080b90195608060405234801561001057600080fd5b50610175806100206000396000f3fe608060405234801561001057600080fd5b506004361061002b5760003560e01c80630c49c36c14610030575b600080fd5b61003861004e565b604051610045919061011d565b60405180910390f35b60606020600052600f6020527f68656c6c6f2073746174656d696e64000000000000000000000000000000000060405260406000f35b600081519050919050565b600082825260208201905092915050565b60005b838110156100be5780820151818401526020810190506100a3565b838111156100cd576000848401525b50505050565b6000601f19601f8301169050919050565b60006100ef82610084565b6100f9818561008f565b93506101098185602086016100a0565b610112816100d3565b840191505092915050565b6000602082019050818103600083015261013781846100e4565b90509291505056fea264697066735822122051449585839a4ea5ac23cae4552ef8a96b64ff59d0668f76bfac3796b2bdbb3664736f6c63430008090033c080a0136ebffaa8fc8b9fda9124de9ccb0b1f64e90fbd44251b4c4ac2501e60b104f9a07eb2999eec6d185ef57e91ed099afb0a926c5b536f0155dd67e537c7476e1471");
+
+    let res = eth_provider.send_raw_transaction(data.into()).await.expect("failed to send transaction");
 }

--- a/tests/eth_provider.rs
+++ b/tests/eth_provider.rs
@@ -11,7 +11,9 @@ use kakarot_rpc::test_utils::fixtures::{counter, katana, setup};
 use kakarot_rpc::test_utils::mongo::{BLOCK_HASH, BLOCK_NUMBER};
 use kakarot_rpc::test_utils::{evm_contract::KakarotEvmContract, katana::Katana};
 use reth_primitives::serde_helper::{JsonStorageKey, U64HexOrNumber};
-use reth_primitives::{hex, Address, BlockNumberOrTag, Bytes, TransactionSigned, B256, U256, U64};
+use reth_primitives::transaction::Signature;
+use reth_primitives::{sign_message, Transaction, TransactionKind, TxEip1559};
+use reth_primitives::{Address, BlockNumberOrTag, Bytes, TransactionSigned, B256, U256, U64};
 use reth_rpc_types::request::TransactionInput;
 use reth_rpc_types::{RpcBlockHash, TransactionRequest};
 use rstest::*;
@@ -399,10 +401,7 @@ async fn test_send_raw_transaction(#[future] katana: Katana, _setup: ()) {
     // Given
     let eth_provider = katana.eth_provider();
 
-    // let tx_bytes = hex!("b901f202f901ee05228459682f008459682f11830209bf8080b90195608060405234801561001057600080fd5b50610175806100206000396000f3fe608060405234801561001057600080fd5b506004361061002b5760003560e01c80630c49c36c14610030575b600080fd5b61003861004e565b604051610045919061011d565b60405180910390f35b60606020600052600f6020527f68656c6c6f2073746174656d696e64000000000000000000000000000000000060405260406000f35b600081519050919050565b600082825260208201905092915050565b60005b838110156100be5780820151818401526020810190506100a3565b838111156100cd576000848401525b50505050565b6000601f19601f8301169050919050565b60006100ef82610084565b6100f9818561008f565b93506101098185602086016100a0565b610112816100d3565b840191505092915050565b6000602082019050818103600083015261013781846100e4565b90509291505056fea264697066735822122051449585839a4ea5ac23cae4552ef8a96b64ff59d0668f76bfac3796b2bdbb3664736f6c63430008090033c080a0136ebffaa8fc8b9fda9124de9ccb0b1f64e90fbd44251b4c4ac2501e60b104f9a07eb2999eec6d185ef57e91ed099afb0a926c5b536f0155dd67e537c7476e1471");
-
-    use reth_primitives::{sign_message, Transaction, TransactionKind, TxEip1559};
-
+    // Create a sample transaction
     let transaction = Transaction::Eip1559(TxEip1559 {
         chain_id: 1,
         nonce: 0,
@@ -415,33 +414,70 @@ async fn test_send_raw_transaction(#[future] katana: Katana, _setup: ()) {
         access_list: Default::default(),
     });
 
-    // let signature = sign_message(
-    //     B256::from_str("02bbf4f9fd0bbb2e60b0316c1fe0b76cf7a4d0198bd493ced9b8df2a3a24d68a")
-    //         .expect("failed to generate private key"),
-    //     transaction.signature_hash(),
-    // )
-    // .unwrap();
-
+    // Sign the transaction
     let signature = sign_message(
-        B256::from_str("0x02a8846878b6ad1f54f6ba46f5f40e11cee755c677f130b2c4b60566c9003f1f")
+        B256::from_str("0x02bbf4f9fd0bbb2e60b0316c1fe0b76cf7a4d0198bd493ced9b8df2a3a24d68a")
             .expect("failed to generate private key"),
         transaction.signature_hash(),
     )
     .unwrap();
-
     let transaction_signed = TransactionSigned::from_transaction_and_signature(transaction, signature);
 
-    println!("tx: {:?}", transaction_signed);
-
-    let res = eth_provider
+    // Send the transaction
+    let _ = eth_provider
         .send_raw_transaction(transaction_signed.envelope_encoded())
         .await
         .expect("failed to send transaction");
 
-    println!("res: {:?}", res);
+    // Retrieve the transaction from the database
+    let tx: Option<StoredTransaction> =
+        eth_provider.database.get_one("transactions_pending", None, None).await.expect("Failed to get transaction");
+    let tx = tx.unwrap().tx;
 
+    // Assert the transaction hash and block number
+    assert_eq!(tx.hash, transaction_signed.hash());
+    assert!(tx.block_number.is_none());
+}
+
+#[rstest]
+#[awt]
+#[tokio::test(flavor = "multi_thread")]
+async fn test_send_raw_transaction_wrong_signature(#[future] katana: Katana, _setup: ()) {
+    // Given
+    let eth_provider = katana.eth_provider();
+
+    // Create a sample transaction
+    let transaction = Transaction::Eip1559(TxEip1559 {
+        chain_id: 1,
+        nonce: 0,
+        gas_limit: 21000,
+        to: TransactionKind::Call(Address::random()),
+        value: U256::from(1000),
+        input: Bytes::default(),
+        max_fee_per_gas: 875000000,
+        max_priority_fee_per_gas: 0,
+        access_list: Default::default(),
+    });
+
+    // Sign the transaction
+    let signature = sign_message(
+        B256::from_str("0x02bbf4f9fd0bbb2e60b0316c1fe0b76cf7a4d0198bd493ced9b8df2a3a24d68a")
+            .expect("failed to generate private key"),
+        transaction.signature_hash(),
+    )
+    .unwrap();
+    let mut transaction_signed = TransactionSigned::from_transaction_and_signature(transaction, signature);
+
+    // Set an incorrect signature
+    transaction_signed.signature = Signature::default();
+
+    // Send the transaction
+    let _ = eth_provider.send_raw_transaction(transaction_signed.envelope_encoded()).await;
+
+    // Retrieve the transaction from the database
     let tx: Option<StoredTransaction> =
         eth_provider.database.get_one("transactions_pending", None, None).await.expect("Failed to get transaction");
 
-    println!("tx: {:?}", tx);
+    // Assert that no transaction is found
+    assert!(tx.is_none());
 }


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

Time spent on this PR: 2h

Resolves: #916

# Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Testing

# What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- During the sending of raw transactions, after signature recovering, a pending transaction database is populated before firing a transaction to Starknet for processing. This database collection aims to be able to query the database based on the hash of the transaction before receiving the receipt.
- The recovery of the chain ID with the handling of the error is moved to the start of the function because it is an inexpensive operation compared to the decoding of the transaction. It is therefore better to execute it first before decoding the transaction possibly for nothing if the chain ID is not correct.

# Does this introduce a breaking change?

- [ ] Yes
- [X] No
