### PR TITLE
Add `KakarotTransactions` trait to upstream `send_raw_transaction`

### DIFF
--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -68,7 +68,6 @@ where
             PoolConfig::default(),
         ));
 
-
         Ok(Self { eth_provider, pool })
     }
 

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -1,19 +1,39 @@
 use crate::{
+    models::transaction::validate_transaction,
     pool::{
         mempool::{KakarotPool, TransactionOrdering},
         validate::KakarotTransactionValidatorBuilder,
     },
     providers::eth_provider::{
-        database::{state::EthDatabase, Database},
-        error::KakarotError,
-        provider::EthDataProvider,
+        chain::ChainProvider,
+        database::{
+            ethereum::{EthereumBlockStore, EthereumTransactionStore},
+            state::EthDatabase,
+            Database,
+        },
+        error::{EthApiError, EthereumDataFormatError, KakarotError, SignatureError, TransactionError},
+        provider::{EthApiResult, EthDataProvider},
+        starknet::kakarot_core::to_starknet_transaction,
     },
 };
+use alloy_rlp::Decodable;
+use async_trait::async_trait;
 use num_traits::ToPrimitive;
 use reth_chainspec::ChainSpec;
-use reth_transaction_pool::{blobstore::NoopBlobStore, EthPooledTransaction, PoolConfig};
+use reth_primitives::{Bytes, TransactionSigned, TransactionSignedEcRecovered, B256};
+use reth_rpc_types_compat::transaction::from_recovered;
+use reth_transaction_pool::{
+    blobstore::NoopBlobStore, EthPooledTransaction, PoolConfig, TransactionOrigin, TransactionPool,
+};
 use starknet::{core::types::Felt, providers::Provider};
 use std::sync::Arc;
+use tracing::Instrument;
+
+#[async_trait]
+pub trait KakarotTransactions {
+    /// Send a raw transaction to the network and returns the transactions hash.
+    async fn send_raw_transaction(&self, transaction: Bytes) -> EthApiResult<B256>;
+}
 
 /// Provides a wrapper structure around the Ethereum Provider
 /// and the Mempool.
@@ -27,8 +47,7 @@ impl<SP> EthClient<SP>
 where
     SP: Provider + Clone + Sync + Send,
 {
-    /// Tries to start a [`EthClient`] by fetching the current chain id, initializing a [`EthDataProvider`] and
-    /// a `Pool`.
+    /// Tries to start a [`EthClient`] by fetching the current chain id, initializing a [`EthDataProvider`] and a `Pool`.
     pub async fn try_new(starknet_provider: SP, database: Database) -> eyre::Result<Self> {
         let chain = (starknet_provider.chain_id().await.map_err(KakarotError::from)?.to_bigint()
             & Felt::from(u32::MAX).to_bigint())
@@ -36,7 +55,7 @@ where
         .unwrap();
 
         // Create a new EthDataProvider instance with the initialized database and Starknet provider.
-        let mut eth_provider = EthDataProvider::try_new(database, starknet_provider).await?;
+        let eth_provider = EthDataProvider::try_new(database, starknet_provider).await?;
 
         let validator =
             KakarotTransactionValidatorBuilder::new(Arc::new(ChainSpec { chain: chain.into(), ..Default::default() }))
@@ -49,7 +68,6 @@ where
             PoolConfig::default(),
         ));
 
-        eth_provider.set_mempool(pool.clone());
 
         Ok(Self { eth_provider, pool })
     }
