### PR TITLE
tests: replace `arbitrary_with_optional_fields` by `arbitrary` impl

### DIFF
--- a/src/providers/eth_provider/database/types/header.rs
+++ b/src/providers/eth_provider/database/types/header.rs
@@ -9,7 +9,6 @@ use {
 
 /// A header as stored in the database
 #[derive(Debug, Serialize, Deserialize, Hash, Clone, PartialEq, Eq)]
-#[cfg_attr(any(test, feature = "arbitrary", feature = "testing"), derive(arbitrary::Arbitrary))]
 pub struct StoredHeader {
     #[serde(deserialize_with = "crate::providers::eth_provider::database::types::serde::deserialize_intermediate")]
     pub header: Header,
@@ -36,8 +35,8 @@ impl Deref for StoredHeader {
 }
 
 #[cfg(any(test, feature = "arbitrary", feature = "testing"))]
-impl<'a> StoredHeader {
-    pub fn arbitrary_with_optional_fields(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
+impl Arbitrary<'_> for StoredHeader {
+    fn arbitrary(u: &mut arbitrary::Unstructured<'_>) -> arbitrary::Result<Self> {
         Ok(Self {
             header: Header {
                 hash: Some(B256::arbitrary(u)?),

--- a/src/test_utils/mongo/mod.rs
+++ b/src/test_utils/mongo/mod.rs
@@ -135,7 +135,7 @@ impl MongoFuzzer {
     ) -> Result<(), Box<dyn std::error::Error>> {
         let bytes: Vec<u8> = (0..self.rnd_bytes_size).map(|_| rand::random()).collect();
         let mut unstructured = arbitrary::Unstructured::new(&bytes);
-        let mut header = StoredHeader::arbitrary_with_optional_fields(&mut unstructured).unwrap();
+        let mut header = StoredHeader::arbitrary(&mut unstructured).unwrap();
 
         header.header.number = Some(block_number);
         header.header.base_fee_per_gas = Some(base_fee);
@@ -177,10 +177,9 @@ impl MongoFuzzer {
     pub fn add_random_transactions(&mut self, n_transactions: usize) -> Result<(), Box<dyn std::error::Error>> {
         for i in 0..n_transactions {
             // Build a transaction using the random byte size.
-            let mut transaction =
-                StoredTransaction::arbitrary_with_optional_fields(&mut arbitrary::Unstructured::new(
-                    &(0..self.rnd_bytes_size).map(|_| rand::random::<u8>()).collect::<Vec<_>>(),
-                ))?;
+            let mut transaction = StoredTransaction::arbitrary(&mut arbitrary::Unstructured::new(
+                &(0..self.rnd_bytes_size).map(|_| rand::random::<u8>()).collect::<Vec<_>>(),
+            ))?;
 
             // For the first transaction, set the block number to 0 to mimic a genesis block.
             //
@@ -240,7 +239,7 @@ impl MongoFuzzer {
     fn generate_transaction_header(&self, transaction: &Transaction) -> StoredHeader {
         let bytes: Vec<u8> = (0..self.rnd_bytes_size).map(|_| rand::random()).collect();
         let mut unstructured = arbitrary::Unstructured::new(&bytes);
-        let mut header = StoredHeader::arbitrary_with_optional_fields(&mut unstructured).unwrap();
+        let mut header = StoredHeader::arbitrary(&mut unstructured).unwrap();
 
         header.header.hash = transaction.block_hash;
         header.header.number = transaction.block_number;

--- a/tests/tests/txpool_api.rs
+++ b/tests/tests/txpool_api.rs
@@ -1,5 +1,6 @@
 #![allow(clippy::used_underscore_binding)]
 #![cfg(feature = "testing")]
+use arbitrary::Arbitrary;
 use jsonrpsee::server::ServerHandle;
 use kakarot_rpc::{
     providers::eth_provider::database::types::transaction::StoredPendingTransaction,
@@ -28,8 +29,7 @@ async fn initial_setup(katana: Katana) -> (SocketAddr, ServerHandle, Katana) {
     // Generate 10 pending transactions and add them to the database
     let mut pending_transactions = Vec::new();
     for _ in 0..10 {
-        pending_transactions
-            .push(StoredPendingTransaction::arbitrary_with_optional_fields(&mut unstructured).unwrap().tx);
+        pending_transactions.push(StoredPendingTransaction::arbitrary(&mut unstructured).unwrap().tx);
     }
     katana.add_pending_transactions_to_database(pending_transactions).await;
     (server_addr, server_handle, katana)


### PR DESCRIPTION
More idiomatic and useful to replace `arbitrary_with_optional_fields` by an appropriate `arbitrary` implementation.