### PR TITLE
dev: balance validation in send_raw_transaction

### DIFF
--- a/src/eth_provider/constant.rs
+++ b/src/eth_provider/constant.rs
@@ -23,6 +23,8 @@ lazy_static! {
     pub static ref MAX_LOGS: Option<u64> = std::env::var("MAX_LOGS")
         .ok()
         .and_then(|val| u64::from_str(&val).ok());
+
+    pub static ref ACCOUNT_BALANCES_DIMENSION: usize = 1000;
 }
 
 /// Gas limit for estimate gas and call

--- a/src/eth_provider/provider.rs
+++ b/src/eth_provider/provider.rs
@@ -169,6 +169,7 @@ pub trait EthereumProvider {
     async fn txpool_transactions(&self) -> EthProviderResult<Vec<Transaction>>;
     /// Returns the content of the pending pool.
     async fn txpool_content(&self) -> EthProviderResult<TxpoolContent>;
+    /// Remove the signer cached balance if the transaction has been removed from the pending pool
     async fn remove_from_account_balances(&self, signer: Address);
 }
 

--- a/src/eth_provider/provider.rs
+++ b/src/eth_provider/provider.rs
@@ -622,8 +622,7 @@ where
         validate_transaction(&transaction_signed, chain_id, &latest_block_header)?;
 
         // Remove the signer's balance from the cache, as it will be updated after the transaction is executed
-        let mut balance_map = self.balance_map.lock().await;
-        balance_map.remove(&signer);
+        self.balance_map.lock().await.remove(&signer);
 
         // Get the number of retries for the transaction
         let retries = self.database.pending_transaction_retries(&transaction_signed.hash).await?;

--- a/src/eth_provider/provider.rs
+++ b/src/eth_provider/provider.rs
@@ -972,8 +972,9 @@ where
                 .as_secs();
 
             // Insert the balance into the cache
-            let mut account_balances = self.account_balances.lock().await;
-            account_balances.insert(signer, (user_balance, now));
+            // let mut account_balances =
+            self.account_balances.lock().await.insert(signer, (user_balance, now));
+            // account_balances.insert(signer, (user_balance, now));
 
             // If the balance is not enough, return an error
             if user_balance < transaction_value {
@@ -990,8 +991,9 @@ where
                 .iter()
                 .min_by_key(|&(_, &(_, timestamp))| timestamp)
                 .expect("Attempted to find the oldest key in an empty map");
-
-            self.remove_from_account_balances(*oldest_key).await;
+            let oldest_key = *oldest_key;
+            drop(account_balances);
+            self.remove_from_account_balances(oldest_key).await;
         }
     }
 }

