### PR TITLE
use `RpcResult` instead of type alias

### DIFF
--- a/src/eth_rpc/api/alchemy_api.rs
+++ b/src/eth_rpc/api/alchemy_api.rs
@@ -1,16 +1,16 @@
 use crate::models::token::{TokenBalances, TokenMetadata};
 use alloy_primitives::{Address, U256};
-use jsonrpsee::{core::RpcResult as Result, proc_macros::rpc};
+use jsonrpsee::{core::RpcResult, proc_macros::rpc};
 
 #[rpc(server, namespace = "alchemy")]
 #[async_trait]
 pub trait AlchemyApi {
     #[method(name = "getTokenBalances")]
-    async fn token_balances(&self, address: Address, contract_addresses: Vec<Address>) -> Result<TokenBalances>;
+    async fn token_balances(&self, address: Address, contract_addresses: Vec<Address>) -> RpcResult<TokenBalances>;
 
     #[method(name = "getTokenMetadata")]
-    async fn token_metadata(&self, contract_address: Address) -> Result<TokenMetadata>;
+    async fn token_metadata(&self, contract_address: Address) -> RpcResult<TokenMetadata>;
 
     #[method(name = "getTokenAllowance")]
-    async fn token_allowance(&self, contract_address: Address, owner: Address, spender: Address) -> Result<U256>;
+    async fn token_allowance(&self, contract_address: Address, owner: Address, spender: Address) -> RpcResult<U256>;
 }

--- a/src/eth_rpc/api/debug_api.rs
+++ b/src/eth_rpc/api/debug_api.rs
@@ -1,7 +1,7 @@
 use alloy_primitives::{Bytes, B256};
 use alloy_rpc_types::{BlockId, BlockNumberOrTag, TransactionRequest};
 use alloy_rpc_types_trace::geth::{GethDebugTracingCallOptions, GethDebugTracingOptions, GethTrace, TraceResult};
-use jsonrpsee::{core::RpcResult as Result, proc_macros::rpc};
+use jsonrpsee::{core::RpcResult, proc_macros::rpc};
 
 /// Debug API
 /// Taken from Reth's DebugApi trait:
@@ -11,25 +11,25 @@ use jsonrpsee::{core::RpcResult as Result, proc_macros::rpc};
 pub trait DebugApi {
     /// Returns an RLP-encoded header.
     #[method(name = "getRawHeader")]
-    async fn raw_header(&self, block_id: BlockId) -> Result<Bytes>;
+    async fn raw_header(&self, block_id: BlockId) -> RpcResult<Bytes>;
 
     /// Returns an RLP-encoded block.
     #[method(name = "getRawBlock")]
-    async fn raw_block(&self, block_id: BlockId) -> Result<Bytes>;
+    async fn raw_block(&self, block_id: BlockId) -> RpcResult<Bytes>;
 
     /// Returns a EIP-2718 binary-encoded transaction.
     ///
     /// If this is a pooled EIP-4844 transaction, the blob sidecar is included.
     #[method(name = "getRawTransaction")]
-    async fn raw_transaction(&self, hash: B256) -> Result<Option<Bytes>>;
+    async fn raw_transaction(&self, hash: B256) -> RpcResult<Option<Bytes>>;
 
     /// Returns an array of EIP-2718 binary-encoded transactions for the given [BlockId].
     #[method(name = "getRawTransactions")]
-    async fn raw_transactions(&self, block_id: BlockId) -> Result<Vec<Bytes>>;
+    async fn raw_transactions(&self, block_id: BlockId) -> RpcResult<Vec<Bytes>>;
 
     /// Returns an array of EIP-2718 binary-encoded receipts.
     #[method(name = "getRawReceipts")]
-    async fn raw_receipts(&self, block_id: BlockId) -> Result<Vec<Bytes>>;
+    async fn raw_receipts(&self, block_id: BlockId) -> RpcResult<Vec<Bytes>>;
 
     /// Returns the Geth debug trace for the given block number.
     #[method(name = "traceBlockByNumber")]
@@ -37,7 +37,7 @@ pub trait DebugApi {
         &self,
         block_number: BlockNumberOrTag,
         opts: Option<GethDebugTracingOptions>,
-    ) -> Result<Vec<TraceResult>>;
+    ) -> RpcResult<Vec<TraceResult>>;
 
     /// Returns the Geth debug trace for the given block hash.
     #[method(name = "traceBlockByHash")]
@@ -45,7 +45,7 @@ pub trait DebugApi {
         &self,
         block_hash: B256,
         opts: Option<GethDebugTracingOptions>,
-    ) -> Result<Vec<TraceResult>>;
+    ) -> RpcResult<Vec<TraceResult>>;
 
     /// Returns the Geth debug trace for the given transaction hash.
     #[method(name = "traceTransaction")]
@@ -53,7 +53,7 @@ pub trait DebugApi {
         &self,
         transaction_hash: B256,
         opts: Option<GethDebugTracingOptions>,
-    ) -> Result<GethTrace>;
+    ) -> RpcResult<GethTrace>;
 
     /// Runs an `eth_call` within the context of a given block execution and returns the Geth debug trace.
     #[method(name = "traceCall")]
@@ -62,5 +62,5 @@ pub trait DebugApi {
         request: TransactionRequest,
         block_number: Option<BlockId>,
         opts: Option<GethDebugTracingCallOptions>,
-    ) -> Result<GethTrace>;
+    ) -> RpcResult<GethTrace>;
 }

--- a/src/eth_rpc/api/eth_api.rs
+++ b/src/eth_rpc/api/eth_api.rs
@@ -5,7 +5,7 @@ use alloy_rpc_types::{
     TransactionReceipt, TransactionRequest, Work,
 };
 use alloy_serde::WithOtherFields;
-use jsonrpsee::{core::RpcResult as Result, proc_macros::rpc};
+use jsonrpsee::{core::RpcResult, proc_macros::rpc};
 use reth_primitives::{BlockId, BlockNumberOrTag};
 
 /// Ethereum JSON-RPC API Trait
