### PR TITLE
dev: update EvmError

### DIFF
--- a/src/eth_provider/error.rs
+++ b/src/eth_provider/error.rs
@@ -181,8 +181,12 @@ pub enum EvmError {
     OutOfBoundsRead,
     #[error("unknown precompile {0}")]
     UnknownPrecompile(String),
+    #[error("unauthorized precompile")]
+    UnauthorizedPrecompile,
     #[error("not implemented precompile {0}")]
     NotImplementedPrecompile(String),
+    #[error("invalid cairo selector")]
+    InvalidCairoSelector,
     #[error("precompile input error")]
     PrecompileInputError,
     #[error("precompile flag error")]
@@ -226,13 +230,15 @@ impl From<Vec<FieldElement>> for EvmError {
             s if s.contains("UnknownPrecompile") => {
                 Self::UnknownPrecompile(s.trim_start_matches("UnknownPrecompile ").to_string())
             }
+            "unauthorizedPrecompile" => Self::UnauthorizedPrecompile,
             s if s.contains("NotImplementedPrecompile") => {
                 Self::NotImplementedPrecompile(s.trim_start_matches("NotImplementedPrecompile ").to_string())
             }
-            "wrong input_length" => Self::PrecompileInputError,
+            "invalidCairoSelector" => Self::InvalidCairoSelector,
+            "wrong input_len" => Self::PrecompileInputError,
             "flag error" => Self::PrecompileFlagError,
             "transfer amount exceeds balance" => Self::BalanceError,
-            "AddressCollision" => Self::AddressCollision,
+            "addressCollision" => Self::AddressCollision,
             s if s.contains("outOfGas") => Self::OutOfGas,
             _ => Self::Other(decode_err(&bytes)),
         }
@@ -361,13 +367,13 @@ mod tests {
     #[test]
     fn test_display_execution_error() {
         // Given
-        let err = EthApiError::Kakarot(KakarotError::Execution(ExecutionError::Evm(EvmError::BalanceError)));
+        let err = EthApiError::Kakarot(KakarotError::Execution(ExecutionError::Evm(EvmError::InvalidCairoSelector)));
 
         // When
         let display = format!("{err:?}");
 
         // Then
-        assert_eq!(display, "execution reverted: Evm(BalanceError)");
+        assert_eq!(display, "execution reverted: Evm(InvalidCairoSelector)");
     }
 
     #[test]

--- a/src/eth_provider/error.rs
+++ b/src/eth_provider/error.rs
@@ -367,13 +367,13 @@ mod tests {
     #[test]
     fn test_display_execution_error() {
         // Given
-        let err = EthApiError::Kakarot(KakarotError::Execution(ExecutionError::Evm(EvmError::InvalidCairoSelector)));
+        let err = EthApiError::Kakarot(KakarotError::Execution(ExecutionError::Evm(EvmError::BalanceError)));
 
         // When
         let display = format!("{err:?}");
 
         // Then
-        assert_eq!(display, "execution reverted: Evm(InvalidCairoSelector)");
+        assert_eq!(display, "execution reverted: Evm(BalanceError)");
     }
 
     #[test]


### PR DESCRIPTION
ajusted PrecompileInputError and added unauthorizedPrecompile and invalidCairoSelector

<!--- Please provide a general summary of your changes in the title above -->

Time spent on this PR: 1 hour

Resolves: #1204 

# Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [x] Build-related changes
- [ ] Documentation content changes
- [ ] Testing

# What is the new behavior?
ajusted the error output from "wrong input_length" to "wrong input_len", according to the "precompileInputError" function output from the "errors.cairo". The same for the output of the "addressCollision" function, from "AddressCollision" to "addressCollision".
Added the "unauthorizedPrecompile" and "invalidCairoSelector" into the "EvmError" enum and the conversion impl From<Vec<FieldElement>> for EvmError.

<!-- Please describe the behavior or changes that are being added by this PR. -->

# Does this introduce a breaking change?

- [ ] Yes
- [x] No
