### PR TITLE
Add `get_and_map_to` to `Database`

### DIFF
--- a/src/eth_provider/database/mod.rs
+++ b/src/eth_provider/database/mod.rs
@@ -68,7 +68,7 @@ impl Database {
     ) -> DatabaseResult<Vec<D>>
     where
         T: DeserializeOwned + CollectionName,
-        D: DeserializeOwned + From<T>,
+        D: From<T>,
     {
         let stored_data: Vec<T> = self.get(filter, project).await?;
         Ok(stored_data.into_iter().map_into().collect())

--- a/src/eth_provider/provider.rs
+++ b/src/eth_provider/provider.rs
@@ -36,9 +36,7 @@ use super::starknet::kakarot_core::{
     KAKAROT_ADDRESS,
 };
 use super::starknet::{ERC20Reader, STARKNET_NATIVE_TOKEN};
-use super::utils::{
-    contract_not_found, entrypoint_not_found, into_filter, iter_into, split_u256, try_from_u8_iterator,
-};
+use super::utils::{contract_not_found, entrypoint_not_found, into_filter, split_u256, try_from_u8_iterator};
 use crate::eth_provider::utils::format_hex;
 use crate::models::block::{EthBlockId, EthBlockNumberOrTag};
 use crate::models::felt::Felt252Wrapper;
@@ -805,11 +803,15 @@ where
         };
 
         let block_transactions = if full {
-            BlockTransactions::Full(iter_into(self.database.get::<StoredTransaction>(transactions_filter, None).await?))
+            BlockTransactions::Full(
+                self.database.get_and_map_to::<_, StoredTransaction>(transactions_filter, None).await?,
+            )
         } else {
-            BlockTransactions::Hashes(iter_into(
-                self.database.get::<StoredTransactionHash>(transactions_filter, doc! {"tx.hash": 1}).await?,
-            ))
+            BlockTransactions::Hashes(
+                self.database
+                    .get_and_map_to::<_, StoredTransactionHash>(transactions_filter, doc! {"tx.hash": 1})
+                    .await?,
+            )
         };
 
         Ok(block_transactions)

--- a/src/eth_provider/utils.rs
+++ b/src/eth_provider/utils.rs
@@ -1,19 +1,12 @@
 use std::fmt::LowerHex;
 
 use cainome::cairo_serde::Error;
-use itertools::Itertools;
 use mongodb::bson::{doc, Document};
 use reth_primitives::{U128, U256};
 use starknet::{
     core::types::{ContractErrorData, StarknetError},
     providers::ProviderError,
 };
-
-/// Converts an iterator of `Into<D>` into a `Vec<D>`.
-#[inline]
-pub(crate) fn iter_into<D, S: Into<D>>(iter: impl IntoIterator<Item = S>) -> Vec<D> {
-    iter.into_iter().map_into().collect()
-}
 
 /// Converts an iterator of `TryInto<u8>` into a `FromIterator<u8>`.
 #[inline]


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

Time spent on this PR: 20 min

# Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [X] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Testing

# What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

In order to avoid a util `iter_into` method which is perhaps a little too generic and used only to transform query results to the database from value stored to values wrapped, I think it is preferable to implement the equivalent logic directly inside the `Database` wrapper.

So, here I implemented a `get_and_map_to` method which allows you to get stored elements from the database in the form of a vector and convert this vector into a vector of rpc wrapped types via an iterator.

# Does this introduce a breaking change?

- [ ] Yes
- [X] No
