### PR TITLE
derive `Arbitrary` for `StoredTransaction` and `StoredHeader`

### DIFF
--- a/src/eth_provider/database/types/header.rs
+++ b/src/eth_provider/database/types/header.rs
@@ -8,7 +8,7 @@ use {
 
 /// A header as stored in the database
 #[derive(Debug, Serialize, Deserialize, Hash, Clone, PartialEq, Eq)]
-#[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
+#[cfg_attr(any(test, feature = "arbitrary", feature = "testing"), derive(arbitrary::Arbitrary))]
 pub struct StoredHeader {
     #[serde(deserialize_with = "crate::eth_provider::database::types::serde::deserialize_intermediate")]
     pub header: Header,

--- a/src/eth_provider/database/types/header.rs
+++ b/src/eth_provider/database/types/header.rs
@@ -24,6 +24,12 @@ impl<'a> StoredHeader {
                 mix_hash: Some(B256::arbitrary(u).unwrap()),
                 nonce: Some(B64::arbitrary(u).unwrap()),
                 withdrawals_root: Some(EMPTY_ROOT_HASH),
+                base_fee_per_gas: Some(u64::arbitrary(u).unwrap() as u128),
+                blob_gas_used: Some(u64::arbitrary(u).unwrap() as u128),
+                excess_blob_gas: Some(u64::arbitrary(u).unwrap() as u128),
+                gas_limit: u64::arbitrary(u).unwrap() as u128,
+                gas_used: u64::arbitrary(u).unwrap() as u128,
+                number: Some(u64::arbitrary(u).unwrap()),
                 ..Self::arbitrary(u)?.header
             },
         })

--- a/src/eth_provider/database/types/header.rs
+++ b/src/eth_provider/database/types/header.rs
@@ -1,44 +1,30 @@
-#[cfg(any(test, feature = "arbitrary", feature = "testing"))]
-use reth_primitives::{constants::EMPTY_ROOT_HASH, SealedHeader, B64, U256};
 use reth_rpc_types::Header;
 use serde::{Deserialize, Serialize};
+#[cfg(any(test, feature = "arbitrary", feature = "testing"))]
+use {
+    arbitrary::Arbitrary,
+    reth_primitives::{constants::EMPTY_ROOT_HASH, B256, B64, U256},
+};
 
 /// A header as stored in the database
 #[derive(Debug, Serialize, Deserialize, Hash, Clone, PartialEq, Eq)]
+#[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
 pub struct StoredHeader {
     #[serde(deserialize_with = "crate::eth_provider::database::types::serde::deserialize_intermediate")]
     pub header: Header,
 }
 
 #[cfg(any(test, feature = "arbitrary", feature = "testing"))]
