### PR TITLE
bump rust to 1.80 and rm lazy_static

### DIFF
--- a/.github/workflows/kakarot_release.yml
+++ b/.github/workflows/kakarot_release.yml
@@ -76,7 +76,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           target: ${{ matrix.target }}
-          toolchain: 1.79.0
+          toolchain: 1.80.0
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true

--- a/.github/workflows/rust_test.yml
+++ b/.github/workflows/rust_test.yml
@@ -25,7 +25,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
-          toolchain: 1.79.0
+          toolchain: 1.80.0
       - name: Retrieve cached dependencies
         uses: Swatinem/rust-cache@v2
       # nextest setup

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7332,7 +7332,6 @@ dependencies = [
  "itertools 0.13.0",
  "jsonrpsee 0.23.2",
  "katana-primitives",
- "lazy_static",
  "mongodb",
  "num-traits 0.2.19",
  "opentelemetry",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ homepage = "https://github.com/kkrt-labs"
 repository = "https://github.com/kkrt-labs/kakarot-rpc"
 readme = "./README.md"
 license = "MIT"
-rust-version = "1.79"
+rust-version = "1.80"
 
 [lints]
 rust.missing_debug_implementations = "warn"
@@ -105,7 +105,6 @@ auto_impl = { version = "1", default-features = false }
 bytes = { version = "1.6", default-features = false }
 dotenvy = { version = "0.15", default-features = false }
 itertools = { version = "0.13", default-features = false }
-lazy_static = { version = "1", default-features = false }
 mongodb = { version = "3.0", default-features = false, features = [
   "rustls-tls",
   "compat-3-0-0",

--- a/src/bin/katana_genesis.rs
+++ b/src/bin/katana_genesis.rs
@@ -1,21 +1,24 @@
 use dotenvy::dotenv;
 use kakarot_rpc::test_utils::katana::genesis::KatanaGenesisBuilder;
-use lazy_static::lazy_static;
 use reth_primitives::{B256, U256};
 use starknet::core::types::Felt;
 use std::{
     env::var,
     path::{Path, PathBuf},
     str::FromStr,
+    sync::LazyLock,
 };
 
-lazy_static! {
-    static ref GENESIS_FOLDER_PATH: PathBuf = Path::new(env!("CARGO_MANIFEST_DIR")).to_path_buf().join(".katana");
-    static ref KAKAROT_CONTRACTS_PATH: PathBuf =
-        Path::new(env!("CARGO_MANIFEST_DIR")).to_path_buf().join("lib/kakarot/build");
-    static ref COINBASE_ADDRESS: Felt = 0x12345u32.into();
-    static ref SALT: Felt = Felt::ZERO;
-}
+/// Katana genesis folder path.
+static GENESIS_FOLDER_PATH: LazyLock<PathBuf> =
+    LazyLock::new(|| Path::new(env!("CARGO_MANIFEST_DIR")).to_path_buf().join(".katana"));
+
+/// Kakarot contracts path.
+static KAKAROT_CONTRACTS_PATH: LazyLock<PathBuf> =
+    LazyLock::new(|| Path::new(env!("CARGO_MANIFEST_DIR")).to_path_buf().join("lib/kakarot/build"));
+
+/// Mock coinbase address.
+static COINBASE_ADDRESS: LazyLock<Felt> = LazyLock::new(|| 0x12345u32.into());
 
 fn main() {
     // Load the env vars.

--- a/src/eth_provider/starknet/kakarot_core.rs
+++ b/src/eth_provider/starknet/kakarot_core.rs
@@ -8,7 +8,6 @@ use crate::{
 };
 use cainome::rs::abigen_legacy;
 use dotenvy::dotenv;
-use lazy_static::lazy_static;
 use reth_primitives::{Address, TransactionSigned, B256};
 use starknet::{
     core::{
@@ -17,7 +16,7 @@ use starknet::{
     },
     macros::selector,
 };
-use std::str::FromStr;
+use std::{str::FromStr, sync::LazyLock};
 
 // Contract ABIs
 
@@ -50,22 +49,24 @@ fn env_var_to_field_element(var_name: &str) -> Felt {
     Felt::from_str(&env_var).unwrap_or_else(|_| panic!("Invalid hex string for {var_name}"))
 }
 
-lazy_static! {
-    // Contract addresses
-    pub static ref KAKAROT_ADDRESS: Felt = env_var_to_field_element("KAKAROT_ADDRESS");
+/// Kakarot address
+pub static KAKAROT_ADDRESS: LazyLock<Felt> = LazyLock::new(|| env_var_to_field_element("KAKAROT_ADDRESS"));
 
-    // Contract class hashes
-    pub static ref UNINITIALIZED_ACCOUNT_CLASS_HASH: Felt = env_var_to_field_element("UNINITIALIZED_ACCOUNT_CLASS_HASH");
+/// Uninitialized account class hash
+pub static UNINITIALIZED_ACCOUNT_CLASS_HASH: LazyLock<Felt> =
+    LazyLock::new(|| env_var_to_field_element("UNINITIALIZED_ACCOUNT_CLASS_HASH"));
 
-    // Contract selectors
-    pub static ref ETH_SEND_TRANSACTION: Felt = selector!("eth_send_transaction");
+/// Ethereum send transaction selector
+pub static ETH_SEND_TRANSACTION: LazyLock<Felt> = LazyLock::new(|| selector!("eth_send_transaction"));
 
-    // Maximum number of felts (bytes) in calldata
-    pub static ref MAX_FELTS_IN_CALLDATA: usize = usize::from_str(
+/// Maximum number of felts in calldata
+pub static MAX_FELTS_IN_CALLDATA: LazyLock<usize> = LazyLock::new(|| {
+    usize::from_str(
         &std::env::var("MAX_FELTS_IN_CALLDATA")
-            .unwrap_or_else(|_| panic!("Missing environment variable MAX_FELTS_IN_CALLDATA"))
-    ).expect("failing to parse MAX_FELTS_IN_CALLDATA");
-}
+            .unwrap_or_else(|_| panic!("Missing environment variable MAX_FELTS_IN_CALLDATA")),
+    )
+    .expect("Failed to parse MAX_FELTS_IN_CALLDATA")
+});
 
 pub fn get_white_listed_eip_155_transaction_hashes() -> Vec<B256> {
     std::env::var("WHITE_LISTED_EIP_155_TRANSACTION_HASHES")

--- a/src/eth_provider/starknet/mod.rs
+++ b/src/eth_provider/starknet/mod.rs
@@ -2,12 +2,11 @@
 pub mod kakarot_core;
 
 use cainome::rs::abigen_legacy;
-use lazy_static::lazy_static;
 use starknet::core::types::Felt;
+use std::sync::LazyLock;
 
 abigen_legacy!(ERC20, "./.kakarot/artifacts/ERC20.json");
 
-lazy_static! {
-    pub static ref STARKNET_NATIVE_TOKEN: Felt =
-        Felt::from_hex("0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7").unwrap();
-}
+/// Starknet native token address
+pub static STARKNET_NATIVE_TOKEN: LazyLock<Felt> =
+    LazyLock::new(|| Felt::from_hex("0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7").unwrap());

--- a/src/test_utils/katana/genesis.rs
+++ b/src/test_utils/katana/genesis.rs
@@ -21,7 +21,6 @@ use katana_primitives::{
         },
     },
 };
-use lazy_static::lazy_static;
 use rayon::prelude::*;
 use reth_primitives::{B256, U256};
 use serde::Serialize;
@@ -35,12 +34,10 @@ use starknet::core::{
     },
     utils::{get_contract_address, get_storage_var_address, get_udc_deployed_address, UdcUniqueness},
 };
-use std::{collections::HashMap, fs, marker::PhantomData, path::PathBuf, str::FromStr};
+use std::{collections::HashMap, fs, marker::PhantomData, path::PathBuf, str::FromStr, sync::LazyLock};
 use walkdir::WalkDir;
 
-lazy_static! {
-    static ref SALT: Felt = Felt::from_bytes_be(&[0u8; 32]);
-}
+pub static SALT: LazyLock<Felt> = LazyLock::new(|| Felt::from_bytes_be(&[0u8; 32]));
 
 #[serde_as]
 #[derive(Serialize, Debug)]

--- a/src/test_utils/katana/genesis.rs
+++ b/src/test_utils/katana/genesis.rs
@@ -340,7 +340,7 @@ impl KatanaGenesisBuilder<Initialized> {
     }
 
     pub fn cache_load(&self, key: &str) -> Result<Felt> {
-        self.cache.get(key).copied().ok_or(eyre!("Cache miss for {key} address"))
+        self.cache.get(key).copied().ok_or_else(|| eyre!("Cache miss for {key} address"))
     }
 
     pub const fn cache(&self) -> &HashMap<String, Felt> {

--- a/src/test_utils/mongo/mod.rs
+++ b/src/test_utils/mongo/mod.rs
@@ -8,7 +8,6 @@ use crate::eth_provider::{
     },
 };
 use arbitrary::Arbitrary;
-use lazy_static::lazy_static;
 use mongodb::{
     bson::{self, doc, Document},
     options::{DatabaseOptions, ReadConcern, UpdateModifications, UpdateOptions, WriteConcern},
@@ -17,7 +16,7 @@ use mongodb::{
 use reth_primitives::{Address, TxType, B256, U256};
 use reth_rpc_types::Transaction;
 use serde::Serialize;
-use std::{ops::Range, str::FromStr};
+use std::{ops::Range, str::FromStr, sync::LazyLock};
 use strum::{EnumIter, IntoEnumIterator};
 use testcontainers::{
     core::{IntoContainerPort, WaitFor},
@@ -25,26 +24,34 @@ use testcontainers::{
     ContainerAsync, Image,
 };
 
-lazy_static! {
-    pub static ref CHAIN_ID: U256 = U256::from(1);
+pub static CHAIN_ID: LazyLock<U256> = LazyLock::new(|| U256::from(1));
+pub static BLOCK_HASH: LazyLock<B256> = LazyLock::new(|| B256::from(U256::from(0x1234)));
+pub static EIP1599_TX_HASH: LazyLock<B256> = LazyLock::new(|| {
+    B256::from(U256::from_str("0xc92a4e464caa049999cb2073cc4d8586bebb42b518115f631710b2597155c962").unwrap())
+});
+pub static EIP2930_TX_HASH: LazyLock<B256> = LazyLock::new(|| {
+    B256::from(U256::from_str("0x972ba18c780c31bade31873d6f076a3be4e6d314776e2ad50a30eda861acab79").unwrap())
+});
+pub static LEGACY_TX_HASH: LazyLock<B256> = LazyLock::new(|| {
+    B256::from(U256::from_str("0x38c7e066854c56932100b896320a37adbab32713cca46d1e06307fe5d6062b7d").unwrap())
+});
+pub static TEST_SIG_R: LazyLock<U256> =
+    LazyLock::new(|| U256::from_str("0x1ae9d63d9152a0f628cc5c843c9d0edc6cb705b027d12d30b871365d7d9c8ed5").unwrap());
+pub static TEST_SIG_S: LazyLock<U256> =
+    LazyLock::new(|| U256::from_str("0x0d9fa834b490259ad6aa62a49d926053ca1b52acbb59a5e1cf8ecabd65304606").unwrap());
+pub static TEST_SIG_V: LazyLock<U256> = LazyLock::new(|| U256::from(1));
 
-    pub static ref BLOCK_HASH: B256 = B256::from(U256::from(0x1234));
-    pub static ref EIP1599_TX_HASH: B256 = B256::from(U256::from_str("0xc92a4e464caa049999cb2073cc4d8586bebb42b518115f631710b2597155c962").unwrap());
-    pub static ref EIP2930_TX_HASH: B256 = B256::from(U256::from_str("0x972ba18c780c31bade31873d6f076a3be4e6d314776e2ad50a30eda861acab79").unwrap());
-    pub static ref LEGACY_TX_HASH: B256 = B256::from(U256::from_str("0x38c7e066854c56932100b896320a37adbab32713cca46d1e06307fe5d6062b7d").unwrap());
-
-    pub static ref TEST_SIG_R: U256 = U256::from_str("0x1ae9d63d9152a0f628cc5c843c9d0edc6cb705b027d12d30b871365d7d9c8ed5").unwrap();
-    pub static ref TEST_SIG_S: U256 = U256::from_str("0x0d9fa834b490259ad6aa62a49d926053ca1b52acbb59a5e1cf8ecabd65304606").unwrap();
-    pub static ref TEST_SIG_V: U256 = U256::from(1);
-    // Given constant r, s, v and transaction fields, we can derive the `Transaction.from` field "a posteriori"
-    // ⚠️ If the transaction fields change, the below addresses should be updated accordingly ⚠️
-    // Recovered address from the above R, S, V, with EIP1559 transaction
-    pub static ref RECOVERED_EIP1599_TX_ADDRESS: Address = Address::from_str("0x520666a744f86a09c2a794b8d56501c109afba2d").unwrap();
-    // Recovered address from the above R, S, V, with EIP2930 transaction
-    pub static ref RECOVERED_EIP2930_TX_ADDRESS: Address = Address::from_str("0x753925d9bbd7682e4b77f102c47d24ee0580aa8d").unwrap();
-    // Recovered address from the above R, S, V, with Legacy transaction
-    pub static ref RECOVERED_LEGACY_TX_ADDRESS: Address = Address::from_str("0x05ac0c7c5930a6f9003a709042dbb136e98220f2").unwrap();
-}
+// Given constant r, s, v and transaction fields, we can derive the `Transaction.from` field "a posteriori"
+// ⚠️ If the transaction fields change, the below addresses should be updated accordingly ⚠️
+// Recovered address from the above R, S, V, with EIP1559 transaction
+pub static RECOVERED_EIP1599_TX_ADDRESS: LazyLock<Address> =
+    LazyLock::new(|| Address::from_str("0x520666a744f86a09c2a794b8d56501c109afba2d").unwrap());
+// Recovered address from the above R, S, V, with EIP2930 transaction
+pub static RECOVERED_EIP2930_TX_ADDRESS: LazyLock<Address> =
+    LazyLock::new(|| Address::from_str("0x753925d9bbd7682e4b77f102c47d24ee0580aa8d").unwrap());
+// Recovered address from the above R, S, V, with Legacy transaction
+pub static RECOVERED_LEGACY_TX_ADDRESS: LazyLock<Address> =
+    LazyLock::new(|| Address::from_str("0x05ac0c7c5930a6f9003a709042dbb136e98220f2").unwrap());
 
 pub const BLOCK_NUMBER: u64 = 0x1234;
 pub const RANDOM_BYTES_SIZE: usize = 100_024;

--- a/src/test_utils/rpc/mod.rs
+++ b/src/test_utils/rpc/mod.rs
@@ -1,18 +1,15 @@
 use super::katana::Katana;
 use crate::eth_rpc::{config::RPCConfig, rpc::KakarotRpcModuleBuilder, run_server};
 use jsonrpsee::server::ServerHandle;
-use lazy_static::lazy_static;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use std::net::SocketAddr;
+use std::{net::SocketAddr, sync::LazyLock};
 use tokio::sync::Mutex;
 
-lazy_static! {
-    /// A lazy static mutex for managing the next available port number.
-    ///
-    /// It ensures thread-safe access to the next port number.
-    static ref NEXT_PORT: Mutex<u16> = Mutex::new(3030);
-}
+/// A lazy static mutex for managing the next available port number.
+///
+/// It ensures thread-safe access to the next port number.
+pub static NEXT_PORT: LazyLock<Mutex<u16>> = LazyLock::new(|| Mutex::new(3030));
 
 /// Asynchronously gets the next available port number.
 ///


### PR DESCRIPTION
Related:
 - In Rust 1.80, `LazyCell` and `LazyLock` are stable https://blog.rust-lang.org/2024/07/25/Rust-1.80.0.html#lazycell-and-lazylock, giving us the opportunity to remove an useless dependency (`static_lazy`).
 - Similar issue is raised in reth: https://github.com/paradigmxyz/reth/issues/9799
 - `lazy_static` appears to be intended to be deprecated https://github.com/rust-lang-nursery/lazy-static.rs/issues/214