@@ -15,23 +15,23 @@ use reth_primitives::{BlockId, BlockNumberOrTag};
 #[async_trait]
 pub trait EthApi {
     #[method(name = "blockNumber")]
-    async fn block_number(&self) -> Result<U64>;
+    async fn block_number(&self) -> RpcResult<U64>;
 
     /// Returns an object with data about the sync status or false.
     #[method(name = "syncing")]
-    async fn syncing(&self) -> Result<SyncStatus>;
+    async fn syncing(&self) -> RpcResult<SyncStatus>;
 
     /// Returns the client coinbase address.
     #[method(name = "coinbase")]
-    async fn coinbase(&self) -> Result<Address>;
+    async fn coinbase(&self) -> RpcResult<Address>;
 
     /// Returns a list of addresses owned by client.
     #[method(name = "accounts")]
-    async fn accounts(&self) -> Result<Vec<Address>>;
+    async fn accounts(&self) -> RpcResult<Vec<Address>>;
 
     /// Returns the chain ID of the current network.
     #[method(name = "chainId")]
-    async fn chain_id(&self) -> Result<Option<U64>>;
+    async fn chain_id(&self) -> RpcResult<Option<U64>>;
 
     /// Returns information about a block by hash.
     #[method(name = "getBlockByHash")]
@@ -39,7 +39,7 @@ pub trait EthApi {
         &self,
         hash: B256,
         full: bool,
-    ) -> Result<Option<WithOtherFields<Block<WithOtherFields<EthTransaction>>>>>;
+    ) -> RpcResult<Option<WithOtherFields<Block<WithOtherFields<EthTransaction>>>>>;
 
     /// Returns information about a block by number.
     #[method(name = "getBlockByNumber")]
@@ -47,23 +47,23 @@ pub trait EthApi {
         &self,
         number: BlockNumberOrTag,
         full: bool,
-    ) -> Result<Option<WithOtherFields<Block<WithOtherFields<EthTransaction>>>>>;
+    ) -> RpcResult<Option<WithOtherFields<Block<WithOtherFields<EthTransaction>>>>>;
 
     /// Returns the number of transactions in a block from a block matching the given block hash.
     #[method(name = "getBlockTransactionCountByHash")]
-    async fn block_transaction_count_by_hash(&self, hash: B256) -> Result<Option<U256>>;
+    async fn block_transaction_count_by_hash(&self, hash: B256) -> RpcResult<Option<U256>>;
 
     /// Returns the number of transactions in a block matching the given block number.
     #[method(name = "getBlockTransactionCountByNumber")]
-    async fn block_transaction_count_by_number(&self, number: BlockNumberOrTag) -> Result<Option<U256>>;
+    async fn block_transaction_count_by_number(&self, number: BlockNumberOrTag) -> RpcResult<Option<U256>>;
 
     /// Returns the number of uncles in a block from a block matching the given block hash.
     #[method(name = "getUncleCountByBlockHash")]
-    async fn block_uncles_count_by_block_hash(&self, hash: B256) -> Result<U256>;
+    async fn block_uncles_count_by_block_hash(&self, hash: B256) -> RpcResult<U256>;
 
     /// Returns the number of uncles in a block with given block number.
     #[method(name = "getUncleCountByBlockNumber")]
-    async fn block_uncles_count_by_block_number(&self, number: BlockNumberOrTag) -> Result<U256>;
+    async fn block_uncles_count_by_block_number(&self, number: BlockNumberOrTag) -> RpcResult<U256>;
 
     /// Returns an uncle block of the given block and index.
     #[method(name = "getUncleByBlockHashAndIndex")]
@@ -71,7 +71,7 @@ pub trait EthApi {
         &self,
         hash: B256,
         index: Index,
-    ) -> Result<Option<WithOtherFields<Block<WithOtherFields<EthTransaction>>>>>;
+    ) -> RpcResult<Option<WithOtherFields<Block<WithOtherFields<EthTransaction>>>>>;
 
     /// Returns an uncle block of the given block and index.
     #[method(name = "getUncleByBlockNumberAndIndex")]
@@ -79,11 +79,11 @@ pub trait EthApi {
         &self,
         number: BlockNumberOrTag,
         index: Index,
-    ) -> Result<Option<WithOtherFields<Block<WithOtherFields<EthTransaction>>>>>;
+    ) -> RpcResult<Option<WithOtherFields<Block<WithOtherFields<EthTransaction>>>>>;
 
     /// Returns the information about a transaction requested by transaction hash.
     #[method(name = "getTransactionByHash")]
-    async fn transaction_by_hash(&self, hash: B256) -> Result<Option<WithOtherFields<EthTransaction>>>;
+    async fn transaction_by_hash(&self, hash: B256) -> RpcResult<Option<WithOtherFields<EthTransaction>>>;
 
     /// Returns information about a transaction by block hash and transaction index position.
     #[method(name = "getTransactionByBlockHashAndIndex")]
@@ -91,7 +91,7 @@ pub trait EthApi {
         &self,
         hash: B256,
         index: Index,
-    ) -> Result<Option<WithOtherFields<EthTransaction>>>;
+    ) -> RpcResult<Option<WithOtherFields<EthTransaction>>>;
 
     /// Returns information about a transaction by block number and transaction index position.
     #[method(name = "getTransactionByBlockNumberAndIndex")]
@@ -99,31 +99,31 @@ pub trait EthApi {
         &self,
         number: BlockNumberOrTag,
         index: Index,
-    ) -> Result<Option<WithOtherFields<EthTransaction>>>;
+    ) -> RpcResult<Option<WithOtherFields<EthTransaction>>>;
 
     /// Returns the receipt of a transaction by transaction hash.
     #[method(name = "getTransactionReceipt")]
-    async fn transaction_receipt(&self, hash: B256) -> Result<Option<WithOtherFields<TransactionReceipt>>>;
+    async fn transaction_receipt(&self, hash: B256) -> RpcResult<Option<WithOtherFields<TransactionReceipt>>>;
 
     /// Returns the balance of the account of given address.
     #[method(name = "getBalance")]
-    async fn balance(&self, address: Address, block_number: Option<BlockId>) -> Result<U256>;
+    async fn balance(&self, address: Address, block_number: Option<BlockId>) -> RpcResult<U256>;
 
     /// Returns the value from a storage position at a given address
     #[method(name = "getStorageAt")]
-    async fn storage_at(&self, address: Address, index: JsonStorageKey, block_id: Option<BlockId>) -> Result<B256>;
+    async fn storage_at(&self, address: Address, index: JsonStorageKey, block_id: Option<BlockId>) -> RpcResult<B256>;
 
     /// Returns the number of transactions sent from an address at given block number.
     #[method(name = "getTransactionCount")]
-    async fn transaction_count(&self, address: Address, block_id: Option<BlockId>) -> Result<U256>;
+    async fn transaction_count(&self, address: Address, block_id: Option<BlockId>) -> RpcResult<U256>;
 
     /// Returns code at a given address at given block number.
     #[method(name = "getCode")]
-    async fn get_code(&self, address: Address, block_id: Option<BlockId>) -> Result<Bytes>;
+    async fn get_code(&self, address: Address, block_id: Option<BlockId>) -> RpcResult<Bytes>;
 
     /// Returns the logs corresponding to the given filter object.
     #[method(name = "getLogs")]
