### PR TITLE
Re-enables the test to see if failure pops on the CICD

### DIFF
--- a/tests/tests/eth_provider.rs
+++ b/tests/tests/eth_provider.rs
@@ -326,7 +326,6 @@ async fn test_get_logs_topics(#[future] katana: Katana, _setup: ()) {
 }
 
 #[rstest]
-#[ignore = "fails randomly on CI: issue #1097"]
 #[awt]
 #[tokio::test(flavor = "multi_thread")]
 async fn test_get_logs_address(#[future] katana: Katana, _setup: ()) {
@@ -335,6 +334,10 @@ async fn test_get_logs_address(#[future] katana: Katana, _setup: ()) {
     let logs = katana.logs_with_min_topics(3);
     let address_one = logs[0].address();
     let address_two = logs[1].address();
+
+    println!("Logs: {:?}", logs);
+    println!("Address one: {:?}", address_one);
+    println!("Address two: {:?}", address_two);
 
     // Filter on the first address
     let filter = Filter { address: address_one.into(), ..Default::default() };


### PR DESCRIPTION
Note:

Opening this PR to trigger the CI/CD workflow and see if I can capture the current flaky test. Since flaky tests can happen as the side-effect of other tests, it would be good to capture the order on which those tests were run.

Time spent on this PR:

Resolves: #<Issue number>

# Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Testing

# What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

# Does this introduce a breaking change?

- [ ] Yes
- [ ] No
