### PR TITLE
fix parity on legacy txs

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -6,7 +6,7 @@ cli:
 plugins:
   sources:
     - id: trunk
-      ref: v1.4.5
+      ref: v1.5.0
       uri: https://github.com/trunk-io/plugins
 runtimes:
   enabled:
@@ -30,7 +30,7 @@ lint:
     - shfmt@3.6.0
     - taplo@0.8.1
     - terrascan@1.19.1
-    - trivy@0.50.2
+    - trivy@0.50.4
     - trufflehog@3.71.0
     - yamllint@1.35.1
   ignore:

--- a/src/eth_provider/error.rs
+++ b/src/eth_provider/error.rs
@@ -250,6 +250,9 @@ pub enum SignatureError {
     /// Thrown when signature is missing.
     #[error("missing signature")]
     MissingSignature,
+    /// Thrown when parity is invalid.
+    #[error("invalid parity")]
+    InvalidParity,
 }
 
 /// Error related to Ethereum data format.


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

Time spent on this PR: 0.1 day

Resolves: #NA

# Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Testing

# What is the new behavior?
Issue in converting rpc tx to ec recovered tx due to missing y parity on legacy transcations.
<!-- Please describe the behavior or changes that are being added by this PR. -->

# Does this introduce a breaking change?

- [ ] Yes
- [x] No