-    async fn get_logs(&self, filter: Filter) -> Result<FilterChanges>;
+    async fn get_logs(&self, filter: Filter) -> RpcResult<FilterChanges>;
 
     /// Executes a new message call immediately without creating a transaction on the block chain.
     #[method(name = "call")]
@@ -133,7 +133,7 @@ pub trait EthApi {
         block_id: Option<BlockId>,
         state_overrides: Option<StateOverride>,
         block_overrides: Option<Box<BlockOverrides>>,
-    ) -> Result<Bytes>;
+    ) -> RpcResult<Bytes>;
 
     /// Generates an access list for a transaction.
     ///
@@ -154,16 +154,16 @@ pub trait EthApi {
         &self,
         request: TransactionRequest,
         block_id: Option<BlockId>,
-    ) -> Result<AccessListResult>;
+    ) -> RpcResult<AccessListResult>;
 
     /// Generates and returns an estimate of how much gas is necessary to allow the transaction to
     /// complete.
     #[method(name = "estimateGas")]
-    async fn estimate_gas(&self, request: TransactionRequest, block_id: Option<BlockId>) -> Result<U256>;
+    async fn estimate_gas(&self, request: TransactionRequest, block_id: Option<BlockId>) -> RpcResult<U256>;
 
     /// Returns the current price per gas in wei.
     #[method(name = "gasPrice")]
-    async fn gas_price(&self) -> Result<U256>;
+    async fn gas_price(&self) -> RpcResult<U256>;
 
     /// Returns the Transaction fee history
     ///
@@ -178,59 +178,59 @@ pub trait EthApi {
         block_count: U64,
         newest_block: BlockNumberOrTag,
         reward_percentiles: Option<Vec<f64>>,
-    ) -> Result<FeeHistory>;
+    ) -> RpcResult<FeeHistory>;
 
     /// Returns the current maxPriorityFeePerGas per gas in wei.
     #[method(name = "maxPriorityFeePerGas")]
-    async fn max_priority_fee_per_gas(&self) -> Result<U256>;
+    async fn max_priority_fee_per_gas(&self) -> RpcResult<U256>;
 
     /// Introduced in EIP-4844, returns the current blob base fee in wei.
     #[method(name = "blobBaseFee")]
-    async fn blob_base_fee(&self) -> Result<U256>;
+    async fn blob_base_fee(&self) -> RpcResult<U256>;
 
     /// Returns whether the client is actively mining new blocks.
     #[method(name = "mining")]
-    async fn mining(&self) -> Result<bool>;
+    async fn mining(&self) -> RpcResult<bool>;
 
     /// Returns the number of hashes per second that the node is mining with.
     #[method(name = "hashrate")]
-    async fn hashrate(&self) -> Result<U256>;
+    async fn hashrate(&self) -> RpcResult<U256>;
 
     /// Returns the hash of the current block, the seedHash, and the boundary condition to be met
     /// (“target”)
     #[method(name = "getWork")]
-    async fn get_work(&self) -> Result<Work>;
+    async fn get_work(&self) -> RpcResult<Work>;
 
     /// Used for submitting mining hashrate.
     #[method(name = "submitHashrate")]
-    async fn submit_hashrate(&self, hashrate: U256, id: B256) -> Result<bool>;
+    async fn submit_hashrate(&self, hashrate: U256, id: B256) -> RpcResult<bool>;
 
     /// Used for submitting a proof-of-work solution.
     #[method(name = "submitWork")]
-    async fn submit_work(&self, nonce: B64, pow_hash: B256, mix_digest: B256) -> Result<bool>;
+    async fn submit_work(&self, nonce: B64, pow_hash: B256, mix_digest: B256) -> RpcResult<bool>;
 
     /// Sends transaction; will block waiting for signer to return the
     /// transaction hash.
     #[method(name = "sendTransaction")]
-    async fn send_transaction(&self, request: TransactionRequest) -> Result<B256>;
+    async fn send_transaction(&self, request: TransactionRequest) -> RpcResult<B256>;
 
     /// Sends signed transaction, returning its hash.
     #[method(name = "sendRawTransaction")]
-    async fn send_raw_transaction(&self, bytes: Bytes) -> Result<B256>;
+    async fn send_raw_transaction(&self, bytes: Bytes) -> RpcResult<B256>;
 
     /// Returns an Ethereum specific signature with: sign(keccak256("\x19Ethereum Signed Message:\n"
     /// + len(message) + message))).
     #[method(name = "sign")]
-    async fn sign(&self, address: Address, message: Bytes) -> Result<Bytes>;
+    async fn sign(&self, address: Address, message: Bytes) -> RpcResult<Bytes>;
 
     /// Signs a transaction that can be submitted to the network at a later time using with
     /// `sendRawTransaction.`
     #[method(name = "signTransaction")]
-    async fn sign_transaction(&self, transaction: TransactionRequest) -> Result<Bytes>;
+    async fn sign_transaction(&self, transaction: TransactionRequest) -> RpcResult<Bytes>;
 
     /// Signs data via [EIP-712](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-712.md).
     #[method(name = "signTypedData")]
-    async fn sign_typed_data(&self, address: Address, data: serde_json::Value) -> Result<Bytes>;
+    async fn sign_typed_data(&self, address: Address, data: serde_json::Value) -> RpcResult<Bytes>;
 
     /// Returns the account and storage values of the specified account including the Merkle-proof.
     /// This call can be used to verify that the data you are pulling from is not tampered with.
@@ -240,36 +240,36 @@ pub trait EthApi {
         address: Address,
         keys: Vec<B256>,
         block_id: Option<BlockId>,
-    ) -> Result<EIP1186AccountProofResponse>;
+    ) -> RpcResult<EIP1186AccountProofResponse>;
 
     /// Creates a filter object, based on filter options, to notify when the state changes (logs).
     #[method(name = "newFilter")]
-    async fn new_filter(&self, filter: Filter) -> Result<U64>;
+    async fn new_filter(&self, filter: Filter) -> RpcResult<U64>;
 
     /// Creates a filter in the node, to notify when a new block arrives.
     #[method(name = "newBlockFilter")]
-    async fn new_block_filter(&self) -> Result<U64>;
+    async fn new_block_filter(&self) -> RpcResult<U64>;
 
     /// Creates a filter in the node, to notify when new pending transactions arrive.
     #[method(name = "newPendingTransactionFilter")]
-    async fn new_pending_transaction_filter(&self) -> Result<U64>;
+    async fn new_pending_transaction_filter(&self) -> RpcResult<U64>;
 
     /// Destroys a filter based on filter ID
     #[method(name = "uninstallFilter")]