--- a/tests/tests/eth_provider.rs
+++ b/tests/tests/eth_provider.rs
@@ -977,7 +977,7 @@ async fn test_send_raw_transaction_check_cached_balance(#[future] katana: Katana
         nonce: 0,
         gas_limit: 21000,
         to: TxKind::Call(Address::random()),
-        value: U256::MAX,
+        value: U256::MAX/U256::from(2u64),
         input: Bytes::default(),
         max_fee_per_gas: 875_000_000,
         max_priority_fee_per_gas: 0,

--- a/tests/tests/eth_provider.rs
+++ b/tests/tests/eth_provider.rs
@@ -1048,6 +1048,7 @@ async fn test_call_with_state_override_bytecode(#[future] plain_opcodes: (Katana
         .call(request, None, Some(state_override), None)
         .await
         .expect("Failed to set number in Counter contract");
+}
 
 #[rstest]
 #[awt]

--- a/tests/tests/eth_provider.rs
+++ b/tests/tests/eth_provider.rs
@@ -961,6 +961,7 @@ async fn test_call_with_state_override_bytecode(#[future] plain_opcodes: (Katana
     
 async fn test_send_raw_transaction_not_enough_balance(#[future] katana: Katana, _setup: ()) {
 async fn test_send_raw_transaction_not_check_cached_balance(#[future] katana: Katana, _setup: ()) {
+async fn test_send_raw_transaction_check_cached_balance(#[future] katana: Katana, _setup: ()) {
     // Check cached balance with a balance not in the map and an error
 
     // Given

--- a/tests/tests/eth_provider.rs
+++ b/tests/tests/eth_provider.rs
@@ -6,6 +6,9 @@ use kakarot_rpc::{
         constant::{MAX_LOGS, STARKNET_MODULUS},
         database::{ethereum::EthereumTransactionStore, types::transaction::StoredPendingTransaction},
         provider::EthereumProvider,
+        error::{
+            EvmError, ExecutionError,
+        }
     },
     models::felt::Felt252Wrapper,
     test_utils::{
@@ -681,6 +684,9 @@ async fn test_send_raw_transaction(#[future] katana: Katana, _setup: ()) {
     let eth_provider = katana.eth_provider();
     let chain_id = eth_provider.chain_id().await.unwrap_or_default().unwrap_or_default().to();
 
+    // Assert that the number of transactions in the cache is 0
+    assert_eq!(eth_provider.get_balance_map().await.len(), 0);
+
     // Create a sample transaction
     let transaction = Transaction::Eip1559(TxEip1559 {
         chain_id,
@@ -716,6 +722,9 @@ async fn test_send_raw_transaction(#[future] katana: Katana, _setup: ()) {
     // Assert the transaction hash and block number
     assert_eq!(tx.hash, transaction_signed.hash());
     assert!(tx.block_number.is_none());
+
+    // Assert that the number of transactions in the cache is 0, because the transaction has been sent and removed from the cache
+    assert_eq!(eth_provider.get_balance_map().await.len(), 0);
 }
 
 #[rstest]
@@ -951,6 +960,96 @@ async fn test_call_with_state_override_bytecode(#[future] plain_opcodes: (Katana
         .call(request, None, Some(state_override), None)
         .await
         .expect("Failed to set number in Counter contract");
+    
+async fn test_send_raw_transaction_not_enough_balance(#[future] katana: Katana, _setup: ()) {
+    // Check cached balance with a balance not in the map and an error
+
+    // Given
+    let eth_provider = katana.eth_provider();
+    let chain_id = eth_provider.chain_id().await.unwrap_or_default().unwrap_or_default().to();
+
+    // Assert that the number of transactions in the cache is 0
+    assert_eq!(eth_provider.get_balance_map().await.len(), 0);
+
+    // Create a sample transaction with a value greater than the EOA balance
+    let transaction = Transaction::Eip1559(TxEip1559 {
+        chain_id,
+        nonce: 0,
+        gas_limit: 21000,
+        to: TxKind::Call(Address::random()),
+        value: U256::MAX,
+        input: Bytes::default(),
+        max_fee_per_gas: 875_000_000,
+        max_priority_fee_per_gas: 0,
+        access_list: Default::default(),
+    });
+
+    // Sign the transaction
+    let signature = sign_message(katana.eoa().private_key(), transaction.signature_hash()).unwrap();
+    let transaction_signed = TransactionSigned::from_transaction_and_signature(transaction, signature);
+
+    // Send the transaction
+    let result = eth_provider
+        .send_raw_transaction(transaction_signed.envelope_encoded())
+        .await;
+
+    // Assert that the transaction failed with EvmError::Balance error
+    match result {
+        Ok(_) => panic!("Expected an error, but the transaction was successful"),
+        Err(e) => {
+            assert_eq!(e.to_string(), ExecutionError::from(EvmError::Balance).to_string());
+        },
+    }
+
+    // Assert that the number of transactions in the cache is 1 because the transaction failed, so the balance is still in the cache
+    assert_eq!(eth_provider.get_balance_map().await.len(), 1);
+
+    // Check cached balance with a balance in the map and an error
+
+    // send again the transaction with a value greater than the EOA balance, to check that the balance in the cache remains 1
+    // Send the transaction
+    let result = eth_provider
+        .send_raw_transaction(transaction_signed.envelope_encoded())
+        .await;
+
+    // Assert that the transaction failed with EvmError::Balance error
+    match result {
+        Ok(_) => panic!("Expected an error, but the transaction was successful"),
+        Err(e) => {
+            assert_eq!(e.to_string(), ExecutionError::from(EvmError::Balance).to_string());
+        },
+    }
+
+    // Assert that the number of transactions in the cache is 1 because the transaction failed, so the balance is still in the cache
+    assert_eq!(eth_provider.get_balance_map().await.len(), 1);
+
+    // Check cached balance with a balance in the map and no error
+
+    // Create a sample transaction with a value less than the EOA balance
+    let transaction = Transaction::Eip1559(TxEip1559 {
+        chain_id,
+        nonce: 0,
+        gas_limit: 21000,
+        to: TxKind::Call(Address::random()),
+        value: U256::from(1000),
+        input: Bytes::default(),
+        max_fee_per_gas: 875_000_000,
+        max_priority_fee_per_gas: 0,
+        access_list: Default::default(),
+    });
+
+    // Sign the transaction
+    let signature = sign_message(katana.eoa().private_key(), transaction.signature_hash()).unwrap();
+    let transaction_signed = TransactionSigned::from_transaction_and_signature(transaction, signature);
+
+    // Send the transaction
+    let _ = eth_provider
+        .send_raw_transaction(transaction_signed.envelope_encoded())
+        .await
+        .expect("failed to send transaction");
+
+    // Assert that the number of transactions in the cache is 0, because the transaction has been sent and removed from the cache
+    assert_eq!(eth_provider.get_balance_map().await.len(), 0);
 }
 
 #[rstest]

--- a/tests/tests/eth_provider.rs
+++ b/tests/tests/eth_provider.rs
@@ -683,7 +683,7 @@ async fn test_send_raw_transaction(#[future] katana: Katana, _setup: ()) {
     let chain_id = eth_provider.chain_id().await.unwrap_or_default().unwrap_or_default().to();
 
     // Assert that the number of transactions in the cache is 0
-    assert_eq!(eth_provider.get_balance_map().await.len(), 0);
+    assert_eq!(eth_provider.get_account_balances().await.len(), 0);
 
     // Create a sample transaction
     let transaction = Transaction::Eip1559(TxEip1559 {
@@ -722,7 +722,7 @@ async fn test_send_raw_transaction(#[future] katana: Katana, _setup: ()) {
     assert!(tx.block_number.is_none());
 
     // Assert that the number of transactions in the cache is 0, because the transaction has been sent and removed from the cache
-    assert_eq!(eth_provider.get_balance_map().await.len(), 0);
+    assert_eq!(eth_provider.get_account_balances().await.len(), 0);
 }
 
 #[rstest]
@@ -969,7 +969,7 @@ async fn test_send_raw_transaction_check_cached_balance(#[future] katana: Katana
     let chain_id = eth_provider.chain_id().await.unwrap_or_default().unwrap_or_default().to();
 
     // Assert that the number of transactions in the cache is 0
-    assert_eq!(eth_provider.get_balance_map().await.len(), 0);
+    assert_eq!(eth_provider.get_account_balances().await.len(), 0);
 
     // Create a sample transaction with a value greater than the EOA balance
     let transaction = Transaction::Eip1559(TxEip1559 {
@@ -1000,7 +1000,7 @@ async fn test_send_raw_transaction_check_cached_balance(#[future] katana: Katana
     }
 
     // Assert that the number of transactions in the cache is 1 because the transaction failed, so the balance is still in the cache
-    assert_eq!(eth_provider.get_balance_map().await.len(), 1);
+    assert_eq!(eth_provider.get_account_balances().await.len(), 1);
 
     // Check cached balance with a balance in the map and an error
 
@@ -1017,7 +1017,7 @@ async fn test_send_raw_transaction_check_cached_balance(#[future] katana: Katana
     }
 
     // Assert that the number of transactions in the cache is 1 because the transaction failed, so the balance is still in the cache
-    assert_eq!(eth_provider.get_balance_map().await.len(), 1);
+    assert_eq!(eth_provider.get_account_balances().await.len(), 1);
 
     // Check cached balance with a balance in the map and no error
 
@@ -1045,7 +1045,7 @@ async fn test_send_raw_transaction_check_cached_balance(#[future] katana: Katana
         .expect("failed to send transaction");
 
     // Assert that the number of transactions in the cache is 0, because the transaction has been sent and removed from the cache
-    assert_eq!(eth_provider.get_balance_map().await.len(), 0);
+    assert_eq!(eth_provider.get_account_balances().await.len(), 0);
 }
 
 #[rstest]

--- a/tests/tests/eth_provider.rs
+++ b/tests/tests/eth_provider.rs
@@ -5,10 +5,8 @@ use kakarot_rpc::{
     eth_provider::{
         constant::{MAX_LOGS, STARKNET_MODULUS},
         database::{ethereum::EthereumTransactionStore, types::transaction::StoredPendingTransaction},
+        error::{EvmError, ExecutionError},
         provider::EthereumProvider,
-        error::{
-            EvmError, ExecutionError,
-        }
     },
     models::felt::Felt252Wrapper,
     test_utils::{
@@ -989,16 +987,14 @@ async fn test_send_raw_transaction_not_enough_balance(#[future] katana: Katana, 
     let transaction_signed = TransactionSigned::from_transaction_and_signature(transaction, signature);
 
     // Send the transaction
-    let result = eth_provider
-        .send_raw_transaction(transaction_signed.envelope_encoded())
-        .await;
+    let result = eth_provider.send_raw_transaction(transaction_signed.envelope_encoded()).await;
 
     // Assert that the transaction failed with EvmError::Balance error
     match result {
         Ok(_) => panic!("Expected an error, but the transaction was successful"),
         Err(e) => {
             assert_eq!(e.to_string(), ExecutionError::from(EvmError::Balance).to_string());
-        },
+        }
     }
 
     // Assert that the number of transactions in the cache is 1 because the transaction failed, so the balance is still in the cache
@@ -1008,16 +1004,14 @@ async fn test_send_raw_transaction_not_enough_balance(#[future] katana: Katana, 
 
     // send again the transaction with a value greater than the EOA balance, to check that the balance in the cache remains 1
     // Send the transaction
-    let result = eth_provider
-        .send_raw_transaction(transaction_signed.envelope_encoded())
-        .await;
+    let result = eth_provider.send_raw_transaction(transaction_signed.envelope_encoded()).await;
 
     // Assert that the transaction failed with EvmError::Balance error
     match result {
         Ok(_) => panic!("Expected an error, but the transaction was successful"),
         Err(e) => {
             assert_eq!(e.to_string(), ExecutionError::from(EvmError::Balance).to_string());
-        },
+        }
     }
 
     // Assert that the number of transactions in the cache is 1 because the transaction failed, so the balance is still in the cache

--- a/tests/tests/eth_provider.rs
+++ b/tests/tests/eth_provider.rs
@@ -977,7 +977,7 @@ async fn test_send_raw_transaction_check_cached_balance(#[future] katana: Katana
         nonce: 0,
         gas_limit: 21000,
         to: TxKind::Call(Address::random()),
-        value: U256::MAX/U256::from(2u64),
+        value: U256::MAX / U256::from(2u64),
         input: Bytes::default(),
         max_fee_per_gas: 875_000_000,
         max_priority_fee_per_gas: 0,

--- a/tests/tests/eth_provider.rs
+++ b/tests/tests/eth_provider.rs
@@ -960,6 +960,7 @@ async fn test_call_with_state_override_bytecode(#[future] plain_opcodes: (Katana
         .expect("Failed to set number in Counter contract");
     
 async fn test_send_raw_transaction_not_enough_balance(#[future] katana: Katana, _setup: ()) {
+async fn test_send_raw_transaction_not_check_cached_balance(#[future] katana: Katana, _setup: ()) {
     // Check cached balance with a balance not in the map and an error
 
     // Given


### PR DESCRIPTION
Resolves: #1303 

# Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Testing

# What is the new behavior?

**Querying the Initial Balance:**
When a transaction is received for the first time, the user's balance is checked in the cache. If it is not cached, the sender's balance is queried.

**Balance Validation:**
If the balance is sufficient and the transaction is valid, the user's balance is removed from the cache.
If the transaction is not valid, the balance is kept in the cache to avoid querying the balance again.

The cache is represented by a HashMap. The size of the HashMap is not limited, as users are removed from the cache every time a transaction is validated, so the growth is not excessive.

# Does this introduce a breaking change?

- [ ] Yes
- [x] No
