### PR TITLE
chore: use setup from kakarot makefile to ease install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ setup: .gitmodules
 	chmod +x ./scripts/extract_abi.sh
 	git submodule update --init --recursive
 	cp .env.example .env
-	cd lib/kakarot && uv sync --all-extras --dev && make build && make build-sol && \
+	cd lib/kakarot && make setup && uv sync --all-extras --dev && make build && make build-sol && \
 	mv build/ssj/contracts_Cairo1Helpers.contract_class.json build/cairo1_helpers.json && rm -fr build/ssj
 	./scripts/extract_abi.sh
 


### PR DESCRIPTION
Time spent on this PR: 2h

# Pull Request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [x] Documentation content changes
- [ ] Testing

# What is the new behavior?

When trying to install kakarot-rpc, I faced a several issues with kakarot dependencies:
- compilation failed because scarb was not installed
- compilation failed because I downloaded scarb with curl instead of adsm and got wrong version
- compilation failed because I didn't have foundry

After a few lookups in kakarot code, I saw that there is a `setup` command that checks everything, we should call it during the setup of kakarot-rpc.

I guess other people didn't face this because they installed kakarot before installing kakarot-rpc

# Does this introduce a breaking change?

- [ ] Yes
- [x] No
