### PR TITLE
provider: facilitate providers import

### DIFF
--- a/src/providers/eth_provider/logs.rs
+++ b/src/providers/eth_provider/logs.rs
@@ -4,12 +4,12 @@ use super::{
     error::EthApiError,
 };
 use crate::providers::eth_provider::{
-    blocks::BlockProvider,
     database::{
         filter::{self},
         FindOpts,
     },
     provider::{EthDataProvider, EthProviderResult},
+    BlockProvider,
 };
 use async_trait::async_trait;
 use auto_impl::auto_impl;

--- a/src/providers/eth_provider/mod.rs
+++ b/src/providers/eth_provider/mod.rs
@@ -13,3 +13,12 @@ pub mod state;
 pub mod transactions;
 pub mod tx_pool;
 pub mod utils;
+
+pub use blocks::*;
+pub use chain::*;
+pub use gas::*;
+pub use logs::*;
+pub use receipts::*;
+pub use state::*;
+pub use transactions::*;
+pub use tx_pool::*;

--- a/src/providers/eth_provider/provider.rs
+++ b/src/providers/eth_provider/provider.rs
@@ -15,8 +15,7 @@ use crate::{
         felt::Felt252Wrapper,
     },
     providers::eth_provider::{
-        blocks::BlockProvider, gas::GasProvider, logs::LogProvider, receipts::ReceiptProvider, state::StateProvider,
-        transactions::TransactionProvider, tx_pool::TxPoolProvider,
+        BlockProvider, GasProvider, LogProvider, ReceiptProvider, StateProvider, TransactionProvider, TxPoolProvider,
     },
 };
 use async_trait::async_trait;

--- a/src/providers/eth_provider/state.rs
+++ b/src/providers/eth_provider/state.rs
@@ -11,9 +11,8 @@ use crate::{
     into_via_wrapper,
     models::felt::Felt252Wrapper,
     providers::eth_provider::{
-        blocks::BlockProvider,
-        chain::ChainProvider,
         provider::{EthDataProvider, EthProviderResult},
+        BlockProvider, ChainProvider,
     },
 };
 use async_trait::async_trait;

--- a/src/providers/eth_provider/transactions.rs
+++ b/src/providers/eth_provider/transactions.rs
@@ -14,12 +14,12 @@ use crate::{
     into_via_wrapper,
     models::{felt::Felt252Wrapper, transaction::validate_transaction},
     providers::eth_provider::{
-        chain::ChainProvider,
         database::{
             ethereum::EthereumTransactionStore,
             filter::{self, format_hex},
         },
         provider::{EthDataProvider, EthProviderResult},
+        ChainProvider,
     },
 };
 use alloy_rlp::Decodable;