-    async fn uninstall_filter(&self, id: U64) -> Result<bool>;
+    async fn uninstall_filter(&self, id: U64) -> RpcResult<bool>;
 
     /// Returns a list of all logs based on filter ID since the last log retrieval
     #[method(name = "getFilterChanges")]
-    async fn get_filter_changes(&self, id: U64) -> Result<FilterChanges>;
+    async fn get_filter_changes(&self, id: U64) -> RpcResult<FilterChanges>;
 
     /// Returns a list of all logs based on filter ID
     #[method(name = "getFilterLogs")]
-    async fn get_filter_logs(&self, id: U64) -> Result<FilterChanges>;
+    async fn get_filter_logs(&self, id: U64) -> RpcResult<FilterChanges>;
 
     /// Returns all transaction receipts for a given block.
     #[method(name = "getBlockReceipts")]
     async fn block_receipts(
         &self,
         block_id: Option<BlockId>,
-    ) -> Result<Option<Vec<WithOtherFields<TransactionReceipt>>>>;
+    ) -> RpcResult<Option<Vec<WithOtherFields<TransactionReceipt>>>>;
 }

--- a/src/eth_rpc/api/kakarot_api.rs
+++ b/src/eth_rpc/api/kakarot_api.rs
@@ -1,9 +1,9 @@
 use crate::providers::eth_provider::constant::Constant;
-use jsonrpsee::{core::RpcResult as Result, proc_macros::rpc};
+use jsonrpsee::{core::RpcResult, proc_macros::rpc};
 
 #[rpc(server, namespace = "kakarot")]
 #[async_trait]
 pub trait KakarotApi {
     #[method(name = "getConfig")]
-    async fn get_config(&self) -> Result<Constant>;
+    async fn get_config(&self) -> RpcResult<Constant>;
 }

--- a/src/eth_rpc/api/net_api.rs
+++ b/src/eth_rpc/api/net_api.rs
@@ -1,5 +1,5 @@
 use alloy_primitives::U64;
-use jsonrpsee::{core::RpcResult as Result, proc_macros::rpc};
+use jsonrpsee::{core::RpcResult, proc_macros::rpc};
 
 // TODO: Define and implement of methods of Net API
 #[rpc(server, namespace = "net")]
@@ -7,19 +7,19 @@ use jsonrpsee::{core::RpcResult as Result, proc_macros::rpc};
 pub trait NetApi {
     /// Returns the protocol version encoded as a string.
     #[method(name = "version")]
-    async fn version(&self) -> Result<U64>;
+    async fn version(&self) -> RpcResult<U64>;
 
     /// Returns number of peers connected to node.
     #[method(name = "peerCount")]
-    fn peer_count(&self) -> Result<U64>;
+    fn peer_count(&self) -> RpcResult<U64>;
 
     /// Returns true if client is actively listening for network connections.
     /// Otherwise false.
     #[method(name = "listening")]
-    fn listening(&self) -> Result<bool>;
+    fn listening(&self) -> RpcResult<bool>;
 
     /// Returns true if Kakarot RPC_URL is reachable.
     /// Otherwise throw an EthApiError.
     #[method(name = "health")]
-    async fn health(&self) -> Result<bool>;
+    async fn health(&self) -> RpcResult<bool>;
 }

--- a/src/eth_rpc/api/trace_api.rs
+++ b/src/eth_rpc/api/trace_api.rs
@@ -1,6 +1,6 @@
 use alloy_rpc_types::BlockId;
 use alloy_rpc_types_trace::parity::LocalizedTransactionTrace;
-use jsonrpsee::{core::RpcResult as Result, proc_macros::rpc};
+use jsonrpsee::{core::RpcResult, proc_macros::rpc};
 
 /// Trace API
 #[rpc(server, namespace = "trace")]
@@ -8,5 +8,5 @@ use jsonrpsee::{core::RpcResult as Result, proc_macros::rpc};
 pub trait TraceApi {
     /// Returns the parity traces for the given block.
     #[method(name = "block")]
-    async fn trace_block(&self, block_id: BlockId) -> Result<Option<Vec<LocalizedTransactionTrace>>>;
+    async fn trace_block(&self, block_id: BlockId) -> RpcResult<Option<Vec<LocalizedTransactionTrace>>>;
 }

--- a/src/eth_rpc/api/web3_api.rs
+++ b/src/eth_rpc/api/web3_api.rs
@@ -1,14 +1,14 @@
 use alloy_primitives::{Bytes, B256};
-use jsonrpsee::{core::RpcResult as Result, proc_macros::rpc};
+use jsonrpsee::{core::RpcResult, proc_macros::rpc};
 
 #[rpc(server, namespace = "web3")]
 #[async_trait]
 pub trait Web3Api {
     /// Returns the client version of the running Kakarot RPC
     #[method(name = "clientVersion")]
-    fn client_version(&self) -> Result<String>;
+    fn client_version(&self) -> RpcResult<String>;
 
     /// Returns Keccak256 of some input value
     #[method(name = "sha3")]
-    fn sha3(&self, input: Bytes) -> Result<B256>;
+    fn sha3(&self, input: Bytes) -> RpcResult<B256>;
 }

--- a/src/eth_rpc/servers/alchemy_rpc.rs
+++ b/src/eth_rpc/servers/alchemy_rpc.rs
@@ -5,7 +5,7 @@ use crate::{
 };
 use alloy_primitives::{Address, U256};
 use async_trait::async_trait;
-use jsonrpsee::core::RpcResult as Result;
+use jsonrpsee::core::RpcResult;
 
 /// The RPC module for the Ethereum protocol required by Kakarot.
 #[derive(Debug)]
