### PR TITLE
rust analyzer check.command check

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,7 +3,8 @@
   "files.exclude": {
     "**/.git": false
   },
-  "rust-analyzer.check.command": "clippy",
+  "rust-analyzer.check.command": "check",
+  "rust-analyzer.checkOnSave": false,
   "rust-analyzer.cargo.features": "all",
   "deno.enable": true,
   "deno.suggest.imports.autoDiscover": true,

--- a/src/providers/eth_provider/provider.rs
+++ b/src/providers/eth_provider/provider.rs
@@ -1,7 +1,7 @@
 use super::{
     constant::CALL_REQUEST_GAS_LIMIT,
     database::{ethereum::EthereumBlockStore, Database},
-    error::{EthApiError, EthereumDataFormatError, EvmError, ExecutionError, TransactionError},
+    error::{EthApiError, EvmError, ExecutionError, TransactionError},
     starknet::kakarot_core::{
         self,
         core::{CallInput, KakarotCoreReader, Uint256},
@@ -294,7 +294,10 @@ where
     /// Deploy the EVM transaction signer if a corresponding contract is not found on
     /// Starknet.
     pub(crate) async fn deploy_evm_transaction_signer(&self, signer: Address) -> EthApiResult<()> {
-        use crate::providers::eth_provider::constant::hive::{DEPLOY_WALLET, DEPLOY_WALLET_NONCE};
+        use crate::providers::eth_provider::{
+            constant::hive::{DEPLOY_WALLET, DEPLOY_WALLET_NONCE},
+            error::EthereumDataFormatError,
+        };
         use starknet::{
             accounts::ExecutionV1,
             core::{

--- a/tests/tests/txpool_api.rs
+++ b/tests/tests/txpool_api.rs
@@ -1,9 +1,7 @@
 #![allow(clippy::used_underscore_binding)]
 #![cfg(feature = "testing")]
 use crate::tests::mempool::create_sample_transactions;
-use alloy_rpc_types::Transaction;
 use alloy_rpc_types_txpool::{TxpoolContent, TxpoolContentFrom, TxpoolInspect, TxpoolInspectSummary, TxpoolStatus};
-use alloy_serde::WithOtherFields;
 use jsonrpsee::server::ServerHandle;
 use kakarot_rpc::{
     providers::eth_provider::database::types::transaction::ExtendedTransaction,


### PR DESCRIPTION
Our rust analyzer is very slow and crashes a lot. 

To try to limit this, check.command is set to check (default) value as per https://rust-analyzer.github.io/manual.html#vs-code

- This limits computation costs by not applying clippy each time (which can be run manually when needed via `cargo clippy` command)