### PR TITLE
Improve `transaction_by_hash` to handle pending tx

### DIFF
--- a/src/eth_provider/error.rs
+++ b/src/eth_provider/error.rs
@@ -96,6 +96,9 @@ pub enum KakarotError {
     /// Error related to the database.
     #[error(transparent)]
     DatabaseError(#[from] mongodb::error::Error),
+    /// Error related to the database deserialization.
+    #[error(transparent)]
+    DatabaseDeserializationError(#[from] mongodb::bson::de::Error),
     /// Error related to the evm execution.
     #[error(transparent)]
     ExecutionError(EvmError),

--- a/src/eth_provider/provider.rs
+++ b/src/eth_provider/provider.rs
@@ -25,7 +25,7 @@ use super::database::types::{
     header::StoredHeader, log::StoredLog, receipt::StoredTransactionReceipt, transaction::StoredPendingTransaction,
     transaction::StoredTransaction, transaction::StoredTransactionHash,
 };
-use super::database::Database;
+use super::database::{CollectionName, Database};
 use super::error::{EthApiError, EthereumDataFormatError, EvmError, KakarotError, SignatureError, TransactionError};
 use super::starknet::kakarot_core::core::{CallInput, Uint256};
 use super::starknet::kakarot_core::{
@@ -232,11 +232,33 @@ where
     }
 
     async fn transaction_by_hash(&self, hash: B256) -> EthProviderResult<Option<reth_rpc_types::Transaction>> {
-        Ok(self
-            .database
-            .get_one::<StoredTransaction>(into_filter("tx.hash", &hash, HASH_PADDING), None)
-            .await?
-            .map(Into::into))
+        let pipeline = vec![
+            doc! {
+                // Union with pending transactions with only specified hash
+                "$unionWith": {
+                    "coll": StoredPendingTransaction::collection_name(),
+                    "pipeline": [
+                        {
+                            "$match": {
+                                "tx.hash": format_hex(hash, HASH_PADDING)
+                            }
+                        }
+                    ]
+                },
+            },
+            // Only specified hash in the transactions collection
+            doc! {
+                "$match": {
+                    "tx.hash": format_hex(hash, HASH_PADDING)
+                }
+            },
+            // Only one document in the final result with priority to the final transactions collection if available
+            doc! {
+                "$limit": 1
+            },
+        ];
+
+        Ok(self.database.get_one_aggregate::<StoredTransaction>(pipeline).await?.map(Into::into))
     }
 
     async fn transaction_by_block_hash_and_index(

--- a/tests/eth_provider.rs
+++ b/tests/eth_provider.rs
@@ -1,7 +1,8 @@
 #![cfg(feature = "testing")]
 use std::str::FromStr;
 
-use kakarot_rpc::eth_provider::database::types::transaction::StoredPendingTransaction;
+use kakarot_rpc::eth_provider::database::types::transaction::{StoredPendingTransaction, StoredTransaction};
+use kakarot_rpc::eth_provider::database::CollectionName;
 use kakarot_rpc::eth_provider::provider::EthereumProvider;
 use kakarot_rpc::models::felt::Felt252Wrapper;
 use kakarot_rpc::test_utils::eoa::Eoa as _;
@@ -9,6 +10,9 @@ use kakarot_rpc::test_utils::evm_contract::EvmContract;
 use kakarot_rpc::test_utils::fixtures::{counter, katana, setup};
 use kakarot_rpc::test_utils::mongo::{BLOCK_HASH, BLOCK_NUMBER};
 use kakarot_rpc::test_utils::{evm_contract::KakarotEvmContract, katana::Katana};
+use mongodb::bson::doc;
+use mongodb::options::UpdateModifications;
+use mongodb::options::UpdateOptions;
 use reth_primitives::serde_helper::{JsonStorageKey, U64HexOrNumber};
 use reth_primitives::transaction::Signature;
 use reth_primitives::{sign_message, Transaction, TransactionKind, TxEip1559};
@@ -483,4 +487,78 @@ async fn test_send_raw_transaction_wrong_signature(#[future] katana: Katana, _se
 
     // Assert that no transaction is found
     assert!(tx.is_none());
+}
+
+#[rstest]
+#[awt]
+#[tokio::test(flavor = "multi_thread")]
+async fn test_transaction_by_hash(#[future] katana: Katana, _setup: ()) {
+    // Given
+    // Retrieve an instance of the Ethereum provider from the test environment
+    let eth_provider = katana.eth_provider();
+
+    // Retrieve the first transaction from the test environment
+    let first_transaction = katana.first_transaction().unwrap();
+
+    // Check if the first transaction is returned correctly by the `transaction_by_hash` method
+    assert_eq!(eth_provider.transaction_by_hash(first_transaction.hash).await.unwrap().unwrap(), first_transaction);
+
+    // Check if a non-existent transaction returns None
+    assert!(eth_provider.transaction_by_hash(B256::random()).await.unwrap().is_none());
+
+    // Generate a pending transaction to be stored in the pending transactions collection
+    // Create a sample transaction
+    let transaction = Transaction::Eip1559(TxEip1559 {
+        chain_id: 1,
+        nonce: 0,
+        gas_limit: 21000,
+        to: TransactionKind::Call(Address::random()),
+        value: U256::from(1000),
+        input: Bytes::default(),
+        max_fee_per_gas: 875000000,
+        max_priority_fee_per_gas: 0,
+        access_list: Default::default(),
+    });
+
+    // Sign the transaction
+    let signature = sign_message(katana.eoa().private_key(), transaction.signature_hash()).unwrap();
+    let transaction_signed = TransactionSigned::from_transaction_and_signature(transaction, signature);
+
+    // Send the transaction
+    let _ = eth_provider
+        .send_raw_transaction(transaction_signed.envelope_encoded())
+        .await
+        .expect("failed to send transaction");
+
+    // Retrieve the pending transaction from the database
+    let mut stored_transaction: StoredPendingTransaction =
+        eth_provider.database().get_one(None, None).await.expect("Failed to get transaction").unwrap();
+
+    let tx = stored_transaction.clone().tx;
+
+    // Check if the pending transaction is returned correctly by the `transaction_by_hash` method
+    assert_eq!(eth_provider.transaction_by_hash(tx.hash).await.unwrap().unwrap(), tx);
+
+    // Modify the block number of the pending transaction
+    stored_transaction.tx.block_number = Some(U256::from(1111));
+
+    // Serialize the `StoredData` into BSON
+    let serialized_data =
+        mongodb::bson::to_document(&stored_transaction).expect("Failed to serialize stored transaction");
+
+    // Insert the transaction into the final transaction collection
+    eth_provider
+        .database()
+        .inner()
+        .collection::<StoredTransaction>(StoredTransaction::collection_name())
+        .update_one(
+            doc! {"tx.hash": serialized_data.get_document("tx").unwrap().get_str("hash").unwrap()},
+            UpdateModifications::Document(doc! {"$set": serialized_data.clone()}),
+            UpdateOptions::builder().upsert(true).build(),
+        )
+        .await
+        .expect("Failed to insert documents");
+
+    // Check if the final transaction is returned correctly by the `transaction_by_hash` method
+    assert_eq!(eth_provider.transaction_by_hash(tx.hash).await.unwrap().unwrap().block_number, Some(U256::from(1111)));
 }


### PR DESCRIPTION
…ansactions

<!--- Please provide a general summary of your changes in the title above -->

Time spent on this PR: 0.5 day

Resolves: #914

# Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [X] Bugfix
- [X] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Testing

# What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- An aggregation is performed between the pending transaction and final transaction collections to retrieve a transaction by its hash before the receipt is received.
- A union is utilized to obtain both pending and final transactions, filtered by hash with a priority on finalized transactions if available. For more details, refer to the MongoDB documentation on the [`$unionWith`](https://www.mongodb.com/docs/manual/reference/operator/aggregation/unionWith/) operator.
- A complete unit test is constructed to verify everything is fine when dealing with this aggregation.

# Does this introduce a breaking change?

- [ ] Yes
- [X] No