@@ -28,17 +28,17 @@ where
     AP: AlchemyProvider + Send + Sync + 'static,
 {
     #[tracing::instrument(skip(self, contract_addresses), ret, err)]
-    async fn token_balances(&self, address: Address, contract_addresses: Vec<Address>) -> Result<TokenBalances> {
+    async fn token_balances(&self, address: Address, contract_addresses: Vec<Address>) -> RpcResult<TokenBalances> {
         self.alchemy_provider.token_balances(address, contract_addresses).await.map_err(Into::into)
     }
 
     #[tracing::instrument(skip(self), ret, err)]
-    async fn token_metadata(&self, contract_address: Address) -> Result<TokenMetadata> {
+    async fn token_metadata(&self, contract_address: Address) -> RpcResult<TokenMetadata> {
         self.alchemy_provider.token_metadata(contract_address).await.map_err(Into::into)
     }
 
     #[tracing::instrument(skip(self), ret, err)]
-    async fn token_allowance(&self, contract_address: Address, owner: Address, spender: Address) -> Result<U256> {
+    async fn token_allowance(&self, contract_address: Address, owner: Address, spender: Address) -> RpcResult<U256> {
         self.alchemy_provider.token_allowance(contract_address, owner, spender).await.map_err(Into::into)
     }
 }

--- a/src/eth_rpc/servers/debug_rpc.rs
+++ b/src/eth_rpc/servers/debug_rpc.rs
@@ -2,7 +2,7 @@ use crate::{eth_rpc::api::debug_api::DebugApiServer, providers::debug_provider::
 use alloy_primitives::{Bytes, B256};
 use alloy_rpc_types::{BlockId, BlockNumberOrTag, TransactionRequest};
 use alloy_rpc_types_trace::geth::{GethDebugTracingCallOptions, GethDebugTracingOptions, GethTrace, TraceResult};
-use jsonrpsee::core::{async_trait, RpcResult as Result};
+use jsonrpsee::core::{async_trait, RpcResult};
 
 /// The RPC module for the implementing Net api
 #[derive(Debug)]
@@ -26,13 +26,13 @@ where
 {
     /// Returns a RLP-encoded header.
     #[tracing::instrument(skip(self), err)]
-    async fn raw_header(&self, block_id: BlockId) -> Result<Bytes> {
+    async fn raw_header(&self, block_id: BlockId) -> RpcResult<Bytes> {
         self.debug_provider.raw_header(block_id).await.map_err(Into::into)
     }
 
     /// Returns a RLP-encoded block.
     #[tracing::instrument(skip(self), err)]
-    async fn raw_block(&self, block_id: BlockId) -> Result<Bytes> {
+    async fn raw_block(&self, block_id: BlockId) -> RpcResult<Bytes> {
         self.debug_provider.raw_block(block_id).await.map_err(Into::into)
     }
 
@@ -40,19 +40,19 @@ where
     ///
     /// If this is a pooled EIP-4844 transaction, the blob sidecar is included.
     #[tracing::instrument(skip(self), err)]
-    async fn raw_transaction(&self, hash: B256) -> Result<Option<Bytes>> {
+    async fn raw_transaction(&self, hash: B256) -> RpcResult<Option<Bytes>> {
         self.debug_provider.raw_transaction(hash).await.map_err(Into::into)
     }
 
     /// Returns an array of EIP-2718 binary-encoded transactions for the given [BlockId].
     #[tracing::instrument(skip(self), err)]
-    async fn raw_transactions(&self, block_id: BlockId) -> Result<Vec<Bytes>> {
+    async fn raw_transactions(&self, block_id: BlockId) -> RpcResult<Vec<Bytes>> {
         self.debug_provider.raw_transactions(block_id).await.map_err(Into::into)
     }
 
     /// Returns an array of EIP-2718 binary-encoded receipts.
     #[tracing::instrument(skip(self), err)]
-    async fn raw_receipts(&self, block_id: BlockId) -> Result<Vec<Bytes>> {
+    async fn raw_receipts(&self, block_id: BlockId) -> RpcResult<Vec<Bytes>> {
         self.debug_provider.raw_receipts(block_id).await.map_err(Into::into)
     }
 
@@ -62,7 +62,7 @@ where
         &self,
         block_number: BlockNumberOrTag,
         opts: Option<GethDebugTracingOptions>,
-    ) -> Result<Vec<TraceResult>> {
+    ) -> RpcResult<Vec<TraceResult>> {
         self.debug_provider.trace_block_by_number(block_number, opts).await.map_err(Into::into)
     }
 
@@ -72,7 +72,7 @@ where
         &self,
         block_hash: B256,
         opts: Option<GethDebugTracingOptions>,
-    ) -> Result<Vec<TraceResult>> {
+    ) -> RpcResult<Vec<TraceResult>> {
         self.debug_provider.trace_block_by_hash(block_hash, opts).await.map_err(Into::into)
     }
 
@@ -82,7 +82,7 @@ where
         &self,
         transaction_hash: B256,
         opts: Option<GethDebugTracingOptions>,
-    ) -> Result<GethTrace> {
+    ) -> RpcResult<GethTrace> {
         self.debug_provider.trace_transaction(transaction_hash, opts).await.map_err(Into::into)
     }
 
@@ -93,7 +93,7 @@ where
         request: TransactionRequest,
         block_number: Option<BlockId>,
         opts: Option<GethDebugTracingCallOptions>,
-    ) -> Result<GethTrace> {
+    ) -> RpcResult<GethTrace> {
         self.debug_provider.trace_call(request, block_number, opts).await.map_err(Into::into)
     }
 }

--- a/src/eth_rpc/servers/eth_rpc.rs
+++ b/src/eth_rpc/servers/eth_rpc.rs
@@ -13,7 +13,7 @@ use alloy_rpc_types::{
     TransactionRequest, Work,
 };
 use alloy_serde::WithOtherFields;
-use jsonrpsee::core::{async_trait, RpcResult as Result};
+use jsonrpsee::core::{async_trait, RpcResult};
 use reth_primitives::{BlockId, BlockNumberOrTag};
 use serde_json::Value;
 use starknet::providers::Provider;
@@ -43,26 +43,26 @@ where
     SP: Provider + Clone + Send + Sync + 'static,
 {
     #[tracing::instrument(skip_all, ret, err)]
-    async fn block_number(&self) -> Result<U64> {
+    async fn block_number(&self) -> RpcResult<U64> {
         Ok(self.eth_client.eth_provider().block_number().await?)
     }
 
     #[tracing::instrument(skip_all, ret, err)]
-    async fn syncing(&self) -> Result<SyncStatus> {
+    async fn syncing(&self) -> RpcResult<SyncStatus> {
         Ok(self.eth_client.eth_provider().syncing().await?)
     }
 
-    async fn coinbase(&self) -> Result<Address> {
+    async fn coinbase(&self) -> RpcResult<Address> {
         Err(EthApiError::Unsupported("eth_coinbase").into())
     }
 
     #[tracing::instrument(skip_all, ret, err)]
-    async fn accounts(&self) -> Result<Vec<Address>> {
+    async fn accounts(&self) -> RpcResult<Vec<Address>> {
         Ok(Vec::new())
     }
 
     #[tracing::instrument(skip_all, ret, err)]
-    async fn chain_id(&self) -> Result<Option<U64>> {
+    async fn chain_id(&self) -> RpcResult<Option<U64>> {
         Ok(self.eth_client.eth_provider().chain_id().await?)
     }
 
@@ -71,7 +71,7 @@ where
         &self,
         hash: B256,
         full: bool,
-    ) -> Result<Option<WithOtherFields<Block<WithOtherFields<Transaction>>>>> {
+    ) -> RpcResult<Option<WithOtherFields<Block<WithOtherFields<Transaction>>>>> {
         Ok(self.eth_client.eth_provider().block_by_hash(hash, full).await?)
     }
 
@@ -80,26 +80,26 @@ where
         &self,
         number: BlockNumberOrTag,
         full: bool,
-    ) -> Result<Option<WithOtherFields<Block<WithOtherFields<Transaction>>>>> {
+    ) -> RpcResult<Option<WithOtherFields<Block<WithOtherFields<Transaction>>>>> {
         Ok(self.eth_client.eth_provider().block_by_number(number, full).await?)
     }
 
     #[tracing::instrument(skip(self), ret, err)]
-    async fn block_transaction_count_by_hash(&self, hash: B256) -> Result<Option<U256>> {
+    async fn block_transaction_count_by_hash(&self, hash: B256) -> RpcResult<Option<U256>> {
         Ok(self.eth_client.eth_provider().block_transaction_count_by_hash(hash).await?)
     }
 
     #[tracing::instrument(skip(self), ret, err)]
-    async fn block_transaction_count_by_number(&self, number: BlockNumberOrTag) -> Result<Option<U256>> {
+    async fn block_transaction_count_by_number(&self, number: BlockNumberOrTag) -> RpcResult<Option<U256>> {
         Ok(self.eth_client.eth_provider().block_transaction_count_by_number(number).await?)
     }
 
-    async fn block_uncles_count_by_block_hash(&self, _hash: B256) -> Result<U256> {
+    async fn block_uncles_count_by_block_hash(&self, _hash: B256) -> RpcResult<U256> {
         tracing::warn!("Kakarot chain does not produce uncles");
         Ok(U256::ZERO)
     }
 
-    async fn block_uncles_count_by_block_number(&self, _number: BlockNumberOrTag) -> Result<U256> {
+    async fn block_uncles_count_by_block_number(&self, _number: BlockNumberOrTag) -> RpcResult<U256> {
         tracing::warn!("Kakarot chain does not produce uncles");
         Ok(U256::ZERO)
     }
@@ -108,7 +108,7 @@ where
         &self,
         _hash: B256,
         _index: Index,
-    ) -> Result<Option<WithOtherFields<Block<WithOtherFields<Transaction>>>>> {
+    ) -> RpcResult<Option<WithOtherFields<Block<WithOtherFields<Transaction>>>>> {
         tracing::warn!("Kakarot chain does not produce uncles");
         Ok(None)
     }
@@ -117,13 +117,13 @@ where
         &self,
         _number: BlockNumberOrTag,
         _index: Index,
-    ) -> Result<Option<WithOtherFields<Block<WithOtherFields<Transaction>>>>> {
+    ) -> RpcResult<Option<WithOtherFields<Block<WithOtherFields<Transaction>>>>> {
         tracing::warn!("Kakarot chain does not produce uncles");
         Ok(None)
     }
 
     #[tracing::instrument(skip(self), ret, err)]
-    async fn transaction_by_hash(&self, hash: B256) -> Result<Option<WithOtherFields<Transaction>>> {
+    async fn transaction_by_hash(&self, hash: B256) -> RpcResult<Option<WithOtherFields<Transaction>>> {
         Ok(self.eth_client.transaction_by_hash(hash).await?)
     }
 
@@ -132,7 +132,7 @@ where
         &self,
         hash: B256,
         index: Index,
-    ) -> Result<Option<WithOtherFields<Transaction>>> {
+    ) -> RpcResult<Option<WithOtherFields<Transaction>>> {
         Ok(self.eth_client.eth_provider().transaction_by_block_hash_and_index(hash, index).await?)
     }
 
@@ -141,37 +141,37 @@ where
         &self,
         number: BlockNumberOrTag,
         index: Index,
-    ) -> Result<Option<WithOtherFields<Transaction>>> {
+    ) -> RpcResult<Option<WithOtherFields<Transaction>>> {
         Ok(self.eth_client.eth_provider().transaction_by_block_number_and_index(number, index).await?)
     }
 
     #[tracing::instrument(skip(self), ret, err)]
-    async fn transaction_receipt(&self, hash: B256) -> Result<Option<WithOtherFields<TransactionReceipt>>> {
+    async fn transaction_receipt(&self, hash: B256) -> RpcResult<Option<WithOtherFields<TransactionReceipt>>> {
         Ok(self.eth_client.eth_provider().transaction_receipt(hash).await?)
     }
 
     #[tracing::instrument(skip(self), ret, err)]
-    async fn balance(&self, address: Address, block_id: Option<BlockId>) -> Result<U256> {
+    async fn balance(&self, address: Address, block_id: Option<BlockId>) -> RpcResult<U256> {
         Ok(self.eth_client.eth_provider().balance(address, block_id).await?)
     }
 
     #[tracing::instrument(skip(self), ret, err)]
-    async fn storage_at(&self, address: Address, index: JsonStorageKey, block_id: Option<BlockId>) -> Result<B256> {
+    async fn storage_at(&self, address: Address, index: JsonStorageKey, block_id: Option<BlockId>) -> RpcResult<B256> {
         Ok(self.eth_client.eth_provider().storage_at(address, index, block_id).await?)
     }
 
     #[tracing::instrument(skip(self), ret, err)]
-    async fn transaction_count(&self, address: Address, block_id: Option<BlockId>) -> Result<U256> {
+    async fn transaction_count(&self, address: Address, block_id: Option<BlockId>) -> RpcResult<U256> {
         Ok(self.eth_client.eth_provider().transaction_count(address, block_id).await?)
     }
 
     #[tracing::instrument(skip(self), err)]
-    async fn get_code(&self, address: Address, block_id: Option<BlockId>) -> Result<Bytes> {
+    async fn get_code(&self, address: Address, block_id: Option<BlockId>) -> RpcResult<Bytes> {
         Ok(self.eth_client.eth_provider().get_code(address, block_id).await?)
     }
 
     #[tracing::instrument(skip_all, err)]
-    async fn get_logs(&self, filter: Filter) -> Result<FilterChanges> {
+    async fn get_logs(&self, filter: Filter) -> RpcResult<FilterChanges> {
         tracing::info!(?filter);
         Ok(self.eth_client.eth_provider().get_logs(filter).await?)
     }
@@ -183,7 +183,7 @@ where
         block_id: Option<BlockId>,
         state_overrides: Option<StateOverride>,
         block_overrides: Option<Box<BlockOverrides>>,
-    ) -> Result<Bytes> {
+    ) -> RpcResult<Bytes> {
         Ok(self.eth_client.eth_provider().call(request, block_id, state_overrides, block_overrides).await?)
     }
 
@@ -191,17 +191,17 @@ where
         &self,
         _request: TransactionRequest,
         _block_id: Option<BlockId>,
-    ) -> Result<AccessListResult> {
+    ) -> RpcResult<AccessListResult> {
         Err(EthApiError::Unsupported("eth_createAccessList").into())
     }
 
     #[tracing::instrument(skip(self, request), err)]
-    async fn estimate_gas(&self, request: TransactionRequest, block_id: Option<BlockId>) -> Result<U256> {
+    async fn estimate_gas(&self, request: TransactionRequest, block_id: Option<BlockId>) -> RpcResult<U256> {
         Ok(U256::from(self.eth_client.eth_provider().estimate_gas(request, block_id).await?))
     }
 
     #[tracing::instrument(skip_all, ret, err)]
-    async fn gas_price(&self) -> Result<U256> {
+    async fn gas_price(&self) -> RpcResult<U256> {
         Ok(self.eth_client.eth_provider().gas_price().await?)
     }
 
@@ -211,62 +211,62 @@ where
         block_count: U64,
         newest_block: BlockNumberOrTag,
         reward_percentiles: Option<Vec<f64>>,
-    ) -> Result<FeeHistory> {
+    ) -> RpcResult<FeeHistory> {
         tracing::info!("Serving eth_feeHistory");
         Ok(self.eth_client.eth_provider().fee_history(block_count, newest_block, reward_percentiles).await?)
     }
 
     #[tracing::instrument(skip_all, ret, err)]
-    async fn max_priority_fee_per_gas(&self) -> Result<U256> {
+    async fn max_priority_fee_per_gas(&self) -> RpcResult<U256> {
         Ok(U256::from(*MAX_PRIORITY_FEE_PER_GAS))
     }
 
-    async fn blob_base_fee(&self) -> Result<U256> {
+    async fn blob_base_fee(&self) -> RpcResult<U256> {
         Err(EthApiError::Unsupported("eth_blobBaseFee").into())
     }
 
-    async fn mining(&self) -> Result<bool> {
+    async fn mining(&self) -> RpcResult<bool> {
         tracing::warn!("Kakarot chain does not use mining");
         Ok(false)
     }
 
-    async fn hashrate(&self) -> Result<U256> {
+    async fn hashrate(&self) -> RpcResult<U256> {
         tracing::warn!("Kakarot chain does not produce hash rate");
         Ok(U256::ZERO)
     }
 
-    async fn get_work(&self) -> Result<Work> {
+    async fn get_work(&self) -> RpcResult<Work> {
         tracing::warn!("Kakarot chain does not produce work");
         Ok(Work::default())
     }
 
-    async fn submit_hashrate(&self, _hashrate: U256, _id: B256) -> Result<bool> {
+    async fn submit_hashrate(&self, _hashrate: U256, _id: B256) -> RpcResult<bool> {
         Err(EthApiError::Unsupported("eth_submitHashrate").into())
     }
 
-    async fn submit_work(&self, _nonce: B64, _pow_hash: B256, _mix_digest: B256) -> Result<bool> {
+    async fn submit_work(&self, _nonce: B64, _pow_hash: B256, _mix_digest: B256) -> RpcResult<bool> {
         Err(EthApiError::Unsupported("eth_submitWork").into())
     }
 
-    async fn send_transaction(&self, _request: TransactionRequest) -> Result<B256> {
+    async fn send_transaction(&self, _request: TransactionRequest) -> RpcResult<B256> {
         Err(EthApiError::Unsupported("eth_sendTransaction").into())
     }
 
     #[tracing::instrument(skip_all, ret, err)]
-    async fn send_raw_transaction(&self, bytes: Bytes) -> Result<B256> {
+    async fn send_raw_transaction(&self, bytes: Bytes) -> RpcResult<B256> {
         tracing::info!("Serving eth_sendRawTransaction");
         Ok(self.eth_client.send_raw_transaction(bytes).await?)
     }
 
-    async fn sign(&self, _address: Address, _message: Bytes) -> Result<Bytes> {
+    async fn sign(&self, _address: Address, _message: Bytes) -> RpcResult<Bytes> {
         Err(EthApiError::Unsupported("eth_sign").into())
     }
 
-    async fn sign_transaction(&self, _transaction: TransactionRequest) -> Result<Bytes> {
+    async fn sign_transaction(&self, _transaction: TransactionRequest) -> RpcResult<Bytes> {
         Err(EthApiError::Unsupported("eth_signTransaction").into())
     }
 
-    async fn sign_typed_data(&self, _address: Address, _data: Value) -> Result<Bytes> {
+    async fn sign_typed_data(&self, _address: Address, _data: Value) -> RpcResult<Bytes> {
         Err(EthApiError::Unsupported("eth_signTypedData").into())
     }
 
@@ -275,38 +275,38 @@ where
         _address: Address,
         _keys: Vec<B256>,
         _block_id: Option<BlockId>,
-    ) -> Result<EIP1186AccountProofResponse> {
+    ) -> RpcResult<EIP1186AccountProofResponse> {
         Err(EthApiError::Unsupported("eth_getProof").into())
     }
 
-    async fn new_filter(&self, _filter: Filter) -> Result<U64> {
+    async fn new_filter(&self, _filter: Filter) -> RpcResult<U64> {
         Err(EthApiError::Unsupported("eth_newFilter").into())
     }
 
-    async fn new_block_filter(&self) -> Result<U64> {
+    async fn new_block_filter(&self) -> RpcResult<U64> {
         Err(EthApiError::Unsupported("eth_newBlockFilter").into())
     }
 
-    async fn new_pending_transaction_filter(&self) -> Result<U64> {
+    async fn new_pending_transaction_filter(&self) -> RpcResult<U64> {
         Err(EthApiError::Unsupported("eth_newPendingTransactionFilter").into())
     }
 
-    async fn uninstall_filter(&self, _id: U64) -> Result<bool> {
+    async fn uninstall_filter(&self, _id: U64) -> RpcResult<bool> {
         Err(EthApiError::Unsupported("eth_uninstallFilter").into())
     }
 
-    async fn get_filter_changes(&self, _id: U64) -> Result<FilterChanges> {
+    async fn get_filter_changes(&self, _id: U64) -> RpcResult<FilterChanges> {
         Err(EthApiError::Unsupported("eth_getFilterChanges").into())
     }
 
-    async fn get_filter_logs(&self, _id: U64) -> Result<FilterChanges> {
+    async fn get_filter_logs(&self, _id: U64) -> RpcResult<FilterChanges> {
         Err(EthApiError::Unsupported("eth_getFilterLogs").into())
     }
 
     async fn block_receipts(
         &self,
         block_id: Option<BlockId>,
-    ) -> Result<Option<Vec<WithOtherFields<TransactionReceipt>>>> {
+    ) -> RpcResult<Option<Vec<WithOtherFields<TransactionReceipt>>>> {
         Ok(self.eth_client.eth_provider().block_receipts(block_id).await?)
     }
 }

--- a/src/eth_rpc/servers/net_rpc.rs
+++ b/src/eth_rpc/servers/net_rpc.rs
@@ -1,6 +1,6 @@
 use crate::{eth_rpc::api::net_api::NetApiServer, providers::eth_provider::provider::EthereumProvider};
 use alloy_primitives::U64;
-use jsonrpsee::core::{async_trait, RpcResult as Result};
+use jsonrpsee::core::{async_trait, RpcResult};
 
 /// The RPC module for the implementing Net api
 #[derive(Debug)]
@@ -16,21 +16,21 @@ impl<P: EthereumProvider> NetRpc<P> {
 
 #[async_trait]
 impl<P: EthereumProvider + Send + Sync + 'static> NetApiServer for NetRpc<P> {
-    async fn version(&self) -> Result<U64> {
+    async fn version(&self) -> RpcResult<U64> {
         Ok(self.eth_provider.chain_id().await?.unwrap_or_default())
     }
 
-    fn peer_count(&self) -> Result<U64> {
+    fn peer_count(&self) -> RpcResult<U64> {
         // Kakarot RPC currently does not have peers connected to node
         Ok(U64::ZERO)
     }
 
-    fn listening(&self) -> Result<bool> {
+    fn listening(&self) -> RpcResult<bool> {
         // Kakarot RPC currently does not support peer-to-peer connections
         Ok(false)
     }
 
-    async fn health(&self) -> Result<bool> {
+    async fn health(&self) -> RpcResult<bool> {
         // Calls starknet block_number method to check if it resolves
         let _ = self.eth_provider.block_number().await?;
 

--- a/src/eth_rpc/servers/trace_rpc.rs
+++ b/src/eth_rpc/servers/trace_rpc.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 use alloy_rpc_types::BlockId;
 use alloy_rpc_types_trace::parity::LocalizedTransactionTrace;
-use jsonrpsee::core::{async_trait, RpcResult as Result};
+use jsonrpsee::core::{async_trait, RpcResult};
 use revm_inspectors::tracing::TracingInspectorConfig;
 use std::sync::Arc;
 
@@ -24,7 +24,7 @@ impl<P: EthereumProvider> TraceRpc<P> {
 impl<P: EthereumProvider + Send + Sync + 'static> TraceApiServer for TraceRpc<P> {
     /// Returns the parity traces for the given block.
     #[tracing::instrument(skip(self), err)]
-    async fn trace_block(&self, block_id: BlockId) -> Result<Option<Vec<LocalizedTransactionTrace>>> {
+    async fn trace_block(&self, block_id: BlockId) -> RpcResult<Option<Vec<LocalizedTransactionTrace>>> {
         tracing::info!("Serving debug_traceBlock");
         let tracer = TracerBuilder::new(Arc::new(&self.eth_provider))
             .await?

--- a/src/eth_rpc/servers/txpool_rpc.rs
+++ b/src/eth_rpc/servers/txpool_rpc.rs
@@ -3,7 +3,7 @@ use alloy_primitives::Address;
 use alloy_rpc_types::Transaction;
 use alloy_rpc_types_txpool::{TxpoolContent, TxpoolContentFrom, TxpoolInspect, TxpoolStatus};
 use alloy_serde::WithOtherFields;
-use jsonrpsee::core::{async_trait, RpcResult as Result};
+use jsonrpsee::core::{async_trait, RpcResult};
 use tracing::instrument;
 
 /// The RPC module for implementing the Txpool api
@@ -32,7 +32,7 @@ where
     ///
     /// Handler for `txpool_status`
     #[instrument(skip(self))]
-    async fn txpool_status(&self) -> Result<TxpoolStatus> {
+    async fn txpool_status(&self) -> RpcResult<TxpoolStatus> {
         self.pool_provider.txpool_status().await.map_err(Into::into)
     }
 
@@ -43,7 +43,7 @@ where
     ///
     /// Handler for `txpool_inspect`
     #[instrument(skip(self))]
-    async fn txpool_inspect(&self) -> Result<TxpoolInspect> {
+    async fn txpool_inspect(&self) -> RpcResult<TxpoolInspect> {
         self.pool_provider.txpool_inspect().await.map_err(Into::into)
     }
 
@@ -53,7 +53,7 @@ where
     /// See [here](https://geth.ethereum.org/docs/rpc/ns-txpool#txpool_contentFrom) for more details
     /// Handler for `txpool_contentFrom`
     #[instrument(skip(self))]
-    async fn txpool_content_from(&self, from: Address) -> Result<TxpoolContentFrom<WithOtherFields<Transaction>>> {
+    async fn txpool_content_from(&self, from: Address) -> RpcResult<TxpoolContentFrom<WithOtherFields<Transaction>>> {
         self.pool_provider.txpool_content_from(from).await.map_err(Into::into)
     }
 
@@ -63,7 +63,7 @@ where
     /// See [here](https://geth.ethereum.org/docs/rpc/ns-txpool#txpool_content) for more details
     /// Handler for `txpool_content`
     #[instrument(skip(self))]
-    async fn txpool_content(&self) -> Result<TxpoolContent<WithOtherFields<Transaction>>> {
+    async fn txpool_content(&self) -> RpcResult<TxpoolContent<WithOtherFields<Transaction>>> {
         self.pool_provider.txpool_content().await.map_err(Into::into)
     }
 }

--- a/src/eth_rpc/servers/web3_rpc.rs
+++ b/src/eth_rpc/servers/web3_rpc.rs
@@ -1,6 +1,6 @@
 use crate::eth_rpc::api::web3_api::Web3ApiServer;
 use alloy_primitives::{keccak256, Bytes, B256};
-use jsonrpsee::core::{async_trait, RpcResult as Result};
+use jsonrpsee::core::{async_trait, RpcResult};
 
 /// The RPC module for the implementing Web3 Api { i.e rpc endpoints prefixed with web3_ }
 #[derive(Default, Debug)]
@@ -14,11 +14,11 @@ impl Web3Rpc {
 
 #[async_trait]
 impl Web3ApiServer for Web3Rpc {
-    fn client_version(&self) -> Result<String> {
+    fn client_version(&self) -> RpcResult<String> {
         Ok(format!("kakarot_{}", env!("CARGO_PKG_VERSION")))
     }
 
-    fn sha3(&self, input: Bytes) -> Result<B256> {
+    fn sha3(&self, input: Bytes) -> RpcResult<B256> {
         Ok(keccak256(input))
     }
 }


### PR DESCRIPTION
Type aliases can be confusing and it's a better practice to use the path name directly.