### PR TITLE
fix: retry by updating the max fee

### DIFF
--- a/src/eth_provider/provider.rs
+++ b/src/eth_provider/provider.rs
@@ -552,7 +552,7 @@ where
             // DuplicateTx error in Starknet, which rejects incoming transactions
             // with the same hash. Incrementing the max fee causes the Starknet
             // hash to change, allowing the transaction to pass.
-            let retries = pending_transaction.as_ref().map(|tx| tx.retries).unwrap_or_default();
+            let retries = pending_transaction.as_ref().map(|tx| tx.retries + 1).unwrap_or_default();
             max_fee.saturating_sub(eth_fees).saturating_add(retries)
         };
 

--- a/src/eth_provider/provider.rs
+++ b/src/eth_provider/provider.rs
@@ -519,8 +519,20 @@ where
         let transaction_signed = TransactionSigned::decode(&mut transaction.0.as_ref())
             .map_err(|_| EthApiError::EthereumDataFormat(EthereumDataFormatError::TransactionConversionError))?;
 
+        // If the transaction gas limit is higher than the tracing
+        // block gas limit, prevent the transaction from being sent
+        // (it will revert anyway on the Starknet side). This assures
+        // that all transactions are traceable.
+        if transaction_signed.gas_limit() > TRACING_BLOCK_GAS_LIMIT {
+            return Err(TransactionError::GasOverflow.into());
+        }
+
         // Recover the signer from the transaction
         let signer = transaction_signed.recover_signer().ok_or(SignatureError::RecoveryError)?;
+
+        // Update pending transactions collection
+        let filter = into_filter("tx.hash", &transaction_signed.hash, HASH_HEX_STRING_LEN);
+        let pending_transaction = self.database.get_one::<StoredPendingTransaction>(filter.clone(), None).await?;
 
         // Determine the maximum fee
         let max_fee = if cfg!(feature = "hive") {
@@ -535,16 +547,10 @@ where
             let balance = self.balance(signer, None).await?;
             let max_fee: u64 = balance.try_into().unwrap_or(u64::MAX);
             let max_fee = (max_fee as u128 * 80 / 100) as u64;
-            max_fee.saturating_sub(eth_fees)
-        };
 
-        // If the transaction gas limit is higher than the tracing
-        // block gas limit, prevent the transaction from being sent
-        // (it will revert anyway on the Starknet side). This assures
-        // that all transactions are traceable.
-        if transaction_signed.gas_limit() > TRACING_BLOCK_GAS_LIMIT {
-            return Err(TransactionError::GasOverflow.into());
-        }
+            let retries = pending_transaction.as_ref().map(|tx| tx.retries).unwrap_or_default();
+            max_fee.saturating_sub(eth_fees).saturating_add(retries)
+        };
 
         // Deploy EVM transaction signer if Hive feature is enabled
         #[cfg(feature = "hive")]
@@ -560,12 +566,7 @@ where
         let transaction =
             from_recovered(TransactionSignedEcRecovered::from_signed_transaction(transaction_signed.clone(), signer));
 
-        // Update pending transactions collection
-        let filter = into_filter("tx.hash", &transaction.hash, HASH_HEX_STRING_LEN);
-
-        if let Some(pending_transaction) =
-            self.database.get_one::<StoredPendingTransaction>(filter.clone(), None).await?
-        {
+        if let Some(pending_transaction) = pending_transaction {
             self.database
                 .update_one::<StoredPendingTransaction>(
                     StoredPendingTransaction::new(transaction, pending_transaction.retries + 1),
@@ -980,16 +981,17 @@ where
         for tx in self.database.get::<StoredPendingTransaction>(None, None).await? {
             // Check if the number of retries exceeds the maximum allowed retries
             // or if the transaction already exists in the database of finalized transactions
+            let hash = tx.tx.hash;
             if tx.retries + 1 > TRANSACTION_MAX_RETRIES
                 || self
                     .database
-                    .get_one::<StoredTransaction>(into_filter("tx.hash", &tx.tx.hash, HASH_HEX_STRING_LEN), None)
+                    .get_one::<StoredTransaction>(into_filter("tx.hash", &hash, HASH_HEX_STRING_LEN), None)
                     .await?
                     .is_some()
             {
                 // Delete the pending transaction from the database
                 self.database
-                    .delete_one::<StoredPendingTransaction>(into_filter("tx.hash", &tx.tx.hash, HASH_HEX_STRING_LEN))
+                    .delete_one::<StoredPendingTransaction>(into_filter("tx.hash", &hash, HASH_HEX_STRING_LEN))
                     .await?;
 
                 // Continue to the next iteration of the loop
@@ -1003,11 +1005,7 @@ where
                     // Delete the pending transaction from the database due conversion error
                     // Malformed transaction
                     self.database
-                        .delete_one::<StoredPendingTransaction>(into_filter(
-                            "tx.hash",
-                            &tx.tx.hash,
-                            HASH_HEX_STRING_LEN,
-                        ))
+                        .delete_one::<StoredPendingTransaction>(into_filter("tx.hash", &hash, HASH_HEX_STRING_LEN))
                         .await?;
                     // Continue to the next iteration of the loop
                     continue;


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

Time spent on this PR: 0.1 day

Resolves: #NA

# Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Testing

# What is the new behavior?
Due to the current implementation of the Starkware appchain mempool, incoming transactions with similar nonces will be rejected. In order to fix the retry mechanism, we add the retry count to the max fee which changes the Starknet hash and allows the transaction to pass the feeder.

<!-- Please describe the behavior or changes that are being added by this PR. -->

# Does this introduce a breaking change?

- [ ] Yes
- [x] No