-impl<'a> arbitrary::Arbitrary<'a> for StoredHeader {
-    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
-        let header = SealedHeader::arbitrary(u)?;
-
-        Ok(StoredHeader {
+impl<'a> StoredHeader {
+    pub fn arbitrary_with_optional_fields(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
+        Ok(Self {
             header: Header {
-                hash: Some(header.hash()),
-                parent_hash: header.parent_hash,
-                uncles_hash: header.ommers_hash,
-                miner: header.beneficiary,
-                state_root: header.state_root,
-                transactions_root: header.transactions_root,
-                receipts_root: header.receipts_root,
-                logs_bloom: header.logs_bloom,
-                difficulty: header.difficulty,
-                number: Some(header.number),
-                gas_limit: u128::from(header.gas_limit),
-                gas_used: u128::from(header.gas_used),
-                timestamp: header.timestamp,
-                total_difficulty: Some(U256::arbitrary(u)?),
-                extra_data: header.extra_data.clone(),
-                mix_hash: Some(header.mix_hash),
-                nonce: Some(B64::from(header.nonce)),
-                base_fee_per_gas: header.base_fee_per_gas.map(|base_fee_per_gas| base_fee_per_gas as u128),
+                hash: Some(B256::arbitrary(u)?),
+                total_difficulty: Some(U256::arbitrary(u).unwrap()),
+                mix_hash: Some(B256::arbitrary(u).unwrap()),
+                nonce: Some(B64::arbitrary(u).unwrap()),
                 withdrawals_root: Some(EMPTY_ROOT_HASH),
-                blob_gas_used: header.blob_gas_used.map(|blob_gas_used| blob_gas_used as u128),
-                excess_blob_gas: header.excess_blob_gas.map(|excess_blob_gas| excess_blob_gas as u128),
-                parent_beacon_block_root: header.parent_beacon_block_root,
+                ..Self::arbitrary(u)?.header
             },
         })
     }

--- a/src/eth_provider/database/types/transaction.rs
+++ b/src/eth_provider/database/types/transaction.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 
 /// A full transaction as stored in the database
 #[derive(Debug, Serialize, Deserialize, Eq, PartialEq, Clone)]
-#[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
+#[cfg_attr(any(test, feature = "arbitrary", feature = "testing"), derive(arbitrary::Arbitrary))]
 pub struct StoredTransaction {
     #[serde(deserialize_with = "crate::eth_provider::database::types::serde::deserialize_intermediate")]
     pub tx: Transaction,

--- a/src/eth_provider/database/types/transaction.rs
+++ b/src/eth_provider/database/types/transaction.rs
@@ -1,11 +1,12 @@
-use reth_primitives::B256;
 #[cfg(any(test, feature = "arbitrary", feature = "testing"))]
-use reth_primitives::{Address, TransactionSigned, U256};
+use arbitrary::Arbitrary;
+use reth_primitives::B256;
 use reth_rpc_types::Transaction;
 use serde::{Deserialize, Serialize};
 
 /// A full transaction as stored in the database
 #[derive(Debug, Serialize, Deserialize, Eq, PartialEq, Clone)]
+#[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
 pub struct StoredTransaction {
     #[serde(deserialize_with = "crate::eth_provider::database::types::serde::deserialize_intermediate")]
     pub tx: Transaction,
@@ -24,48 +25,24 @@ impl From<Transaction> for StoredTransaction {
 }
 
 #[cfg(any(test, feature = "arbitrary", feature = "testing"))]
-impl<'a> arbitrary::Arbitrary<'a> for StoredTransaction {
-    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
-        let transaction = TransactionSigned::arbitrary(u)?;
-
-        Ok(StoredTransaction {
+impl<'a> StoredTransaction {
+    pub fn arbitrary_with_optional_fields(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
+        Ok(Self {
             tx: Transaction {
-                hash: transaction.hash,
-                nonce: transaction.nonce(),
                 block_hash: Some(B256::arbitrary(u)?),
                 block_number: Some(u64::arbitrary(u)?),
                 transaction_index: Some(u64::arbitrary(u)?),
-                from: Address::arbitrary(u)?,
-                to: transaction.to(),
-                value: transaction.value(),
                 gas_price: Some(u128::arbitrary(u)?),
                 gas: u64::arbitrary(u)? as u128,
-                max_fee_per_gas: Some(transaction.max_fee_per_gas()),
-                max_priority_fee_per_gas: Some(transaction.max_priority_fee_per_gas().unwrap_or_default()),
-                max_fee_per_blob_gas: transaction.max_fee_per_blob_gas(),
-                input: transaction.input().clone(),
+                max_fee_per_gas: Some(u128::arbitrary(u)?),
+                max_priority_fee_per_gas: Some(u128::arbitrary(u)?),
                 signature: Some(reth_rpc_types::Signature {
-                    r: transaction.signature.r,
-                    s: transaction.signature.s,
-                    v: U256::arbitrary(u)?,
                     y_parity: Some(reth_rpc_types::Parity(bool::arbitrary(u)?)),
+                    ..reth_rpc_types::Signature::arbitrary(u)?
                 }),
-                chain_id: transaction.chain_id(),
-                blob_versioned_hashes: transaction.blob_versioned_hashes(),
-                access_list: transaction.access_list().map(|list| {
-                    reth_rpc_types::AccessList(
-                        list.0
-                            .iter()
-                            .map(|item| reth_rpc_types::AccessListItem {
-                                address: item.address,
-                                storage_keys: item.storage_keys.clone(),
-                            })
-                            .collect(),
-                    )
-                }),
-
-                transaction_type: Some(Into::<u8>::into(transaction.tx_type()) % 3),
+                transaction_type: Some(u8::arbitrary(u)? % 3),
                 other: Default::default(),
+                ..Self::arbitrary(u)?.into()
             },
         })
     }

--- a/src/eth_provider/database/types/transaction.rs
+++ b/src/eth_provider/database/types/transaction.rs
@@ -27,7 +27,7 @@ impl From<Transaction> for StoredTransaction {
 #[cfg(any(test, feature = "arbitrary", feature = "testing"))]
 impl<'a> StoredTransaction {
     pub fn arbitrary_with_optional_fields(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
-        let transaction = Self::arbitrary(u)?.tx;
+        let transaction = Transaction::arbitrary(u)?;
 
         let transaction_type = Into::<u8>::into(transaction.transaction_type.unwrap_or_default()) % 3;
 

--- a/src/models/transaction.rs
+++ b/src/models/transaction.rs
@@ -82,8 +82,8 @@ pub fn rpc_to_ec_recovered_transaction(
         TxType::Legacy => {
             // EIP-155: v = {0, 1} + CHAIN_ID * 2 + 35
             let chain_id = transaction.chain_id().ok_or(TransactionError::InvalidChainId)?;
-            let recovery: U256 = U256::from(2) * U256::from(chain_id) + U256::from(35);
-            signature.v - recovery
+            let recovery = chain_id.saturating_mul(2).saturating_add(35);
+            signature.v - U256::from(recovery)
         }
         TxType::Eip1559 | TxType::Eip2930 | TxType::Eip4844 => signature.v,
     };

--- a/src/test_utils/mongo/mod.rs
+++ b/src/test_utils/mongo/mod.rs
@@ -199,7 +199,7 @@ impl MongoFuzzer {
         for i in range {
             let bytes: Vec<u8> = (0..self.rnd_bytes_size).map(|_| rand::random()).collect();
             let mut unstructured = arbitrary::Unstructured::new(&bytes);
-            let mut header = StoredHeader::arbitrary(&mut unstructured).unwrap();
+            let mut header = StoredHeader::arbitrary_with_optional_fields(&mut unstructured).unwrap();
 
             header.header.number = Some(i as u64);
 
@@ -272,7 +272,7 @@ impl MongoFuzzer {
     fn generate_transaction_header(&self, transaction: &Transaction) -> StoredHeader {
         let bytes: Vec<u8> = (0..self.rnd_bytes_size).map(|_| rand::random()).collect();
         let mut unstructured = arbitrary::Unstructured::new(&bytes);
-        let mut header = StoredHeader::arbitrary(&mut unstructured).unwrap();
+        let mut header = StoredHeader::arbitrary_with_optional_fields(&mut unstructured).unwrap();
 
         header.header.hash = transaction.block_hash;
         header.header.number = transaction.block_number;
@@ -423,7 +423,7 @@ impl TransactionBuilder {
             });
         }
 
-        Ok(StoredTransaction::arbitrary(&mut arbitrary::Unstructured::new(&{
+        Ok(StoredTransaction::arbitrary_with_optional_fields(&mut arbitrary::Unstructured::new(&{
             (0..rnd_bytes_size).map(|_| rand::random::<u8>()).collect::<Vec<_>>()
         }))?)
     }


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

Time spent on this PR: 1h

Resolves: #<Issue number>

# Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Testing

# What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

Derive `Arbitrary` for `StoredTransaction` and `StoredHeader`
- `arbitrary_with_optional_fields` are provided in order to ensure that each optional value has a `Some` and not a `None` which would throw an error in our test suite.
- For `StoredTransactionReceipt` we don't use the derivation process because a lot of fields are optional and the `arbitrary_with_optional_fields` function would be similar in size to the current `arbitrary` function so there is no point in going through a derivation at the moment.

# Does this introduce a breaking change?

- [ ] Yes
- [ ] No