--- a/src/test_utils/eoa.rs
+++ b/src/test_utils/eoa.rs
@@ -1,8 +1,7 @@
 use crate::{
     models::felt::Felt252Wrapper,
     providers::eth_provider::{
-        chain::ChainProvider, provider::EthDataProvider, starknet::kakarot_core::starknet_address,
-        transactions::TransactionProvider,
+        provider::EthDataProvider, starknet::kakarot_core::starknet_address, ChainProvider, TransactionProvider,
     },
     test_utils::{
         evm_contract::{EvmContract, KakarotEvmContract, TransactionInfo, TxCommonInfo, TxFeeMarketInfo},

--- a/src/test_utils/mock_provider.rs
+++ b/src/test_utils/mock_provider.rs
@@ -1,6 +1,6 @@
 use crate::providers::eth_provider::{
-    blocks::BlockProvider, chain::ChainProvider, gas::GasProvider, logs::LogProvider, provider::EthProviderResult,
-    receipts::ReceiptProvider, state::StateProvider, transactions::TransactionProvider, tx_pool::TxPoolProvider,
+    provider::EthProviderResult, BlockProvider, ChainProvider, GasProvider, LogProvider, ReceiptProvider,
+    StateProvider, TransactionProvider, TxPoolProvider,
 };
 use async_trait::async_trait;
 use mockall::mock;

--- a/tests/tests/debug_api.rs
+++ b/tests/tests/debug_api.rs
@@ -2,7 +2,7 @@
 #![cfg(feature = "testing")]
 use alloy_rlp::Encodable;
 use kakarot_rpc::{
-    providers::eth_provider::{blocks::BlockProvider, receipts::ReceiptProvider, transactions::TransactionProvider},
+    providers::eth_provider::{BlockProvider, ReceiptProvider, TransactionProvider},
     test_utils::{
         fixtures::{katana, setup},
         katana::Katana,

--- a/tests/tests/eth_provider.rs
+++ b/tests/tests/eth_provider.rs
@@ -4,16 +4,10 @@ use alloy_sol_types::{sol, SolCall};
 use kakarot_rpc::{
     models::felt::Felt252Wrapper,
     providers::eth_provider::{
-        BlockProvider,
-        ChainProvider,
         constant::{MAX_LOGS, STARKNET_MODULUS},
         database::{ethereum::EthereumTransactionStore, types::transaction::StoredPendingTransaction},
-        GasProvider,
-        LogProvider,
         provider::EthereumProvider,
-        ReceiptProvider,
-        StateProvider,
-        TransactionProvider,
+        BlockProvider, ChainProvider, GasProvider, LogProvider, ReceiptProvider, StateProvider, TransactionProvider,
     },
     test_utils::{
         eoa::Eoa,

--- a/tests/tests/eth_provider.rs
+++ b/tests/tests/eth_provider.rs
@@ -4,16 +4,16 @@ use alloy_sol_types::{sol, SolCall};
 use kakarot_rpc::{
     models::felt::Felt252Wrapper,
     providers::eth_provider::{
-        blocks::BlockProvider,
-        chain::ChainProvider,
+        BlockProvider,
+        ChainProvider,
         constant::{MAX_LOGS, STARKNET_MODULUS},
         database::{ethereum::EthereumTransactionStore, types::transaction::StoredPendingTransaction},
-        gas::GasProvider,
-        logs::LogProvider,
+        GasProvider,
+        LogProvider,
         provider::EthereumProvider,
-        receipts::ReceiptProvider,
-        state::StateProvider,
-        transactions::TransactionProvider,
+        ReceiptProvider,
+        StateProvider,
+        TransactionProvider,
     },
     test_utils::{
         eoa::Eoa,

--- a/tests/tests/kakarot_api.rs
+++ b/tests/tests/kakarot_api.rs
@@ -2,8 +2,8 @@
 #![cfg(feature = "testing")]
 use kakarot_rpc::{
     providers::eth_provider::{
-        chain::ChainProvider, constant::Constant, database::types::transaction::StoredPendingTransaction,
-        transactions::TransactionProvider,
+        ChainProvider, constant::Constant, database::types::transaction::StoredPendingTransaction,
+        TransactionProvider,
     },
     test_utils::{
         eoa::Eoa,

--- a/tests/tests/kakarot_api.rs
+++ b/tests/tests/kakarot_api.rs
@@ -2,8 +2,7 @@
 #![cfg(feature = "testing")]
 use kakarot_rpc::{
     providers::eth_provider::{
-        ChainProvider, constant::Constant, database::types::transaction::StoredPendingTransaction,
-        TransactionProvider,
+        constant::Constant, database::types::transaction::StoredPendingTransaction, ChainProvider, TransactionProvider,
     },
     test_utils::{
         eoa::Eoa,

--- a/tests/tests/trace_api.rs
+++ b/tests/tests/trace_api.rs
@@ -3,7 +3,7 @@
 use alloy_dyn_abi::DynSolValue;
 use alloy_sol_types::{sol, SolCall};
 use kakarot_rpc::{
-    providers::eth_provider::chain::ChainProvider,
+    providers::eth_provider::ChainProvider,
     test_utils::{
         eoa::Eoa,
         evm_contract::{EvmContract, KakarotEvmContract, TransactionInfo, TxCommonInfo, TxFeeMarketInfo},

--- a/tests/tests/tracer.rs
+++ b/tests/tests/tracer.rs
@@ -2,7 +2,7 @@
 #![cfg(feature = "testing")]
 use alloy_dyn_abi::DynSolValue;
 use kakarot_rpc::{
-    providers::eth_provider::{blocks::BlockProvider, chain::ChainProvider},
+    providers::eth_provider::{BlockProvider, ChainProvider},
     test_utils::{
         eoa::Eoa,
         evm_contract::{EvmContract, KakarotEvmContract, TransactionInfo, TxCommonInfo, TxFeeMarketInfo},


### PR DESCRIPTION
Since there are many providers and they are separated in different files, this PR simplifies their import via unification without needing to resort to submodules each time.