### PR TITLE
Handle empty bytecode case in `get_code`

### DIFF
--- a/src/eth_provider/provider.rs
+++ b/src/eth_provider/provider.rs
@@ -350,7 +350,11 @@ where
         let account_contract = AccountContractReader::new(address, &self.starknet_provider);
         let bytecode = account_contract.bytecode().block_id(starknet_block_id).call().await;
 
-        if contract_not_found(&bytecode) || entrypoint_not_found(&bytecode) {
+        if contract_not_found(&bytecode)
+            || entrypoint_not_found(&bytecode)
+            || account_contract.bytecode_len().block_id(starknet_block_id).call().await.map_err(KakarotError::from)?.len
+                == FieldElement::ZERO
+        {
             return Ok(Bytes::default());
         }
 

--- a/src/test_utils/eoa.rs
+++ b/src/test_utils/eoa.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use ethers::abi::Tokenize;
 use ethers::signers::{LocalWallet, Signer};
+use ethers_solc::artifacts::CompactContractBytecode;
 use reth_primitives::{
     sign_message, Address, Bytes, Transaction, TransactionKind, TransactionSigned, TxEip1559, B256, U256,
 };
@@ -83,26 +84,43 @@ impl<P: Provider + Send + Sync> KakarotEOA<P> {
 
     pub async fn deploy_evm_contract<T: Tokenize>(
         &self,
-        contract_name: &str,
+        contract_name: Option<&str>,
         constructor_args: T,
     ) -> Result<KakarotEvmContract, eyre::Error> {
         let nonce = self.nonce().await?;
         let nonce: u64 = nonce.try_into()?;
         let chain_id = self.eth_provider.chain_id().await?.unwrap_or_default();
 
-        let bytecode = <KakarotEvmContract as EvmContract>::load_contract_bytecode(contract_name)?;
+        let is_empty_bytecode = contract_name.is_none();
+
+        let bytecode = if is_empty_bytecode {
+            CompactContractBytecode::default()
+        } else {
+            <KakarotEvmContract as EvmContract>::load_contract_bytecode(contract_name.unwrap())?
+        };
         let expected_address = {
             let expected_eth_address = self.evm_address().expect("Failed to get EVM address").create(nonce);
             FieldElement::from_byte_slice_be(expected_eth_address.as_slice())
                 .expect("Failed to convert address to field element")
         };
 
-        let tx = <KakarotEvmContract as EvmContract>::prepare_create_transaction(
-            &bytecode,
-            constructor_args,
-            nonce,
-            chain_id.try_into()?,
-        )?;
+        let tx = if is_empty_bytecode {
+            Transaction::Eip1559(TxEip1559 {
+                chain_id: chain_id.try_into()?,
+                nonce,
+                gas_limit: TX_GAS_LIMIT,
+                to: TransactionKind::Create,
+                value: U256::ZERO,
+                ..Default::default()
+            })
+        } else {
+            <KakarotEvmContract as EvmContract>::prepare_create_transaction(
+                &bytecode,
+                constructor_args,
+                nonce,
+                chain_id.try_into()?,
+            )?
+        };
         let tx_signed = self.sign_transaction(tx)?;
         let tx_hash = self.send_transaction(tx_signed).await?;
         let tx_hash: Felt252Wrapper = tx_hash.try_into().expect("Tx Hash should fit into Felt252Wrapper");

--- a/src/test_utils/eoa.rs
+++ b/src/test_utils/eoa.rs
@@ -91,6 +91,7 @@ impl<P: Provider + Send + Sync> KakarotEOA<P> {
         let nonce: u64 = nonce.try_into()?;
         let chain_id = self.eth_provider.chain_id().await?.unwrap_or_default();
 
+        // Empty bytecode if contract_name is None
         let bytecode = if let Some(name) = contract_name {
             <KakarotEvmContract as EvmContract>::load_contract_bytecode(name)?
         } else {

--- a/src/test_utils/fixtures.rs
+++ b/src/test_utils/fixtures.rs
@@ -11,7 +11,16 @@ use {
 #[awt]
 pub async fn counter(#[future] katana: Katana) -> (Katana, KakarotEvmContract) {
     let eoa = katana.eoa();
-    let contract = eoa.deploy_evm_contract("Counter", ()).await.expect("Failed to deploy Counter contract");
+    let contract = eoa.deploy_evm_contract(Some("Counter"), ()).await.expect("Failed to deploy Counter contract");
+    (katana, contract)
+}
+
+#[cfg(any(test, feature = "arbitrary", feature = "testing"))]
+#[fixture]
+#[awt]
+pub async fn contract_empty(#[future] katana: Katana) -> (Katana, KakarotEvmContract) {
+    let eoa = katana.eoa();
+    let contract = eoa.deploy_evm_contract(None, ()).await.expect("Failed to deploy empty contract");
     (katana, contract)
 }
 
@@ -22,7 +31,7 @@ pub async fn erc20(#[future] katana: Katana) -> (Katana, KakarotEvmContract) {
     let eoa = katana.eoa();
     let contract = eoa
         .deploy_evm_contract(
-            "ERC20",
+            Some("ERC20"),
             (
                 Token::String("Test".into()),               // name
                 Token::String("TT".into()),                 // symbol

--- a/tests/eth_provider.rs
+++ b/tests/eth_provider.rs
@@ -233,8 +233,6 @@ async fn test_get_code_empty(#[future] contract_empty: (Katana, KakarotEvmContra
     // When
     let bytecode = eth_provider.get_code(counter_address, None).await.unwrap();
 
-    println!("bytecode {:?}", bytecode);
-
     // Then
     assert_eq!(bytecode, Bytes::default());
 }

--- a/tests/eth_provider.rs
+++ b/tests/eth_provider.rs
@@ -6,7 +6,7 @@ use kakarot_rpc::eth_provider::provider::EthereumProvider;
 use kakarot_rpc::models::felt::Felt252Wrapper;
 use kakarot_rpc::test_utils::eoa::Eoa as _;
 use kakarot_rpc::test_utils::evm_contract::EvmContract;
-use kakarot_rpc::test_utils::fixtures::{counter, katana, setup};
+use kakarot_rpc::test_utils::fixtures::{contract_empty, counter, katana, setup};
 use kakarot_rpc::test_utils::mongo::{BLOCK_HASH, BLOCK_NUMBER};
 use kakarot_rpc::test_utils::{evm_contract::KakarotEvmContract, katana::Katana};
 use reth_primitives::serde_helper::{JsonStorageKey, U64HexOrNumber};
@@ -216,6 +216,27 @@ async fn test_get_code(#[future] counter: (Katana, KakarotEvmContract), _setup: 
     let expected =
         counter_bytecode.deployed_bytecode.unwrap().bytecode.unwrap().object.into_bytes().unwrap().as_ref().to_vec();
     assert_eq!(bytecode, Bytes::from(expected));
+}
+
+#[rstest]
+#[awt]
+#[tokio::test(flavor = "multi_thread")]
+async fn test_get_code_empty(#[future] contract_empty: (Katana, KakarotEvmContract), _setup: ()) {
+    // Given
+    let katana: Katana = contract_empty.0;
+
+    let counter = contract_empty.1;
+    let eth_provider = katana.eth_provider();
+    let counter_address: Felt252Wrapper = counter.evm_address.into();
+    let counter_address = counter_address.try_into().expect("Failed to convert EVM address");
+
+    // When
+    let bytecode = eth_provider.get_code(counter_address, None).await.unwrap();
+
+    println!("bytecode {:?}", bytecode);
+
+    // Then
+    assert_eq!(bytecode, Bytes::default());
 }
 
 #[rstest]


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

Time spent on this PR: 1h

Resolves: #859 

# Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Testing

# What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- The case where the bytecode is null is handled in `get_code`. Indeed, when the bytecode is null (and after the other conditions are met), instead of outputting an error, we can simply call the function which gives us the length of the bytecode. If this is zero then we know that the bytecode is null and we can return the default value (as in the case where the contract does not exist).
- A unit test is used to test this functionality with a null bytecode contract deployed for this occasion.

# Does this introduce a breaking change?

- [ ] Yes
- [x] No