@@ -62,5 +80,79 @@ where
     /// Returns a clone of the `Pool`
     pub fn mempool(&self) -> Arc<KakarotPool<EthDataProvider<SP>>> {
         self.pool.clone()
+    }
+}
+
+#[async_trait]
+impl<SP> KakarotTransactions for EthClient<SP>
+where
+    SP: Provider + Clone + Sync + Send,
+{
+    async fn send_raw_transaction(&self, transaction: Bytes) -> EthApiResult<B256> {
+        // Decode the transaction data
+        let transaction_signed = TransactionSigned::decode(&mut transaction.0.as_ref())
+            .map_err(|_| EthApiError::EthereumDataFormat(EthereumDataFormatError::TransactionConversion))?;
+
+        let chain_id: u64 = self
+            .eth_provider
+            .chain_id()
+            .await?
+            .unwrap_or_default()
+            .try_into()
+            .map_err(|_| TransactionError::InvalidChainId)?;
+
+        // Validate the transaction
+        let latest_block_header =
+            self.eth_provider.database().latest_header().await?.ok_or(EthApiError::UnknownBlockNumber(None))?;
+        validate_transaction(&transaction_signed, chain_id, &latest_block_header)?;
+
+        // Recover the signer from the transaction
+        let signer = transaction_signed.recover_signer().ok_or(SignatureError::Recovery)?;
+
+        // Get the number of retries for the transaction
+        let retries = self.eth_provider.database().pending_transaction_retries(&transaction_signed.hash).await?;
+
+        let transaction_signed_ec_recovered =
+            TransactionSignedEcRecovered::from_signed_transaction(transaction_signed.clone(), signer);
+
+        let encoded_length = transaction_signed_ec_recovered.clone().length_without_header();
+
+        // Upsert the transaction as pending in the database
+        let transaction = from_recovered(transaction_signed_ec_recovered.clone());
+        self.eth_provider.database().upsert_pending_transaction(transaction, retries).await?;
+
+        // Convert the Ethereum transaction to a Starknet transaction
+        let starknet_transaction = to_starknet_transaction(&transaction_signed, signer, retries)?;
+
+        // Deploy EVM transaction signer if Hive feature is enabled
+        #[cfg(feature = "hive")]
+        self.eth_provider.deploy_evm_transaction_signer(signer).await?;
+
+        // Add the transaction to the Starknet provider
+        let span = tracing::span!(tracing::Level::INFO, "sn::add_invoke_transaction");
+        let res = self
+            .eth_provider
+            .starknet_provider()
+            .add_invoke_transaction(starknet_transaction)
+            .instrument(span)
+            .await
+            .map_err(KakarotError::from)?;
+
+        let pool_transaction = EthPooledTransaction::new(transaction_signed_ec_recovered, encoded_length);
+
+        // Don't handle the result in case we are adding multiple times the same transaction due to the retry.
+        let _ = self.pool.as_ref().add_transaction(TransactionOrigin::Local, pool_transaction).await;
+
+        // Return transaction hash if testing feature is enabled, otherwise log and return Ethereum hash
+        if cfg!(feature = "testing") {
+            return Ok(B256::from_slice(&res.transaction_hash.to_bytes_be()[..]));
+        }
+        let hash = transaction_signed.hash();
+        tracing::info!(
+            ethereum_hash = ?hash,
+            starknet_hash = ?B256::from_slice(&res.transaction_hash.to_bytes_be()[..]),
+        );
+
+        Ok(hash)
     }
 }

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -47,7 +47,7 @@ impl<SP> EthClient<SP>
 where
     SP: Provider + Clone + Sync + Send,
 {
-    /// Tries to start a [`EthClient`] by fetching the current chain id, initializing a [`EthDataProvider`] and a `Pool`.
+    /// Tries to start a [`EthClient`] by fetching the current chain id, initializing a [`EthDataProvider`] and a [`Pool`].
     pub async fn try_new(starknet_provider: SP, database: Database) -> eyre::Result<Self> {
         let chain = (starknet_provider.chain_id().await.map_err(KakarotError::from)?.to_bigint()
             & Felt::from(u32::MAX).to_bigint())

--- a/src/eth_rpc/servers/eth_rpc.rs
+++ b/src/eth_rpc/servers/eth_rpc.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::blocks_in_conditions)]
 
 use crate::{
-    client::EthClient,
+    client::{EthClient, KakarotTransactions},
     eth_rpc::api::eth_api::EthApiServer,
     providers::eth_provider::{
         constant::MAX_PRIORITY_FEE_PER_GAS, error::EthApiError, BlockProvider, ChainProvider, GasProvider, LogProvider,
@@ -238,7 +238,7 @@ where
     #[tracing::instrument(skip_all, ret, err)]
     async fn send_raw_transaction(&self, bytes: Bytes) -> Result<B256> {
         tracing::info!("Serving eth_sendRawTransaction");
-        Ok(self.eth_client.eth_provider().send_raw_transaction(bytes).await?)
+        Ok(self.eth_client.send_raw_transaction(bytes).await?)
     }
 
     async fn sign(&self, _address: Address, _message: Bytes) -> Result<Bytes> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -49,10 +49,9 @@ async fn main() -> Result<()> {
     let starknet_provider = Arc::new(starknet_provider);
 
     let eth_client = EthClient::try_new(starknet_provider, db.clone()).await.expect("failed to start ethereum client");
-    let eth_provider = eth_client.eth_provider().clone();
 
     // Setup the retry handler
-    let retry_handler = RetryHandler::new(eth_provider, db);
+    let retry_handler = RetryHandler::new(eth_client.clone(), db);
     retry_handler.start(&tokio::runtime::Handle::current());
 
     // Setup the RPC module

--- a/src/pool/mempool.rs
+++ b/src/pool/mempool.rs
@@ -1,7 +1,8 @@
 use super::validate::KakarotTransactionValidator;
+use crate::pool::EthClient;
 use reth_transaction_pool::{
     blobstore::NoopBlobStore, CoinbaseTipOrdering, EthPooledTransaction, Pool, TransactionPool,
-};use crate::pool::EthClient;
+};
 use serde_json::Value;
 use starknet::core::types::Felt;
 use std::{collections::HashSet, fs::File, io::Read, time::Duration};
@@ -59,7 +60,7 @@ impl AccountManager {
 
     pub fn start<SP>(&self, rt_handle: &Handle, eth_client: &'static EthClient<SP>)
     where
-        SP: starknet::providers::Provider + Send + Sync+Clone + 'static,
+        SP: starknet::providers::Provider + Send + Sync + Clone + 'static,
     {
         let accounts = self.accounts.clone();
 
@@ -76,13 +77,12 @@ impl AccountManager {
 
     fn process_transaction<SP>(address: &Felt, eth_client: &EthClient<SP>)
     where
-        SP: starknet::providers::Provider + Send + Sync+Clone + 'static,
+        SP: starknet::providers::Provider + Send + Sync + Clone + 'static,
     {
         let balance = Self::check_balance(address);
 
         if balance > Felt::ONE {
-            let best_hashes =
-                eth_client.mempool().as_ref().best_transactions().map(|x| *x.hash()).collect::<Vec<_>>();
+            let best_hashes = eth_client.mempool().as_ref().best_transactions().map(|x| *x.hash()).collect::<Vec<_>>();
 
             if let Some(best_hash) = best_hashes.first() {
                 eth_client.mempool().as_ref().remove_transactions(vec![*best_hash]);

--- a/src/providers/eth_provider/provider.rs
+++ b/src/providers/eth_provider/provider.rs
@@ -78,8 +78,6 @@ where
     pub const fn starknet_provider(&self) -> &SP {
         &self.starknet_provider
     }
-
-
 }
 
 impl<SP> EthDataProvider<SP>
@@ -93,7 +91,7 @@ where
         let chain_id =
             (Felt::from(u32::MAX).to_biguint() & starknet_provider.chain_id().await?.to_biguint()).try_into().unwrap(); // safe unwrap
 
-        Ok(Self { database, starknet_provider, chain_id,})
+        Ok(Self { database, starknet_provider, chain_id })
     }
 
     /// Prepare the call input for an estimate gas or call from a transaction request.

--- a/src/providers/eth_provider/provider.rs
+++ b/src/providers/eth_provider/provider.rs
@@ -24,9 +24,6 @@ use itertools::Itertools;
 use mongodb::bson::doc;
 use num_traits::cast::ToPrimitive;
 use reth_primitives::{BlockId, BlockNumberOrTag, TxKind, U256};
-use std::sync::Arc;
-
-use crate::pool::mempool::KakarotPool;
 use reth_rpc_types::{BlockHashOrNumber, TransactionRequest};
 use starknet::core::types::Felt;
 use tracing::{instrument, Instrument};
@@ -66,7 +63,6 @@ pub struct EthDataProvider<SP: starknet::providers::Provider + Send + Sync> {
     database: Database,
     starknet_provider: SP,
     pub(crate) chain_id: u64,
-    pub mempool: Option<Arc<KakarotPool<Self>>>,
 }
 
 impl<SP> EthDataProvider<SP>
@@ -83,10 +79,7 @@ where
         &self.starknet_provider
     }
 
-    /// Returns a reference to the pool.
-    pub fn mempool(&self) -> Option<Arc<KakarotPool<Self>>> {
-        self.mempool.clone()
-    }
+
 }
 
 impl<SP> EthDataProvider<SP>
@@ -100,11 +93,7 @@ where
         let chain_id =
             (Felt::from(u32::MAX).to_biguint() & starknet_provider.chain_id().await?.to_biguint()).try_into().unwrap(); // safe unwrap
 
-        Ok(Self { database, starknet_provider, chain_id, mempool: None })
-    }
-
-    pub fn set_mempool(&mut self, mempool: Arc<KakarotPool<Self>>) {
-        self.mempool = Some(mempool);
+        Ok(Self { database, starknet_provider, chain_id,})
     }
 
     /// Prepare the call input for an estimate gas or call from a transaction request.

--- a/src/test_utils/katana/mod.rs
+++ b/src/test_utils/katana/mod.rs
@@ -131,8 +131,7 @@ impl<'a> Katana {
         let eth_client = EthClient::try_new(starknet_provider, database).await.expect("failed to start eth client");
 
         // Create a new Kakarot EOA instance with the private key and EthDataProvider instance.
-        let eth_provider = Arc::new(eth_client.eth_provider().clone());
-        let eoa = KakarotEOA::new(pk, eth_provider);
+        let eoa = KakarotEOA::new(pk, Arc::new(eth_client.clone()));
 
         // Return a new instance of Katana with initialized fields.
         Self {
@@ -152,11 +151,11 @@ impl<'a> Katana {
     }
 
     pub fn eth_provider(&self) -> Arc<EthDataProvider<Arc<JsonRpcClient<HttpTransport>>>> {
-        self.eoa.eth_provider.clone()
+        Arc::new(self.eoa.eth_client.eth_provider().clone())
     }
 
     pub fn starknet_provider(&self) -> Arc<JsonRpcClient<HttpTransport>> {
-        self.eoa.eth_provider.starknet_provider().clone()
+        self.eoa.eth_client.eth_provider().starknet_provider().clone()
     }
 
     pub fn eoa(&self) -> KakarotEOA<Arc<JsonRpcClient<HttpTransport>>> {

--- a/src/test_utils/mock_provider.rs
+++ b/src/test_utils/mock_provider.rs
@@ -79,8 +79,6 @@ mock! {
         async fn transaction_by_block_number_and_index(&self, number_or_tag: BlockNumberOrTag, index: reth_rpc_types::Index) -> EthApiResult<Option<reth_rpc_types::Transaction>>;
 
         async fn transaction_count(&self, address: Address, block_id: Option<BlockId>) -> EthApiResult<U256>;
-
-        async fn send_raw_transaction(&self, transaction: Bytes) -> EthApiResult<B256>;
     }
 
     #[async_trait]

--- a/tests/tests/eth_provider.rs
+++ b/tests/tests/eth_provider.rs
@@ -3,6 +3,7 @@
 use alloy_primitives::{address, bytes};
 use alloy_sol_types::{sol, SolCall};
 use kakarot_rpc::{
+    client::KakarotTransactions,
     models::felt::Felt252Wrapper,
     providers::eth_provider::{
         constant::{MAX_LOGS, STARKNET_MODULUS},
@@ -28,7 +29,7 @@ use reth_rpc_types::{
 };
 use rstest::*;
 use starknet::core::types::{BlockTag, Felt};
-use std::{collections::HashMap, sync::Arc};use kakarot_rpc::client::KakarotTransactions;
+use std::{collections::HashMap, sync::Arc};
 
 #[rstest]
 #[awt]

--- a/tests/tests/eth_provider.rs
+++ b/tests/tests/eth_provider.rs
@@ -730,7 +730,7 @@ async fn test_send_raw_transaction(#[future] katana: Katana, _setup: ()) {
     let transaction_signed = TransactionSigned::from_transaction_and_signature(transaction, signature);
 
     // Retrieve the current size of the mempool
-    let mempool_size = eth_provider.mempool().unwrap().pool_size();
+    let mempool_size = eth_client.mempool().pool_size();
     // Assert that the number of pending and total transactions in the mempool is 0
     assert_eq!(mempool_size.pending, 0);
     assert_eq!(mempool_size.total, 0);
@@ -755,11 +755,11 @@ async fn test_send_raw_transaction(#[future] katana: Katana, _setup: ()) {
     assert!(tx.block_number.is_none());
 
     // Retrieve the current size of the mempool
-    let mempool_size_after_send = eth_provider.mempool().unwrap().pool_size();
+    let mempool_size_after_send = eth_client.mempool().pool_size();
     // Assert that the number of pending transactions in the mempool is 1
     assert_eq!(mempool_size_after_send.pending, 1);
     assert_eq!(mempool_size_after_send.total, 1);
-    let tx_in_mempool = eth_provider.mempool().unwrap().get(&tx.hash);
+    let tx_in_mempool = eth_client.mempool().get(&tx.hash);
     // Assert that the transaction in the mempool exists
     assert!(tx_in_mempool.is_some());
     // Verify that the hash of the transaction in the mempool matches the expected hash
@@ -772,6 +772,7 @@ async fn test_send_raw_transaction(#[future] katana: Katana, _setup: ()) {
 async fn test_send_raw_transaction_wrong_nonce(#[future] katana: Katana, _setup: ()) {
     // Given
     let eth_provider = katana.eth_provider();
+    let eth_client = katana.eth_client();
     let chain_id = eth_provider.chain_id().await.unwrap_or_default().unwrap_or_default().to();
 
     // Create a sample transaction
@@ -792,19 +793,19 @@ async fn test_send_raw_transaction_wrong_nonce(#[future] katana: Katana, _setup:
     let transaction_signed = TransactionSigned::from_transaction_and_signature(transaction, signature);
 
     // Retrieve the current size of the mempool
-    let mempool_size = eth_provider.mempool().unwrap().pool_size();
+    let mempool_size = eth_client.mempool().pool_size();
     // Assert that the number of pending and total transactions in the mempool is 0
     assert_eq!(mempool_size.pending, 0);
     assert_eq!(mempool_size.total, 0);
 
     // Send the transaction
-    let _ = eth_provider
+    let _ = eth_client
         .send_raw_transaction(transaction_signed.envelope_encoded())
         .await
         .expect("failed to send transaction");
 
     // Assert that the number of pending transactions in the mempool is 1
-    assert_eq!(eth_provider.mempool().unwrap().pool_size().pending, 1);
+    assert_eq!(eth_client.mempool().pool_size().pending, 1);
 
     // Create a sample transaction with nonce 0 instead of 1
     let wrong_transaction = Transaction::Eip1559(TxEip1559 {
@@ -825,19 +826,19 @@ async fn test_send_raw_transaction_wrong_nonce(#[future] katana: Katana, _setup:
         TransactionSigned::from_transaction_and_signature(wrong_transaction, wrong_signature);
 
     // Retrieve the current size of the mempool
-    let mempool_size_after_send = eth_provider.mempool().unwrap().pool_size();
+    let mempool_size_after_send = eth_client.mempool().pool_size();
     // Assert that the number of pending transactions in the mempool is 1
     assert_eq!(mempool_size_after_send.pending, 1);
     assert_eq!(mempool_size_after_send.total, 1);
 
     // Send the transaction
-    let _ = eth_provider
+    let _ = eth_client
         .send_raw_transaction(wrong_transaction_signed.envelope_encoded())
         .await
         .expect("failed to send transaction");
 
     // Retrieve the current size of the mempool
-    let mempool_size_after_wrong_send = eth_provider.mempool().unwrap().pool_size();
+    let mempool_size_after_wrong_send = eth_client.mempool().pool_size();
     // Assert that the number of pending transactions in the mempool is still 1 (wrong_transaction was not added to the mempool)
     assert_eq!(mempool_size_after_wrong_send.pending, 1);
     assert_eq!(mempool_size_after_wrong_send.total, 1);
@@ -849,6 +850,7 @@ async fn test_send_raw_transaction_wrong_nonce(#[future] katana: Katana, _setup:
 async fn test_send_raw_transaction_exceed_size_limit(#[future] katana: Katana, _setup: ()) {
     // Given
     let eth_provider = katana.eth_provider();
+    let eth_client = katana.eth_client();
     let chain_id = eth_provider.chain_id().await.unwrap_or_default().unwrap_or_default().to();
 
     // Create a sample transaction
@@ -869,15 +871,15 @@ async fn test_send_raw_transaction_exceed_size_limit(#[future] katana: Katana, _
     let transaction_signed = TransactionSigned::from_transaction_and_signature(transaction, signature);
 
     // Retrieve the current size of the mempool
-    let mempool_size = eth_provider.mempool().unwrap().pool_size();
+    let mempool_size = eth_client.mempool().pool_size();
     // Assert that the number of pending and total transactions in the mempool is 0
     assert_eq!(mempool_size.pending, 0);
     assert_eq!(mempool_size.total, 0);
 
-    let _ = eth_provider.send_raw_transaction(transaction_signed.envelope_encoded()).await;
+    let _ = eth_client.send_raw_transaction(transaction_signed.envelope_encoded()).await;
 
     // Retrieve the current size of the mempool
-    let mempool_size_after_send = eth_provider.mempool().unwrap().pool_size();
+    let mempool_size_after_send = eth_client.mempool().pool_size();
     // Verify that the number of pending transactions in the mempool remains unchanged (0 tx)
     assert_eq!(mempool_size_after_send.pending, 0);
     assert_eq!(mempool_size_after_send.total, 0);
@@ -889,6 +891,7 @@ async fn test_send_raw_transaction_exceed_size_limit(#[future] katana: Katana, _
 async fn test_send_raw_transaction_exceed_max_priority_fee_per_gas(#[future] katana: Katana, _setup: ()) {
     // Given
     let eth_provider = katana.eth_provider();
+    let eth_client = katana.eth_client();
     let chain_id = eth_provider.chain_id().await.unwrap_or_default().unwrap_or_default().to();
 
     // Create a sample transaction
@@ -909,15 +912,15 @@ async fn test_send_raw_transaction_exceed_max_priority_fee_per_gas(#[future] kat
     let transaction_signed = TransactionSigned::from_transaction_and_signature(transaction, signature);
 
     // Retrieve the current size of the mempool
-    let mempool_size = eth_provider.mempool().unwrap().pool_size();
+    let mempool_size = eth_client.mempool().pool_size();
     // Assert that the number of pending and total transactions in the mempool is 0
     assert_eq!(mempool_size.pending, 0);
     assert_eq!(mempool_size.total, 0);
 
-    let _ = eth_provider.send_raw_transaction(transaction_signed.envelope_encoded()).await;
+    let _ = eth_client.send_raw_transaction(transaction_signed.envelope_encoded()).await;
 
     // Retrieve the current size of the mempool
-    let mempool_size_after_send = eth_provider.mempool().unwrap().pool_size();
+    let mempool_size_after_send = eth_client.mempool().pool_size();
     // Verify that the number of pending transactions in the mempool remains unchanged (0 tx)
     assert_eq!(mempool_size_after_send.pending, 0);
     assert_eq!(mempool_size_after_send.total, 0);
@@ -929,6 +932,7 @@ async fn test_send_raw_transaction_exceed_max_priority_fee_per_gas(#[future] kat
 async fn test_send_raw_transaction_exceed_gas_limit(#[future] katana: Katana, _setup: ()) {
     // Given
     let eth_provider = katana.eth_provider();
+    let eth_client = katana.eth_client();
     let chain_id = eth_provider.chain_id().await.unwrap_or_default().unwrap_or_default().to();
 
     // Create a sample transaction
@@ -949,15 +953,15 @@ async fn test_send_raw_transaction_exceed_gas_limit(#[future] katana: Katana, _s
     let transaction_signed = TransactionSigned::from_transaction_and_signature(transaction, signature);
 
     // Retrieve the current size of the mempool
-    let mempool_size = eth_provider.mempool().unwrap().pool_size();
+    let mempool_size = eth_client.mempool().pool_size();
     // Assert that the number of pending and total transactions in the mempool is 0
     assert_eq!(mempool_size.pending, 0);
     assert_eq!(mempool_size.total, 0);
 
-    let _ = eth_provider.send_raw_transaction(transaction_signed.envelope_encoded()).await;
+    let _ = eth_client.send_raw_transaction(transaction_signed.envelope_encoded()).await;
 
     // Retrieve the current size of the mempool
-    let mempool_size_after_send = eth_provider.mempool().unwrap().pool_size();
+    let mempool_size_after_send = eth_client.mempool().pool_size();
     // Verify that the number of pending transactions in the mempool remains unchanged (0 tx)
     assert_eq!(mempool_size_after_send.pending, 0);
     assert_eq!(mempool_size_after_send.total, 0);
@@ -986,7 +990,7 @@ async fn test_send_raw_transaction_pre_eip_155(#[future] katana: Katana, _setup:
     let random_hash = B256::random();
     std::env::set_var("WHITE_LISTED_EIP_155_TRANSACTION_HASHES", format!("{hash}, {random_hash}"));
 
-    let mempool_size = eth_provider.mempool().unwrap().pool_size();
+    let mempool_size = eth_client.mempool().pool_size();
     // Assert that the number of pending and total transactions in the mempool is 0
     assert_eq!(mempool_size.pending, 0);
     assert_eq!(mempool_size.total, 0);
@@ -1000,7 +1004,7 @@ async fn test_send_raw_transaction_pre_eip_155(#[future] katana: Katana, _setup:
     let bytes = tx_hash.0;
     let starknet_tx_hash = Felt::from_bytes_be(&bytes);
 
-    let mempool_size_after_send = eth_provider.mempool().unwrap().pool_size();
+    let mempool_size_after_send = eth_client.mempool().pool_size();
     // Assert that the number of pending transactions in the mempool is 1
     assert_eq!(mempool_size_after_send.pending, 1);
     assert_eq!(mempool_size_after_send.total, 1);
@@ -1040,7 +1044,7 @@ async fn test_send_raw_transaction_wrong_signature(#[future] katana: Katana, _se
     // Set an incorrect signature
     transaction_signed.signature = Signature::default();
 
-    let mempool_size = eth_provider.mempool().unwrap().pool_size();
+    let mempool_size = eth_client.mempool().pool_size();
     // Assert that the number of pending and total transactions in the mempool is 0
     assert_eq!(mempool_size.pending, 0);
     assert_eq!(mempool_size.total, 0);
@@ -1055,7 +1059,7 @@ async fn test_send_raw_transaction_wrong_signature(#[future] katana: Katana, _se
     // Assert that no transaction is found
     assert!(tx.is_none());
 
-    let mempool_size_after_send = eth_provider.mempool().unwrap().pool_size();
+    let mempool_size_after_send = eth_client.mempool().pool_size();
     // Verify that the number of pending transactions in the mempool remains unchanged (0 tx)
     assert_eq!(mempool_size_after_send.pending, 0);
     assert_eq!(mempool_size_after_send.total, 0);
@@ -1066,7 +1070,7 @@ async fn test_send_raw_transaction_wrong_signature(#[future] katana: Katana, _se
 #[tokio::test(flavor = "multi_thread")]
 async fn test_send_raw_transaction_wrong_chain_id(#[future] katana: Katana, _setup: ()) {
     // Given
-    let eth_provider = katana.eth_provider();
+    let eth_client = katana.eth_client();
     let wrong_chain_id = 999; // An arbitrary wrong chain ID
 
     // Create a transaction with the wrong chain ID
@@ -1086,18 +1090,18 @@ async fn test_send_raw_transaction_wrong_chain_id(#[future] katana: Katana, _set
     let signature = sign_message(katana.eoa().private_key(), transaction.signature_hash()).unwrap();
     let transaction_signed = TransactionSigned::from_transaction_and_signature(transaction, signature);
 
-    let mempool_size = eth_provider.mempool().unwrap().pool_size();
+    let mempool_size = eth_client.mempool().pool_size();
     // Assert that the number of pending and total transactions in the mempool is 0
     assert_eq!(mempool_size.pending, 0);
     assert_eq!(mempool_size.total, 0);
 
     // Attempt to send the transaction
-    let result = eth_provider.send_raw_transaction(transaction_signed.envelope_encoded()).await;
+    let result = eth_client.send_raw_transaction(transaction_signed.envelope_encoded()).await;
 
     // Then
     assert!(result.is_err()); // Ensure the transaction is rejected
 
-    let mempool_size_after_send = eth_provider.mempool().unwrap().pool_size();
+    let mempool_size_after_send = eth_client.mempool().pool_size();
     // Verify that the number of pending transactions in the mempool remains unchanged (0 tx)
     assert_eq!(mempool_size_after_send.pending, 0);
     assert_eq!(mempool_size_after_send.total, 0);
@@ -1109,6 +1113,7 @@ async fn test_send_raw_transaction_wrong_chain_id(#[future] katana: Katana, _set
 async fn test_send_raw_transaction_insufficient_balance(#[future] katana: Katana, _setup: ()) {
     // Given
     let eth_provider = katana.eth_provider();
+    let eth_client = katana.eth_client();
     let eoa = katana.eoa();
     let chain_id = eth_provider.chain_id().await.unwrap().unwrap_or_default().to();
 
@@ -1129,15 +1134,15 @@ async fn test_send_raw_transaction_insufficient_balance(#[future] katana: Katana
     let signature = sign_message(eoa.private_key(), transaction.signature_hash()).unwrap();
     let transaction_signed = TransactionSigned::from_transaction_and_signature(transaction, signature);
 
-    let mempool_size = eth_provider.mempool().unwrap().pool_size();
+    let mempool_size = eth_client.mempool().pool_size();
     // Assert that the number of pending and total transactions in the mempool is 0
     assert_eq!(mempool_size.pending, 0);
     assert_eq!(mempool_size.total, 0);
 
     // Attempt to send the transaction
-    let _ = eth_provider.send_raw_transaction(transaction_signed.envelope_encoded()).await;
+    let _ = eth_client.send_raw_transaction(transaction_signed.envelope_encoded()).await;
 
-    let mempool_size_after_send = eth_provider.mempool().unwrap().pool_size();
+    let mempool_size_after_send = eth_client.mempool().pool_size();
     // Verify that the number of pending transactions in the mempool remains unchanged (0 tx)
     assert_eq!(mempool_size_after_send.pending, 0);
     assert_eq!(mempool_size_after_send.total, 0);

--- a/tests/tests/kakarot_api.rs
+++ b/tests/tests/kakarot_api.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::used_underscore_binding)]
 #![cfg(feature = "testing")]
 use kakarot_rpc::{
+    client::KakarotTransactions,
     providers::eth_provider::{
         constant::Constant, database::types::transaction::StoredPendingTransaction, ChainProvider,
     },
@@ -10,7 +11,7 @@ use kakarot_rpc::{
         katana::Katana,
         rpc::{start_kakarot_rpc_server, RawRpcParamsBuilder},
     },
-};use kakarot_rpc::client::KakarotTransactions;
+};
 use reth_primitives::{sign_message, Address, Bytes, Transaction, TransactionSigned, TxEip1559, TxKind, B256, U256};
 use rstest::*;
 use serde_json::Value;

--- a/tests/tests/kakarot_api.rs
+++ b/tests/tests/kakarot_api.rs
@@ -2,7 +2,7 @@
 #![cfg(feature = "testing")]
 use kakarot_rpc::{
     providers::eth_provider::{
-        constant::Constant, database::types::transaction::StoredPendingTransaction, ChainProvider, TransactionProvider,
+        constant::Constant, database::types::transaction::StoredPendingTransaction, ChainProvider,
     },
     test_utils::{
         eoa::Eoa,
@@ -10,11 +10,12 @@ use kakarot_rpc::{
         katana::Katana,
         rpc::{start_kakarot_rpc_server, RawRpcParamsBuilder},
     },
-};
+};use kakarot_rpc::client::KakarotTransactions;
 use reth_primitives::{sign_message, Address, Bytes, Transaction, TransactionSigned, TxEip1559, TxKind, B256, U256};
 use rstest::*;
 use serde_json::Value;
 use std::str::FromStr;
+
 #[rstest]
 #[awt]
 #[tokio::test(flavor = "multi_thread")]
@@ -23,6 +24,7 @@ async fn test_kakarot_get_starknet_transaction_hash(#[future] katana: Katana, _s
         start_kakarot_rpc_server(&katana).await.expect("Error setting up Kakarot RPC server");
 
     let eth_provider = katana.eth_provider();
+    let eth_client = katana.eth_client();
     let chain_id = eth_provider.chain_id().await.unwrap_or_default().unwrap_or_default().to();
 
     // Create a sample transaction
@@ -43,7 +45,7 @@ async fn test_kakarot_get_starknet_transaction_hash(#[future] katana: Katana, _s
     let transaction_signed = TransactionSigned::from_transaction_and_signature(transaction, signature);
 
     // Send the transaction
-    let tx_return = eth_provider
+    let tx_return = eth_client
         .send_raw_transaction(transaction_signed.envelope_encoded())
         .await
         .expect("failed to send transaction");

--- a/tests/tests/trace_api.rs
+++ b/tests/tests/trace_api.rs
@@ -52,7 +52,8 @@ pub async fn tracing(
     let eoa = katana.eoa();
     let eoa_address = eoa.evm_address().expect("Failed to get eoa address");
     let nonce: u64 = eoa.nonce().await.expect("Failed to get nonce").to();
-    let chain_id = eoa.eth_provider().chain_id().await.expect("Failed to get chain id").unwrap_or_default().to();
+    let chain_id =
+        eoa.eth_client().eth_provider().chain_id().await.expect("Failed to get chain id").unwrap_or_default().to();
 
     // Push 10 RPC transactions into the database.
     let mut txs = Vec::with_capacity(TRACING_TRANSACTIONS_COUNT);

--- a/tests/tests/tracer.rs
+++ b/tests/tests/tracer.rs
@@ -52,7 +52,8 @@ pub async fn tracing(
     let eoa = katana.eoa();
     let eoa_address = eoa.evm_address().expect("Failed to get eoa address");
     let nonce: u64 = eoa.nonce().await.expect("Failed to get nonce").to();
-    let chain_id = eoa.eth_provider().chain_id().await.expect("Failed to get chain id").unwrap_or_default().to();
+    let chain_id =
+        eoa.eth_client().eth_provider().chain_id().await.expect("Failed to get chain id").unwrap_or_default().to();
 
     // Push 10 RPC transactions into the database.
     let mut txs = Vec::with_capacity(TRACING_TRANSACTIONS_COUNT);


### PR DESCRIPTION
**Context:**

As a follow-up to #1321, this pull request addresses the circular dependency between the mempool and the provider.

**Changes Introduced:**

1. **Creation of `KakarotTransactions` Trait:**
   - The `send_raw_transaction` method has been moved to a new trait called `KakarotTransactions`.
   - This trait is implemented for our `EthClient`.
   - This design is inspired by the `FullEthApi` trait in the [reth project](https://github.com/paradigmxyz/reth/blob/6f086d1060ede0a015b9257053218d010a7c6c70/crates/rpc/rpc-eth-api/src/helpers/mod.rs#L55-L66), where the trait is implemented for `EthApi`, which itself contains both a provider and a pool.

2. **Separation of Implementations:**
   - By upstreaming the `send_raw_transaction` method, we start to differentiate between the Client's implementations and those of the provider.
   - The provider, being lower in the hierarchy, serves the client. This refactor makes it clear that the pool only needs access to the provider, not the entire client.

3. **Elimination of Circular Dependency:**
   - The previous circular dependency between the pool and the provider is removed. Now, the pool relies solely on the provider, not the full client.
