### PR TITLE
Fix indexer's sepolia docker config

### DIFF
--- a/docker-compose.sepolia.yaml
+++ b/docker-compose.sepolia.yaml
@@ -135,11 +135,11 @@ services:
       # Whitelist environment variables
       - ALLOW_ENV_FROM_ENV=DEBUG,APIBARA_AUTH_TOKEN,STARTING_BLOCK,STREAM_URL,SINK_TYPE,MONGO_CONNECTION_STRING,MONGO_DATABASE_NAME,STARKNET_NETWORK,KAKAROT_ADDRESS,ALLOW_NET,MONGO_REPLACE_DATA_INSIDE_TRANSACTION,DEFAULT_BLOCK_GAS_LIMIT
       - DEBUG=""
-      - APIBARA_AUTH_TOKEN=${APIBARA_AUTH_TOKEN}
+      - AUTH_TOKEN=${APIBARA_AUTH_TOKEN}
       - MONGO_CONNECTION_STRING=mongodb://mongo:mongo@mongo:27017
       - MONGO_DATABASE_NAME=kakarot-local
       - STARTING_BLOCK=220000
-      - STREAM_URL=sepolia.starknet.a5a.ch
+      - STREAM_URL=https://sepolia.starknet.a5a.ch
       - SINK_TYPE=mongo
       - STARKNET_NETWORK=https://juno-kakarot-sepolia.karnot.xyz/
       - ALLOW_NET=

--- a/indexer/src/constants.ts
+++ b/indexer/src/constants.ts
@@ -30,9 +30,6 @@ export const STARTING_BLOCK = (() => {
     })();
 })();
 
-// Get authentication token from Apibara or returns an empty string if the value is null or undefined
-export const AUTH_TOKEN = Deno.env.get("APIBARA_AUTH_TOKEN") ?? "";
-
 // Get stream URL or returns "http://localhost:7171" if the value is null or undefined
 export const STREAM_URL = Deno.env.get("STREAM_URL") ?? "http://localhost:7171";
 

--- a/indexer/src/main.ts
+++ b/indexer/src/main.ts
@@ -8,7 +8,6 @@ import {
 
 // Constants
 import {
-  AUTH_TOKEN,
   NULL_HASH,
   SINK_OPTIONS,
   SINK_TYPE,
@@ -52,7 +51,6 @@ import {
 
 export const config: Config<NetworkOptions, SinkOptions> = {
   streamUrl: STREAM_URL,
-  authToken: AUTH_TOKEN,
   startingBlock: STARTING_BLOCK,
   network: "starknet",
   finality: "DATA_STATUS_PENDING",


### PR DESCRIPTION
This PR fixes a couple of small configuration errors in the Sepolia docker-compose file:

 - Rename `APIBARA_AUTH_TOKEN` to `AUTH_TOKEN`.
 - The `STREAM_URL` requires the protocol (in this case `https`) to know whether or not to enable TLS.

Time spent on this PR: 10 minutes

# Pull Request type

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Testing

# What is the new behavior?

The Sepolia docker compose setup is now indexing data.

# Does this introduce a breaking change?

- [ ] Yes
- [x] No
