### PR TITLE
Update README.md

### DIFF
--- a/indexer/README.md
+++ b/indexer/README.md
@@ -35,7 +35,7 @@ _Why not directly modify a CairoVM client?_
   more stability to directly fork/modify a client. New engines, storage
   technologies and other innovations are being developed by talented teams (e.g.
   [Starknet](https://starkware.co/starknet/),
-  [Katana](https://book.dojoengine.org/toolchain/katana/overview.html),
+  [Katana](https://book.dojoengine.org/toolchain/katana),
   [Madara](https://madara-docs.vercel.app/)).
 
 <details>


### PR DESCRIPTION
Update Katana documentation link 

Changes:
- Updated outdated Katana documentation link from '/overview.html' to the new correct path
- Removed redundant URL segment to improve link readability
- Ensures documentation reference stays current and accessible

The previous link was broken and led to a 404 error. This update points to the correct documentation location.
